### PR TITLE
refactor: DDD boundary cleanup — abstract errors, semantic tokens, clean layering

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -10,38 +10,56 @@ use crate::domain::{
     merge_ready::MergeReadinessRepository, pr_state::PrStateRepository,
     review::ReviewRepository,
 };
+use errors::{ErrorLogger, ErrorPresenter};
+
+/// アプリケーション層が返す出力トークンの意味オブジェクト
+///
+/// 文字列表現への変換は presentation 層が担う。
+pub enum OutputToken {
+    Conflict,
+    UpdateBranch,
+    SyncUnknown,
+    CiFail,
+    CiAction,
+    ReviewRequested,
+    MergeReady,
+}
 
 /// PR マージ可否チェックのユースケース
-pub fn run<C>(client: &C)
+///
+/// 表示すべきトークンを返す。呼び出し元が表示処理を担う。
+/// PR が対象外（クローズ等）または取得失敗の場合は空 `Vec` を返す。
+pub fn run<C, L, P>(client: &C, err_logger: &L, err_presenter: &P) -> Vec<OutputToken>
 where
     C: PrStateRepository
         + BranchSyncRepository
         + CiChecksRepository
         + ReviewRepository
         + MergeReadinessRepository,
+    L: ErrorLogger,
+    P: ErrorPresenter,
 {
-    let Some(lifecycle) = pr_state::fetch(client) else {
-        return;
+    let Some(lifecycle) = pr_state::fetch(client, err_logger, err_presenter) else {
+        return vec![];
     };
-
     if !pr_state::is_open(&lifecycle) {
-        return;
+        return vec![];
     }
 
-    let Some(sync_status) = branch_sync::fetch(client) else {
-        return;
+    let Some(sync_status) = branch_sync::fetch(client, err_logger, err_presenter) else {
+        return vec![];
     };
-    let Some(buckets) = ci_checks::fetch(client) else {
-        return;
+    let Some(buckets) = ci_checks::fetch(client, err_logger, err_presenter) else {
+        return vec![];
     };
-    let Some(review_status) = review::fetch(client) else {
-        return;
+    let Some(review_status) = review::fetch(client, err_logger, err_presenter) else {
+        return vec![];
     };
-    let Some(readiness) = merge_ready::fetch(client) else {
-        return;
+    let Some(readiness) = merge_ready::fetch(client, err_logger, err_presenter) else {
+        return vec![];
     };
 
-    let mut tokens: Vec<&'static str> = Vec::new();
+    let mut tokens: Vec<OutputToken> = Vec::new();
     if let Some(t) = branch_sync::check(&sync_status) {
         tokens.push(t);
     }
@@ -52,5 +70,10 @@ where
         tokens.push(t);
     }
 
-    merge_ready::display(&readiness, &tokens);
+    // ブロッカーがなければマージ可否を判定
+    if tokens.is_empty() && let Some(t) = merge_ready::check(&readiness) {
+        tokens.push(t);
+    }
+
+    tokens
 }

--- a/src/application/branch_sync.rs
+++ b/src/application/branch_sync.rs
@@ -1,17 +1,28 @@
-use crate::domain::branch_sync::{BranchSyncStatus, BranchSyncRepository};
+use crate::application::errors::{ErrorLogger, ErrorPresenter};
+use crate::application::OutputToken;
+use crate::domain::branch_sync::{BranchSyncRepository, BranchSyncStatus};
 
 /// ブランチ同期状態を取得する。失敗時は `None` を返してエラー出力する。
-pub fn fetch(repo: &impl BranchSyncRepository) -> Option<BranchSyncStatus> {
+pub fn fetch(
+    repo: &impl BranchSyncRepository,
+    err_logger: &impl ErrorLogger,
+    err_presenter: &impl ErrorPresenter,
+) -> Option<BranchSyncStatus> {
     match repo.fetch_sync_status() {
         Ok(status) => Some(status),
         Err(e) => {
-            super::errors::handle(e);
+            super::errors::handle(e, err_logger, err_presenter);
             None
         }
     }
 }
 
 /// ブランチ同期状態を評価し、該当するトークンを返す
-pub fn check(status: &BranchSyncStatus) -> Option<&'static str> {
-    crate::domain::branch_sync::evaluate(status)
+pub fn check(status: &BranchSyncStatus) -> Option<OutputToken> {
+    match status {
+        BranchSyncStatus::Conflicting => Some(OutputToken::Conflict),
+        BranchSyncStatus::Behind => Some(OutputToken::UpdateBranch),
+        BranchSyncStatus::Unknown => Some(OutputToken::SyncUnknown),
+        BranchSyncStatus::Clean => None,
+    }
 }

--- a/src/application/ci_checks.rs
+++ b/src/application/ci_checks.rs
@@ -1,17 +1,27 @@
-use crate::domain::ci_checks::{CheckBucket, CiChecksRepository};
+use crate::application::errors::{ErrorLogger, ErrorPresenter};
+use crate::application::OutputToken;
+use crate::domain::ci_checks::{CheckBucket, CiChecksRepository, CiStatus};
 
 /// CI チェック結果を取得する。失敗時は `None` を返してエラー出力する。
-pub fn fetch(repo: &impl CiChecksRepository) -> Option<Vec<CheckBucket>> {
+pub fn fetch(
+    repo: &impl CiChecksRepository,
+    err_logger: &impl ErrorLogger,
+    err_presenter: &impl ErrorPresenter,
+) -> Option<Vec<CheckBucket>> {
     match repo.fetch_check_buckets() {
         Ok(buckets) => Some(buckets),
         Err(e) => {
-            super::errors::handle(e);
+            super::errors::handle(e, err_logger, err_presenter);
             None
         }
     }
 }
 
 /// CI チェック結果を集約・評価し、該当するトークンを返す
-pub fn check(buckets: &[CheckBucket]) -> Option<&'static str> {
-    crate::domain::ci_checks::evaluate(&crate::domain::ci_checks::aggregate(buckets))
+pub fn check(buckets: &[CheckBucket]) -> Option<OutputToken> {
+    match crate::domain::ci_checks::aggregate(buckets) {
+        CiStatus::Fail => Some(OutputToken::CiFail),
+        CiStatus::ActionRequired => Some(OutputToken::CiAction),
+        CiStatus::Pass => None,
+    }
 }

--- a/src/application/errors.rs
+++ b/src/application/errors.rs
@@ -1,20 +1,46 @@
 use crate::domain::error::RepositoryError;
-use crate::{infra, presentation};
+
+/// エラー時に表示するトークンの意味オブジェクト
+///
+/// 文字列表現への変換は presentation 層が担う。
+#[derive(Clone, Copy)]
+pub enum ErrorToken {
+    /// 認証が必要（ツール未インストール含む）
+    AuthRequired,
+    /// レート制限によりアクセス不可
+    RateLimited,
+    /// 予期しない API エラー
+    ApiError,
+}
+
+/// エラーをログに記録するポート
+pub trait ErrorLogger {
+    fn log(&self, msg: &str);
+}
+
+/// エラーをユーザーに表示するポート
+pub trait ErrorPresenter {
+    fn show_error(&self, token: ErrorToken);
+}
 
 /// `RepositoryError` を受け取り、エラーポリシーに従って出力・ログ記録を行う
-pub fn handle(e: RepositoryError) {
+pub fn handle(
+    e: RepositoryError,
+    err_logger: &impl ErrorLogger,
+    err_presenter: &impl ErrorPresenter,
+) {
     match e {
-        RepositoryError::NotInstalled | RepositoryError::AuthRequired => {
-            presentation::display_error("! gh auth login");
+        RepositoryError::Unauthenticated => {
+            err_presenter.show_error(ErrorToken::AuthRequired);
         }
-        RepositoryError::NoPr => {}
+        RepositoryError::NotFound => {}
         RepositoryError::RateLimited => {
-            infra::logger::append_error("rate limit");
-            presentation::display_error("✗ rate-limited");
+            err_logger.log("rate limit");
+            err_presenter.show_error(ErrorToken::RateLimited);
         }
-        RepositoryError::ApiError(msg) => {
-            infra::logger::append_error(&msg);
-            presentation::display_error("✗ api-error");
+        RepositoryError::Unexpected(msg) => {
+            err_logger.log(&msg);
+            err_presenter.show_error(ErrorToken::ApiError);
         }
     }
 }

--- a/src/application/merge_ready.rs
+++ b/src/application/merge_ready.rs
@@ -1,26 +1,27 @@
+use crate::application::errors::{ErrorLogger, ErrorPresenter};
+use crate::application::OutputToken;
 use crate::domain::merge_ready::{MergeReadiness, MergeReadinessRepository};
-use crate::presentation;
 
 /// マージ可否状態を取得する。失敗時は `None` を返してエラー出力する。
-pub fn fetch(repo: &impl MergeReadinessRepository) -> Option<MergeReadiness> {
+pub fn fetch(
+    repo: &impl MergeReadinessRepository,
+    err_logger: &impl ErrorLogger,
+    err_presenter: &impl ErrorPresenter,
+) -> Option<MergeReadiness> {
     match repo.fetch_readiness() {
         Ok(readiness) => Some(readiness),
         Err(e) => {
-            super::errors::handle(e);
+            super::errors::handle(e, err_logger, err_presenter);
             None
         }
     }
 }
 
-/// 評価結果に応じてマージ可否を `stdout` に出力する
-///
-/// - ブロッカーがあれば各トークンをスペース区切りで出力
-/// - ブロッカーなし かつ `merge_ready` 条件を満たせば `✓ merge-ready` を出力
-/// - それ以外（`draft`・`pending` 等）は何も出力しない
-pub fn display(readiness: &MergeReadiness, tokens: &[&str]) {
-    if !tokens.is_empty() {
-        presentation::display(tokens);
-    } else if crate::domain::merge_ready::is_ready(readiness) {
-        presentation::display(&["✓ merge-ready"]);
+/// マージ可否状態を評価し、該当するトークンを返す
+pub fn check(readiness: &MergeReadiness) -> Option<OutputToken> {
+    if crate::domain::merge_ready::is_ready(readiness) {
+        Some(OutputToken::MergeReady)
+    } else {
+        None
     }
 }

--- a/src/application/pr_state.rs
+++ b/src/application/pr_state.rs
@@ -1,11 +1,16 @@
+use crate::application::errors::{ErrorLogger, ErrorPresenter};
 use crate::domain::pr_state::{PrLifecycle, PrStateRepository};
 
 /// ライフサイクル状態を取得する。失敗時は `None` を返してエラー出力する。
-pub fn fetch(repo: &impl PrStateRepository) -> Option<PrLifecycle> {
+pub fn fetch(
+    repo: &impl PrStateRepository,
+    err_logger: &impl ErrorLogger,
+    err_presenter: &impl ErrorPresenter,
+) -> Option<PrLifecycle> {
     match repo.fetch_lifecycle() {
         Ok(lifecycle) => Some(lifecycle),
         Err(e) => {
-            super::errors::handle(e);
+            super::errors::handle(e, err_logger, err_presenter);
             None
         }
     }

--- a/src/application/review.rs
+++ b/src/application/review.rs
@@ -1,17 +1,26 @@
-use crate::domain::review::{ReviewStatus, ReviewRepository};
+use crate::application::errors::{ErrorLogger, ErrorPresenter};
+use crate::application::OutputToken;
+use crate::domain::review::{ReviewRepository, ReviewStatus};
 
 /// レビュー状態を取得する。失敗時は `None` を返してエラー出力する。
-pub fn fetch(repo: &impl ReviewRepository) -> Option<ReviewStatus> {
+pub fn fetch(
+    repo: &impl ReviewRepository,
+    err_logger: &impl ErrorLogger,
+    err_presenter: &impl ErrorPresenter,
+) -> Option<ReviewStatus> {
     match repo.fetch_review_status() {
         Ok(status) => Some(status),
         Err(e) => {
-            super::errors::handle(e);
+            super::errors::handle(e, err_logger, err_presenter);
             None
         }
     }
 }
 
 /// レビュー状態を評価し、該当するトークンを返す
-pub fn check(status: &ReviewStatus) -> Option<&'static str> {
-    crate::domain::review::evaluate(status)
+pub fn check(status: &ReviewStatus) -> Option<OutputToken> {
+    match status {
+        ReviewStatus::ChangesRequested => Some(OutputToken::ReviewRequested),
+        ReviewStatus::Other => None,
+    }
 }

--- a/src/domain/branch_sync.rs
+++ b/src/domain/branch_sync.rs
@@ -5,15 +5,8 @@ pub enum BranchSyncStatus {
     Clean,
     Conflicting,
     Behind,
-}
-
-/// `branch_sync` グループ評価（択一: `Conflicting` 優先）
-pub fn evaluate(status: &BranchSyncStatus) -> Option<&'static str> {
-    match status {
-        BranchSyncStatus::Conflicting => Some("✗ conflict"),
-        BranchSyncStatus::Behind => Some("✗ update-branch"),
-        BranchSyncStatus::Clean => None,
-    }
+    /// 同期状態を判定できない（取得手段が利用不可）
+    Unknown,
 }
 
 pub trait BranchSyncRepository {

--- a/src/domain/ci_checks.rs
+++ b/src/domain/ci_checks.rs
@@ -34,15 +34,6 @@ pub fn aggregate(buckets: &[CheckBucket]) -> CiStatus {
     }
 }
 
-/// `ci_checks` グループ評価
-pub fn evaluate(status: &CiStatus) -> Option<&'static str> {
-    match status {
-        CiStatus::Fail => Some("✗ ci-fail"),
-        CiStatus::ActionRequired => Some("⚠ ci-action"),
-        CiStatus::Pass => None,
-    }
-}
-
 pub trait CiChecksRepository {
     fn fetch_check_buckets(&self) -> Result<Vec<CheckBucket>, RepositoryError>;
 }

--- a/src/domain/error.rs
+++ b/src/domain/error.rs
@@ -1,8 +1,13 @@
 /// リポジトリ操作で発生しうるエラー種別（全ドメイントレイト共通）
+///
+/// infra の実装手段（CLI・REST 等）に依存しない抽象的な分類のみを持つ。
 pub enum RepositoryError {
-    NotInstalled,
-    AuthRequired,
-    NoPr,
+    /// 認証不可（ツール未インストール・未認証を含む）
+    Unauthenticated,
+    /// リソースが存在しない（該当 PR なし等）
+    NotFound,
+    /// レート制限によりアクセス不可
     RateLimited,
-    ApiError(String),
+    /// 上記に当てはまらない予期しないエラー
+    Unexpected(String),
 }

--- a/src/domain/review.rs
+++ b/src/domain/review.rs
@@ -6,14 +6,6 @@ pub enum ReviewStatus {
     Other,
 }
 
-/// `review` 評価（独立条件）
-pub fn evaluate(status: &ReviewStatus) -> Option<&'static str> {
-    match status {
-        ReviewStatus::ChangesRequested => Some("⚠ review"),
-        ReviewStatus::Other => None,
-    }
-}
-
 pub trait ReviewRepository {
     fn fetch_review_status(&self) -> Result<ReviewStatus, RepositoryError>;
 }

--- a/src/infra/gh.rs
+++ b/src/infra/gh.rs
@@ -72,7 +72,7 @@ impl GhClient {
             "state,isDraft,mergeable,mergeStateStatus,reviewDecision,baseRefName,headRefName",
         ])?;
         let raw: GhPrView = serde_json::from_slice(&bytes)
-            .map_err(|e| RepositoryError::ApiError(e.to_string()))?;
+            .map_err(|e| RepositoryError::Unexpected(e.to_string()))?;
         let _ = self.pr_view_cache.set(raw);
         Ok(self.pr_view_cache.get().expect("just set"))
     }
@@ -93,18 +93,19 @@ impl BranchSyncRepository for GhClient {
     }
 }
 
+
 impl CiChecksRepository for GhClient {
     fn fetch_check_buckets(&self) -> Result<Vec<CheckBucket>, RepositoryError> {
         let bytes = match run_gh(&["pr", "checks", "--json", "bucket,state"]) {
             Ok(b) => b,
             // CI が未設定のブランチではチェックなし（正常）として扱う
-            Err(RepositoryError::ApiError(msg)) if msg.contains("no checks reported") => {
+            Err(RepositoryError::Unexpected(msg)) if msg.contains("no checks reported") => {
                 return Ok(vec![]);
             }
             Err(e) => return Err(e),
         };
         let items: Vec<GhCheckItem> = serde_json::from_slice(&bytes)
-            .map_err(|e| RepositoryError::ApiError(e.to_string()))?;
+            .map_err(|e| RepositoryError::Unexpected(e.to_string()))?;
         Ok(items.iter().map(|c| translate_bucket(&c.bucket)).collect())
     }
 }
@@ -133,31 +134,36 @@ fn translate_lifecycle(state: &str) -> PrLifecycle {
     }
 }
 
-fn translate_sync(mergeable: &str, behind_by: u64) -> BranchSyncStatus {
+fn translate_sync(mergeable: &str, behind_by: Option<u64>) -> BranchSyncStatus {
     if mergeable == "CONFLICTING" {
+        // conflict は Compare API に依らず判定可能なので Unknown より優先
         BranchSyncStatus::Conflicting
-    } else if behind_by > 0 {
-        BranchSyncStatus::Behind
     } else {
-        BranchSyncStatus::Clean
+        match behind_by {
+            None => BranchSyncStatus::Unknown,
+            Some(0) => BranchSyncStatus::Clean,
+            Some(_) => BranchSyncStatus::Behind,
+        }
     }
 }
 
 /// GitHub Compare API でベースブランチとの差分コミット数を取得する。
 ///
-/// `base_ref` / `head_ref` が空（テスト用フィクスチャや旧形式 JSON）の場合は
-/// API を呼ばずに `0` を返す。API 呼び出しに失敗した場合も `0` を返す（劣化動作）。
-fn fetch_behind_by(base_ref: &str, head_ref: &str) -> u64 {
+/// `base_ref` / `head_ref` が空の場合（`baseRefName` / `headRefName` フィールドが
+/// 存在しない旧形式 JSON 等）は `Some(0)` を返す（フィールドなし ≒ 追跡不要）。
+/// Compare API 呼び出しに失敗した場合は `None` を返す。
+/// 呼び出し元は `None` を `BranchSyncStatus::Unknown`（同期状態判定不能）として扱う。
+fn fetch_behind_by(base_ref: &str, head_ref: &str) -> Option<u64> {
     if base_ref.is_empty() || head_ref.is_empty() {
-        return 0;
+        return Some(0);
     }
 
     let name_with_owner = match run_gh(&["repo", "view", "--json", "nameWithOwner"]) {
         Ok(bytes) => match serde_json::from_slice::<GhRepoView>(&bytes) {
             Ok(r) => r.name_with_owner,
-            Err(_) => return 0,
+            Err(_) => return None,
         },
-        Err(_) => return 0,
+        Err(_) => return None,
     };
 
     let path = format!("repos/{name_with_owner}/compare/{base_ref}...{head_ref}");
@@ -165,8 +171,8 @@ fn fetch_behind_by(base_ref: &str, head_ref: &str) -> u64 {
     match run_gh(&["api", &path]) {
         Ok(bytes) => serde_json::from_slice::<GhCompare>(&bytes)
             .map(|c| c.behind_by)
-            .unwrap_or(0),
-        Err(_) => 0,
+            .ok(),
+        Err(_) => None,
     }
 }
 
@@ -196,28 +202,54 @@ fn translate_bucket(bucket: &str) -> CheckBucket {
 
 // ── gh コマンド実行・エラー判別 ──────────────────────────────────────────────
 
-fn run_gh(args: &[&str]) -> Result<Vec<u8>, RepositoryError> {
-    let output = Command::new("gh").args(args).output();
-    match output {
-        Err(e) if e.kind() == ErrorKind::NotFound => Err(RepositoryError::NotInstalled),
-        Err(e) => Err(RepositoryError::ApiError(e.to_string())),
-        Ok(out) if out.status.success() => Ok(out.stdout),
-        Ok(out) => {
-            let exit_code = out.status.code().unwrap_or(1);
-            let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-            Err(classify_error(exit_code, &stderr))
+/// gh CLI 固有のエラー種別（infra 内にのみ存在）
+enum GhError {
+    /// gh バイナリが見つからない
+    NotInstalled,
+    /// 認証エラー（exit 4 / HTTP 401）
+    AuthRequired,
+    /// 対象 PR が存在しない
+    NoPr,
+    /// API レート制限
+    RateLimited,
+    /// その他の CLI エラー
+    ApiError(String),
+}
+
+impl From<GhError> for RepositoryError {
+    fn from(e: GhError) -> Self {
+        match e {
+            GhError::NotInstalled | GhError::AuthRequired => RepositoryError::Unauthenticated,
+            GhError::NoPr => RepositoryError::NotFound,
+            GhError::RateLimited => RepositoryError::RateLimited,
+            GhError::ApiError(msg) => RepositoryError::Unexpected(msg),
         }
     }
 }
 
-fn classify_error(exit_code: i32, stderr: &str) -> RepositoryError {
+fn run_gh(args: &[&str]) -> Result<Vec<u8>, RepositoryError> {
+    let output = Command::new("gh").args(args).output();
+    let gh_err = match output {
+        Err(e) if e.kind() == ErrorKind::NotFound => GhError::NotInstalled,
+        Err(e) => GhError::ApiError(e.to_string()),
+        Ok(out) if out.status.success() => return Ok(out.stdout),
+        Ok(out) => {
+            let exit_code = out.status.code().unwrap_or(1);
+            let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+            classify_gh_error(exit_code, &stderr)
+        }
+    };
+    Err(gh_err.into())
+}
+
+fn classify_gh_error(exit_code: i32, stderr: &str) -> GhError {
     if exit_code == 4 || (exit_code == 1 && stderr.contains("HTTP 401")) {
-        RepositoryError::AuthRequired
+        GhError::AuthRequired
     } else if exit_code == 1 && stderr.contains("no pull requests found") {
-        RepositoryError::NoPr
+        GhError::NoPr
     } else if exit_code == 1 && stderr.contains("rate limit") {
-        RepositoryError::RateLimited
+        GhError::RateLimited
     } else {
-        RepositoryError::ApiError(stderr.to_owned())
+        GhError::ApiError(stderr.to_owned())
     }
 }

--- a/src/infra/logger.rs
+++ b/src/infra/logger.rs
@@ -1,6 +1,10 @@
 use std::fs::{self, OpenOptions};
 use std::io::Write as _;
 
+use crate::application::errors::ErrorLogger;
+
+pub struct Logger;
+
 /// `$HOME/.cache/ci-status/error.log` にエラーメッセージを追記する。
 ///
 /// ディレクトリが存在しない場合は自動的に作成する。
@@ -16,4 +20,10 @@ pub fn append_error(message: &str) {
         return;
     };
     let _ = writeln!(file, "{message}");
+}
+
+impl ErrorLogger for Logger {
+    fn log(&self, msg: &str) {
+        append_error(msg);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,5 +4,12 @@ mod infra;
 mod presentation;
 
 fn main() {
-    application::run(&infra::gh::GhClient::new());
+    let tokens = application::run(
+        &infra::gh::GhClient::new(),
+        &infra::logger::Logger,
+        &presentation::Presenter,
+    );
+    if !tokens.is_empty() {
+        presentation::display(&tokens);
+    }
 }

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -1,9 +1,40 @@
-/// ドメイン結果を `stdout` に出力する（末尾改行なし）
-pub fn display(tokens: &[&str]) {
-    print!("{}", tokens.join(" "));
+use crate::application::{
+    OutputToken,
+    errors::{ErrorPresenter, ErrorToken},
+};
+
+/// `OutputToken` を表示文字列に変換する
+fn render(token: &OutputToken) -> &'static str {
+    match token {
+        OutputToken::Conflict => "✗ conflict",
+        OutputToken::UpdateBranch => "✗ update-branch",
+        OutputToken::SyncUnknown => "? sync-unknown",
+        OutputToken::CiFail => "✗ ci-fail",
+        OutputToken::CiAction => "⚠ ci-action",
+        OutputToken::ReviewRequested => "⚠ review",
+        OutputToken::MergeReady => "✓ merge-ready",
+    }
 }
 
-/// 単一トークンを `stdout` に出力する（末尾改行なし）
-pub fn display_error(token: &str) {
-    print!("{token}");
+/// `ErrorToken` を表示文字列に変換する
+fn render_error(token: ErrorToken) -> &'static str {
+    match token {
+        ErrorToken::AuthRequired => "! gh auth login",
+        ErrorToken::RateLimited => "✗ rate-limited",
+        ErrorToken::ApiError => "✗ api-error",
+    }
+}
+
+/// トークン列を `stdout` に出力する（末尾改行なし）
+pub fn display(tokens: &[OutputToken]) {
+    let rendered: Vec<&str> = tokens.iter().map(render).collect();
+    print!("{}", rendered.join(" "));
+}
+
+pub struct Presenter;
+
+impl ErrorPresenter for Presenter {
+    fn show_error(&self, token: ErrorToken) {
+        print!("{}", render_error(token));
+    }
 }

--- a/tests/e2e/branch_sync.rs
+++ b/tests/e2e/branch_sync.rs
@@ -42,6 +42,20 @@ fn test_update_branch() {
         .stderr("");
 }
 
+/// compare API が失敗した場合 → `? sync-unknown`
+#[test]
+fn test_compare_api_error() {
+    let env = TestEnv::with_compare_error(
+        r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"BLOCKED","reviewDecision":null,"baseRefName":"main","headRefName":"feat/test"}"#,
+        Some(r#"[{"bucket":"pass","state":"SUCCESS"}]"#),
+    );
+    cmd(&env)
+        .assert()
+        .success()
+        .stdout("? sync-unknown")
+        .stderr("");
+}
+
 // ─── 同期状態内の優先度 ───────────────────────────────────────────────────
 
 /// `CONFLICTING` かつ `BEHIND` → `conflict` のみ表示（`update-branch` は抑制される）

--- a/tests/e2e/helpers.rs
+++ b/tests/e2e/helpers.rs
@@ -116,6 +116,45 @@ impl TestEnv {
         Self { bin_dir, home_dir }
     }
 
+    /// Compare API がエラーを返すシナリオ用の `fake gh` を配置する。
+    ///
+    /// `pr view` JSON には `baseRefName` / `headRefName` を含めること（API を呼ぶため）。
+    /// `repo view` は正常に応答し、`api compare` のみ `exit 1` で失敗する。
+    pub fn with_compare_error(pr_view_json: &str, pr_checks_json: Option<&str>) -> Self {
+        let (bin_dir, home_dir) = Self::setup();
+
+        let checks_block = match pr_checks_json {
+            Some(j) => format!("printf '%s' '{j}'\n"),
+            None => "printf 'unexpected pr checks call' >&2\nexit 1\n".to_string(),
+        };
+
+        let script = format!(
+            "#!/bin/sh\n\
+             case \"$*\" in\n\
+               *'pr view'*)\n\
+                 printf '%s' '{pr_view_json}'\n\
+                 ;;\n\
+               *'pr checks'*)\n\
+                 {checks_block}\
+                 ;;\n\
+               *'repo view'*)\n\
+                 printf '{{\"nameWithOwner\":\"owner/repo\"}}'\n\
+                 ;;\n\
+               *'api'*'compare'*)\n\
+                 printf 'API error' >&2\n\
+                 exit 1\n\
+                 ;;\n\
+               *)\n\
+                 printf 'unknown gh command: %s' \"$*\" >&2\n\
+                 exit 127\n\
+                 ;;\n\
+             esac\n"
+        );
+
+        write_executable(bin_dir.path().join("gh"), &script);
+        Self { bin_dir, home_dir }
+    }
+
     /// エラー系: 指定した `exit_code` と `stderr` メッセージを返す `fake gh` を配置する。
     pub fn with_error(stderr_msg: &str, exit_code: u8) -> Self {
         let (bin_dir, home_dir) = Self::setup();


### PR DESCRIPTION
## Summary

- `RepositoryError` を domain-abstract なバリアントに抽象化し、`GhError`（infra 固有）を infra に閉じた
- `BranchSyncStatus::Unknown` を導入し、Compare API 失敗時の「判定不能」状態を明示モデル化
- `ErrorLogger` / `ErrorPresenter` ポートを `application/errors.rs` に定義し、`application` 層から infra・presentation への直接依存を除去
- `OutputToken` / `ErrorToken` 意味オブジェクトを導入し、表示文字列責務を `presentation` 層に集約
- `application::run()` を `Vec<OutputToken>` 返りに変更し、`application → presentation` の依存を完全に除去

## Changes

| ファイル | 変更内容 |
|---|---|
| `domain/error.rs` | `NotInstalled`/`AuthRequired` → `Unauthenticated`、`NoPr` → `NotFound`、`ApiError` → `Unexpected` |
| `domain/branch_sync.rs` | `Unknown` バリアント追加（同期状態判定不能）、`evaluate()` 削除 |
| `domain/ci_checks.rs` / `review.rs` | `evaluate()` 削除（UI 関心をドメインから排除） |
| `infra/gh.rs` | `GhError` プライベート enum 追加 + `From<GhError> for RepositoryError`、`fetch_behind_by` を `Option<u64>` 返りに変更 |
| `infra/logger.rs` | `Logger` struct 追加（`ErrorLogger` アダプタ） |
| `application/errors.rs` | `ErrorToken` / `ErrorLogger` / `ErrorPresenter` ポートを定義 |
| `application/*.rs` | `fetch()` に `err_logger` / `err_presenter` 引数追加、`check()` を `Option<OutputToken>` 返りに変更 |
| `application.rs` | `OutputToken` 定義、`run()` を `Vec<OutputToken>` 返りに変更 |
| `presentation.rs` | `render()` / `render_error()` で文字列変換を集約、`Presenter` アダプタを `ErrorToken` 対応に |
| `tests/e2e/` | `test_compare_api_error` / `with_compare_error` ヘルパーを追加 |

## Test plan

- [x] `cargo test` — 24 tests passed
- [x] `cargo clippy --all-targets` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)