### PR TITLE
test(ci_checks): add RED tests for "no checks reported" scenario

### DIFF
--- a/tests/e2e/ci_checks.rs
+++ b/tests/e2e/ci_checks.rs
@@ -64,6 +64,30 @@ fn test_ci_fail_wins_over_ci_action() {
     cmd(&env).assert().success().stdout("✗ ci-fail").stderr("");
 }
 
+// ─── CI 未設定 ──────────────────────────────────────────────────────────────
+
+/// `gh pr checks` が "no checks reported" で失敗 → 空リスト扱い → `✓ merge-ready`
+#[test]
+fn test_no_ci_checks_merge_ready() {
+    let env = TestEnv::with_no_ci_checks(
+        r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED"}"#,
+    );
+    cmd(&env)
+        .assert()
+        .success()
+        .stdout("✓ merge-ready")
+        .stderr("");
+}
+
+/// `gh pr checks` が "no checks reported" + `review` あり → CI なし扱いで `⚠ review` のみ出力
+#[test]
+fn test_no_ci_checks_with_review() {
+    let env = TestEnv::with_no_ci_checks(
+        r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"BLOCKED","reviewDecision":"CHANGES_REQUESTED"}"#,
+    );
+    cmd(&env).assert().success().stdout("⚠ review").stderr("");
+}
+
 // ─── review との複合出力 ──────────────────────────────────────────────────
 
 /// `ci-fail` + `review` → 両方をスペース区切りで出力（`ci_checks` は `review` を抑制しない）

--- a/tests/e2e/helpers.rs
+++ b/tests/e2e/helpers.rs
@@ -80,6 +80,30 @@ impl TestEnv {
         Self { bin_dir, home_dir }
     }
 
+    /// CI 未設定シナリオ: `gh pr view` は成功するが `gh pr checks` が
+    /// `"no checks reported"` で `exit 1` を返す。
+    pub fn with_no_ci_checks(pr_view_json: &str) -> Self {
+        let (bin_dir, home_dir) = Self::setup();
+        let script = format!(
+            "#!/bin/sh\n\
+             case \"$*\" in\n\
+               *'pr view'*)\n\
+                 printf '%s' '{pr_view_json}'\n\
+                 ;;\n\
+               *'pr checks'*)\n\
+                 printf \"%s\" \"no checks reported on the 'test-branch' branch\" >&2\n\
+                 exit 1\n\
+                 ;;\n\
+               *)\n\
+                 printf 'unknown gh command: %s' \"$*\" >&2\n\
+                 exit 127\n\
+                 ;;\n\
+             esac\n"
+        );
+        write_executable(bin_dir.path().join("gh"), &script);
+        Self { bin_dir, home_dir }
+    }
+
     /// `gh` バイナリが `PATH` に存在しないシナリオ（`fake git` と `home_dir` は用意する）
     pub fn without_gh() -> Self {
         let (bin_dir, home_dir) = Self::setup();


### PR DESCRIPTION
## Summary

`gh pr checks` が CI 未設定のブランチで `"no checks reported"` を返す場合、
空のチェックリスト（正常）として扱うべき動作を検証するテストケースを追加。

- `TestEnv::with_no_ci_checks()` — `gh pr checks` が "no checks reported" で exit 1 を返す fake gh を生成するヘルパー追加
- `test_no_ci_checks_merge_ready` — no CI + clean PR → `✓ merge-ready`
- `test_no_ci_checks_with_review` — no CI + review request → `⚠ review`

現時点では main ブランチに実装がないため **RED**。
実装は #3 で対応済み（`infra/gh.rs` の `pr_checks()` 内で当該メッセージを空リストに翻訳）。

## Test plan

- [x] 新規テスト 2 件が RED であることを確認（main では未実装のため）
- [x] `rtk cargo fmt --check` / `rtk cargo clippy --all-targets` — 問題なし
- [ ] #3 マージ後にこのブランチを rebase して全件 GREEN になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)