### PR TITLE
style: apply rustfmt to application and gh modules

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -7,8 +7,7 @@ mod review;
 
 use crate::domain::{
     branch_sync::BranchSyncRepository, ci_checks::CiChecksRepository,
-    merge_ready::MergeReadinessRepository, pr_state::PrStateRepository,
-    review::ReviewRepository,
+    merge_ready::MergeReadinessRepository, pr_state::PrStateRepository, review::ReviewRepository,
 };
 use errors::{ErrorLogger, ErrorPresenter};
 
@@ -71,7 +70,9 @@ where
     }
 
     // ブロッカーがなければマージ可否を判定
-    if tokens.is_empty() && let Some(t) = merge_ready::check(&readiness) {
+    if tokens.is_empty()
+        && let Some(t) = merge_ready::check(&readiness)
+    {
         tokens.push(t);
     }
 

--- a/src/application/branch_sync.rs
+++ b/src/application/branch_sync.rs
@@ -1,5 +1,5 @@
-use crate::application::errors::{ErrorLogger, ErrorPresenter};
 use crate::application::OutputToken;
+use crate::application::errors::{ErrorLogger, ErrorPresenter};
 use crate::domain::branch_sync::{BranchSyncRepository, BranchSyncStatus};
 
 /// ブランチ同期状態を取得する。失敗時は `None` を返してエラー出力する。

--- a/src/application/ci_checks.rs
+++ b/src/application/ci_checks.rs
@@ -1,5 +1,5 @@
-use crate::application::errors::{ErrorLogger, ErrorPresenter};
 use crate::application::OutputToken;
+use crate::application::errors::{ErrorLogger, ErrorPresenter};
 use crate::domain::ci_checks::{CheckBucket, CiChecksRepository, CiStatus};
 
 /// CI チェック結果を取得する。失敗時は `None` を返してエラー出力する。

--- a/src/application/merge_ready.rs
+++ b/src/application/merge_ready.rs
@@ -1,5 +1,5 @@
-use crate::application::errors::{ErrorLogger, ErrorPresenter};
 use crate::application::OutputToken;
+use crate::application::errors::{ErrorLogger, ErrorPresenter};
 use crate::domain::merge_ready::{MergeReadiness, MergeReadinessRepository};
 
 /// マージ可否状態を取得する。失敗時は `None` を返してエラー出力する。

--- a/src/application/review.rs
+++ b/src/application/review.rs
@@ -1,5 +1,5 @@
-use crate::application::errors::{ErrorLogger, ErrorPresenter};
 use crate::application::OutputToken;
+use crate::application::errors::{ErrorLogger, ErrorPresenter};
 use crate::domain::review::{ReviewRepository, ReviewStatus};
 
 /// レビュー状態を取得する。失敗時は `None` を返してエラー出力する。

--- a/src/infra/gh.rs
+++ b/src/infra/gh.rs
@@ -93,7 +93,6 @@ impl BranchSyncRepository for GhClient {
     }
 }
 
-
 impl CiChecksRepository for GhClient {
     fn fetch_check_buckets(&self) -> Result<Vec<CheckBucket>, RepositoryError> {
         let bytes = match run_gh(&["pr", "checks", "--json", "bucket,state"]) {
@@ -120,7 +119,10 @@ impl ReviewRepository for GhClient {
 impl MergeReadinessRepository for GhClient {
     fn fetch_readiness(&self) -> Result<MergeReadiness, RepositoryError> {
         let raw = self.pr_view_cached()?;
-        Ok(translate_merge_readiness(raw.is_draft, &raw.merge_state_status))
+        Ok(translate_merge_readiness(
+            raw.is_draft,
+            &raw.merge_state_status,
+        ))
     }
 }
 


### PR DESCRIPTION
## Summary

Applies `rustfmt` formatting to application modules and `infra/gh.rs`: import ordering, line breaks for `if` + `let` chains, and minor whitespace.

## Notes

- No functional changes.
- `mise.toml` was left untracked locally; add it in a separate change if you want it in the repo.

Made with [Cursor](https://cursor.com)