### PR TITLE
feat: sub-40ms latency via cache-first architecture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +130,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,6 +201,73 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "difflib"
@@ -288,10 +388,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -345,6 +465,7 @@ version = "0.1.0"
 dependencies = [
  "assert_cmd",
  "clap",
+ "criterion",
  "predicates",
  "serde",
  "serde_json",
@@ -377,6 +498,40 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "predicates"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,16 +68,153 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -124,6 +267,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +299,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,10 +323,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -203,6 +393,7 @@ name = "merge-ready"
 version = "0.1.0"
 dependencies = [
  "assert_cmd",
+ "criterion",
  "predicates",
  "serde",
  "serde_json",
@@ -229,6 +420,40 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "predicates"
@@ -295,6 +520,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,6 +579,21 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -416,6 +676,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +707,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,6 +732,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -486,6 +811,25 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -589,6 +933,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,10 @@ path = "tests/e2e/mod.rs"
 
 [dev-dependencies]
 assert_cmd = "2"
+criterion = { version = "0.5", features = ["html_reports"] }
 predicates = "3"
 tempfile = "3"
+
+[[bench]]
+name = "hot_path"
+harness = false

--- a/benches/hot_path.rs
+++ b/benches/hot_path.rs
@@ -1,0 +1,146 @@
+//! ホットパスのベンチマーク
+//!
+//! キャッシュヒットパス（ファイル読み込み → 出力）と
+//! キャッシュミスパス（フェイク gh を使った全フロー）の両方を計測する。
+//!
+//! 使用方法:
+//! ```
+//! cargo bench --bench hot_path
+//! ```
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use tempfile::TempDir;
+
+// ── フェイク環境のセットアップ ──────────────────────────────────────────────
+
+struct BenchEnv {
+    bin_dir: TempDir,
+    home_dir: TempDir,
+}
+
+const OPEN_MERGE_READY_JSON: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}"#;
+const CI_PASS_JSON: &str = r#"[{"bucket":"pass","state":"SUCCESS","name":"ci","link":""}]"#;
+
+/// フェイクの gh/git バイナリを含むベンチマーク環境を構築する
+fn setup_bench_env() -> BenchEnv {
+    let bin_dir = TempDir::new().expect("bin_dir");
+    let home_dir = TempDir::new().expect("home_dir");
+
+    // fake git
+    let git_script = "#!/bin/sh\n\
+        case \"$*\" in\n\
+          *'remote get-url origin'*) echo 'https://github.com/bench/repo.git'; exit 0 ;;\n\
+          *) exit 0 ;;\n\
+        esac\n";
+    write_executable(&bin_dir.path().join("git"), git_script);
+
+    // fake gh（即時応答）
+    // JSON に `{}` が含まれているため format! ではなく文字列連結を使用
+    let gh_script = "#!/bin/sh\ncase \"$*\" in\n  *'pr view'*) printf '%s' '".to_owned()
+        + OPEN_MERGE_READY_JSON
+        + "' ;;\n  *'pr checks'*) printf '%s' '"
+        + CI_PASS_JSON
+        + "' ;;\n  *) exit 0 ;;\nesac\n";
+    write_executable(&bin_dir.path().join("gh"), &gh_script);
+
+    BenchEnv { bin_dir, home_dir }
+}
+
+fn write_executable(path: &PathBuf, content: &str) {
+    fs::write(path, content).expect("write");
+    fs::set_permissions(path, fs::Permissions::from_mode(0o755)).expect("chmod");
+}
+
+fn path_env(env: &BenchEnv) -> String {
+    format!("{}:/bin:/usr/bin", env.bin_dir.path().display())
+}
+
+fn binary_path() -> PathBuf {
+    let mut path = std::env::current_exe().expect("current_exe");
+    // benches/hot_path → target/debug/deps/hot_path-xxx
+    // binary は target/debug/merge-ready
+    path.pop(); // hot_path-xxx
+    path.pop(); // deps
+    path.push("merge-ready");
+    if !path.exists() {
+        // release build の場合
+        path.pop();
+        path.pop();
+        path.push("release");
+        path.push("merge-ready");
+    }
+    path
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
+/// キャッシュヒットパスのベンチマーク（目標: <5ms）
+///
+/// ファイル読み込み → 文字列返却 のみを計測する。
+fn bench_cache_hit(c: &mut Criterion) {
+    let env = setup_bench_env();
+    let repo_id = "https___github_com_bench_repo_git";
+    let cache_dir = env
+        .home_dir
+        .path()
+        .join(".cache")
+        .join("merge-ready")
+        .join(repo_id);
+    fs::create_dir_all(&cache_dir).expect("create cache dir");
+
+    let state_json = format!(
+        r#"{{"fetched_at_secs":{now},"output":"✓ merge-ready"}}"#,
+        now = now_secs()
+    );
+    fs::write(cache_dir.join("state.json"), state_json).expect("write state.json");
+
+    let bin = binary_path();
+    let path = path_env(&env);
+    let home = env.home_dir.path().to_owned();
+
+    c.bench_function("cache_hit", |b| {
+        b.iter(|| {
+            Command::new(&bin)
+                .env("PATH", &path)
+                .env("HOME", &home)
+                .output()
+                .expect("merge-ready failed")
+        });
+    });
+}
+
+/// キャッシュミスパスのベンチマーク（フェイク gh 使用）
+///
+/// `MERGE_READY_NO_CACHE=1` で従来のフロー（gh 呼び出し）を計測する。
+/// ネットワーク遅延はないが、プロセス起動 + JSON パース + ロジックのコストが含まれる。
+fn bench_no_cache_direct(c: &mut Criterion) {
+    let env = setup_bench_env();
+    let bin = binary_path();
+    let path = path_env(&env);
+    let home = env.home_dir.path().to_owned();
+
+    c.bench_function("no_cache_direct", |b| {
+        b.iter(|| {
+            Command::new(&bin)
+                .env("PATH", &path)
+                .env("HOME", &home)
+                .env("MERGE_READY_NO_CACHE", "1")
+                .output()
+                .expect("merge-ready failed")
+        });
+    });
+}
+
+criterion_group!(benches, bench_cache_hit, bench_no_cache_direct);
+criterion_main!(benches);

--- a/benches/hot_path.rs
+++ b/benches/hot_path.rs
@@ -1,7 +1,7 @@
 //! ホットパスのベンチマーク
 //!
 //! キャッシュヒットパス（ファイル読み込み → 出力）と
-//! キャッシュミスパス（フェイク gh を使った全フロー）の両方を計測する。
+//! キャッシュなし直接実行パス（フェイク gh を使った全フロー）の両方を計測する。
 //!
 //! 使用方法:
 //! ```
@@ -24,21 +24,34 @@ struct BenchEnv {
     home_dir: TempDir,
 }
 
+const FAKE_TOPLEVEL: &str = "/fake/bench/repo";
 const OPEN_MERGE_READY_JSON: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}"#;
 const CI_PASS_JSON: &str = r#"[{"bucket":"pass","state":"SUCCESS","name":"ci","link":""}]"#;
+
+/// FNV-1a ハッシュで repo_id を生成する（`infra::repo_id::path_to_id` と同じアルゴリズム）
+fn path_to_id(path: &str) -> String {
+    let mut hash: u64 = 14_695_981_039_346_656_037;
+    for byte in path.bytes() {
+        hash ^= byte as u64;
+        hash = hash.wrapping_mul(1_099_511_628_211);
+    }
+    format!("{hash:016x}")
+}
 
 /// フェイクの gh/git バイナリを含むベンチマーク環境を構築する
 fn setup_bench_env() -> BenchEnv {
     let bin_dir = TempDir::new().expect("bin_dir");
     let home_dir = TempDir::new().expect("home_dir");
 
-    // fake git
-    let git_script = "#!/bin/sh\n\
-        case \"$*\" in\n\
-          *'remote get-url origin'*) echo 'https://github.com/bench/repo.git'; exit 0 ;;\n\
-          *) exit 0 ;;\n\
-        esac\n";
-    write_executable(&bin_dir.path().join("git"), git_script);
+    // fake git: rev-parse --show-toplevel のみ必要
+    let git_script = format!(
+        "#!/bin/sh\n\
+         case \"$*\" in\n\
+           *'rev-parse --show-toplevel'*) echo '{FAKE_TOPLEVEL}'; exit 0 ;;\n\
+           *) exit 0 ;;\n\
+         esac\n"
+    );
+    write_executable(&bin_dir.path().join("git"), &git_script);
 
     // fake gh（即時応答）
     // JSON に `{}` が含まれているため format! ではなく文字列連結を使用
@@ -46,7 +59,7 @@ fn setup_bench_env() -> BenchEnv {
         + OPEN_MERGE_READY_JSON
         + "' ;;\n  *'pr checks'*) printf '%s' '"
         + CI_PASS_JSON
-        + "' ;;\n  *) exit 0 ;;\nesac\n";
+        + "' ;;\n  *'api'*'compare'*) printf '{\"behind_by\":0}' ;;\n  *) exit 0 ;;\nesac\n";
     write_executable(&bin_dir.path().join("gh"), &gh_script);
 
     BenchEnv { bin_dir, home_dir }
@@ -87,23 +100,23 @@ fn now_secs() -> u64 {
 
 /// キャッシュヒットパスのベンチマーク（目標: <5ms）
 ///
-/// ファイル読み込み → 文字列返却 のみを計測する。
+/// `prompt` サブコマンドでキャッシュファイルを読み込んで返すパスのみを計測する。
 fn bench_cache_hit(c: &mut Criterion) {
     let env = setup_bench_env();
-    let repo_id = "https___github_com_bench_repo_git";
-    let cache_dir = env
+    let repo_id = path_to_id(FAKE_TOPLEVEL);
+    let cache_path = env
         .home_dir
         .path()
         .join(".cache")
         .join("merge-ready")
-        .join(repo_id);
-    fs::create_dir_all(&cache_dir).expect("create cache dir");
+        .join(format!("{repo_id}.json"));
 
+    fs::create_dir_all(cache_path.parent().unwrap()).expect("create cache dir");
     let state_json = format!(
         r#"{{"fetched_at_secs":{now},"output":"✓ merge-ready"}}"#,
         now = now_secs()
     );
-    fs::write(cache_dir.join("state.json"), state_json).expect("write state.json");
+    fs::write(&cache_path, state_json).expect("write cache");
 
     let bin = binary_path();
     let path = path_env(&env);
@@ -114,15 +127,16 @@ fn bench_cache_hit(c: &mut Criterion) {
             Command::new(&bin)
                 .env("PATH", &path)
                 .env("HOME", &home)
+                .arg("prompt")
                 .output()
                 .expect("merge-ready failed")
         });
     });
 }
 
-/// キャッシュミスパスのベンチマーク（フェイク gh 使用）
+/// キャッシュなし直接実行パスのベンチマーク（フェイク gh 使用）
 ///
-/// `MERGE_READY_NO_CACHE=1` で従来のフロー（gh 呼び出し）を計測する。
+/// `prompt --no-cache` で gh を直接呼ぶフローを計測する。
 /// ネットワーク遅延はないが、プロセス起動 + JSON パース + ロジックのコストが含まれる。
 fn bench_no_cache_direct(c: &mut Criterion) {
     let env = setup_bench_env();
@@ -135,7 +149,7 @@ fn bench_no_cache_direct(c: &mut Criterion) {
             Command::new(&bin)
                 .env("PATH", &path)
                 .env("HOME", &home)
-                .env("MERGE_READY_NO_CACHE", "1")
+                .args(["prompt", "--no-cache"])
                 .output()
                 .expect("merge-ready failed")
         });

--- a/benches/hot_path.rs
+++ b/benches/hot_path.rs
@@ -25,13 +25,17 @@ struct BenchEnv {
 }
 
 const FAKE_TOPLEVEL: &str = "/fake/bench/repo";
+const FAKE_BRANCH: &str = "main";
 const OPEN_MERGE_READY_JSON: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}"#;
 const CI_PASS_JSON: &str = r#"[{"bucket":"pass","state":"SUCCESS","name":"ci","link":""}]"#;
 
 /// FNV-1a ハッシュで repo_id を生成する（`infra::repo_id::path_to_id` と同じアルゴリズム）
-fn path_to_id(path: &str) -> String {
+///
+/// キーは `"<toplevel>\0<branch>"` の形式で生成する。
+fn bench_repo_id() -> String {
+    let input = format!("{FAKE_TOPLEVEL}\0{FAKE_BRANCH}");
     let mut hash: u64 = 14_695_981_039_346_656_037;
-    for byte in path.bytes() {
+    for byte in input.bytes() {
         hash ^= byte as u64;
         hash = hash.wrapping_mul(1_099_511_628_211);
     }
@@ -43,11 +47,12 @@ fn setup_bench_env() -> BenchEnv {
     let bin_dir = TempDir::new().expect("bin_dir");
     let home_dir = TempDir::new().expect("home_dir");
 
-    // fake git: rev-parse --show-toplevel のみ必要
+    // fake git: rev-parse --show-toplevel と branch --show-current が必要
     let git_script = format!(
         "#!/bin/sh\n\
          case \"$*\" in\n\
            *'rev-parse --show-toplevel'*) echo '{FAKE_TOPLEVEL}'; exit 0 ;;\n\
+           *'branch --show-current'*) echo '{FAKE_BRANCH}'; exit 0 ;;\n\
            *) exit 0 ;;\n\
          esac\n"
     );
@@ -103,7 +108,7 @@ fn now_secs() -> u64 {
 /// `prompt` サブコマンドでキャッシュファイルを読み込んで返すパスのみを計測する。
 fn bench_cache_hit(c: &mut Criterion) {
     let env = setup_bench_env();
-    let repo_id = path_to_id(FAKE_TOPLEVEL);
+    let repo_id = bench_repo_id();
     let cache_path = env
         .home_dir
         .path()

--- a/src/application.rs
+++ b/src/application.rs
@@ -4,6 +4,7 @@ mod ci_checks;
 pub(super) mod errors;
 mod merge_ready;
 mod pr_state;
+pub(crate) mod prompt;
 mod review;
 
 use crate::domain::{

--- a/src/application.rs
+++ b/src/application.rs
@@ -53,19 +53,21 @@ where
     // branch_sync と ci_checks は独立した gh 呼び出しを必要とするため並列フェッチ
     // review と merge_ready はキャッシュ済みの pr_view データを使用するため追加呼び出しなし
     let (sync_result, ci_result) = std::thread::scope(|s| {
-        let sync_handle = s.spawn(|| branch_sync::fetch(client, err_logger, err_presenter));
-        let ci_handle = s.spawn(|| ci_checks::fetch(client, err_logger, err_presenter));
+        let sync_handle = s.spawn(|| branch_sync::fetch(client));
+        let ci_handle = s.spawn(|| ci_checks::fetch(client));
         (
             sync_handle.join().expect("branch_sync thread panicked"),
             ci_handle.join().expect("ci_checks thread panicked"),
         )
     });
 
-    let Some(sync_status) = sync_result else {
-        return vec![];
-    };
-    let Some(buckets) = ci_result else {
-        return vec![];
+    // 両方失敗した場合でも err_presenter への通知は 1 回だけ（重複表示を防ぐ）
+    let (sync_status, buckets) = match (sync_result, ci_result) {
+        (Ok(s), Ok(b)) => (s, b),
+        (Err(e), _) | (_, Err(e)) => {
+            errors::handle(e, err_logger, err_presenter);
+            return vec![];
+        }
     };
 
     let Some(review_status) = review::fetch(client, err_logger, err_presenter) else {

--- a/src/application.rs
+++ b/src/application.rs
@@ -28,15 +28,19 @@ pub enum OutputToken {
 ///
 /// 表示すべきトークンを返す。呼び出し元が表示処理を担う。
 /// PR が対象外（クローズ等）または取得失敗の場合は空 `Vec` を返す。
+///
+/// `branch_sync` と `ci_checks` のフェッチは独立した gh 呼び出しを必要とするため、
+/// `std::thread::scope` を使って並列実行する。
 pub fn run<C, L, P>(client: &C, err_logger: &L, err_presenter: &P) -> Vec<OutputToken>
 where
     C: PrStateRepository
         + BranchSyncRepository
         + CiChecksRepository
         + ReviewRepository
-        + MergeReadinessRepository,
-    L: ErrorLogger,
-    P: ErrorPresenter,
+        + MergeReadinessRepository
+        + Sync,
+    L: ErrorLogger + Sync,
+    P: ErrorPresenter + Sync,
 {
     let Some(lifecycle) = pr_state::fetch(client, err_logger, err_presenter) else {
         return vec![];
@@ -45,12 +49,24 @@ where
         return vec![];
     }
 
-    let Some(sync_status) = branch_sync::fetch(client, err_logger, err_presenter) else {
+    // branch_sync と ci_checks は独立した gh 呼び出しを必要とするため並列フェッチ
+    // review と merge_ready はキャッシュ済みの pr_view データを使用するため追加呼び出しなし
+    let (sync_result, ci_result) = std::thread::scope(|s| {
+        let sync_handle = s.spawn(|| branch_sync::fetch(client, err_logger, err_presenter));
+        let ci_handle = s.spawn(|| ci_checks::fetch(client, err_logger, err_presenter));
+        (
+            sync_handle.join().expect("branch_sync thread panicked"),
+            ci_handle.join().expect("ci_checks thread panicked"),
+        )
+    });
+
+    let Some(sync_status) = sync_result else {
         return vec![];
     };
-    let Some(buckets) = ci_checks::fetch(client, err_logger, err_presenter) else {
+    let Some(buckets) = ci_result else {
         return vec![];
     };
+
     let Some(review_status) = review::fetch(client, err_logger, err_presenter) else {
         return vec![];
     };

--- a/src/application.rs
+++ b/src/application.rs
@@ -1,4 +1,5 @@
 mod branch_sync;
+pub(crate) mod cache;
 mod ci_checks;
 pub(super) mod errors;
 mod merge_ready;

--- a/src/application/branch_sync.rs
+++ b/src/application/branch_sync.rs
@@ -1,20 +1,10 @@
 use crate::application::OutputToken;
-use crate::application::errors::{ErrorLogger, ErrorPresenter};
 use crate::domain::branch_sync::{BranchSyncRepository, BranchSyncStatus};
+use crate::domain::error::RepositoryError;
 
-/// ブランチ同期状態を取得する。失敗時は `None` を返してエラー出力する。
-pub fn fetch(
-    repo: &impl BranchSyncRepository,
-    err_logger: &impl ErrorLogger,
-    err_presenter: &impl ErrorPresenter,
-) -> Option<BranchSyncStatus> {
-    match repo.fetch_sync_status() {
-        Ok(status) => Some(status),
-        Err(e) => {
-            super::errors::handle(e, err_logger, err_presenter);
-            None
-        }
-    }
+/// ブランチ同期状態を取得する。失敗時は `Err` を返す（エラー表示は呼び出し元が担う）。
+pub fn fetch(repo: &impl BranchSyncRepository) -> Result<BranchSyncStatus, RepositoryError> {
+    repo.fetch_sync_status()
 }
 
 /// ブランチ同期状態を評価し、該当するトークンを返す

--- a/src/application/cache.rs
+++ b/src/application/cache.rs
@@ -16,7 +16,9 @@ pub(crate) enum DisplayAction {
     Display(String),
     /// 表示してからバックグラウンドリフレッシュを要求する
     DisplayAndRefresh(String),
-    /// "? loading" を表示してバックグラウンドリフレッシュを要求する
+    /// "? loading" を表示してバックグラウンドリフレッシュを要求する（git リポジトリは存在する）
+    LoadingWithRefresh,
+    /// "? loading" を表示するのみ（git リポジトリが取得できない）
     Loading,
 }
 
@@ -28,6 +30,6 @@ pub(crate) fn resolve(repo_id: Option<&str>, cache: &impl CachePort) -> DisplayA
     match cache.check(id) {
         CacheState::Fresh(s) => DisplayAction::Display(s),
         CacheState::Stale(s) => DisplayAction::DisplayAndRefresh(s),
-        CacheState::Miss => DisplayAction::Loading,
+        CacheState::Miss => DisplayAction::LoadingWithRefresh,
     }
 }

--- a/src/application/cache.rs
+++ b/src/application/cache.rs
@@ -1,0 +1,33 @@
+/// キャッシュの状態（アプリケーション層の表現）
+pub(crate) enum CacheState {
+    Fresh(String),
+    Stale(String),
+    Miss,
+}
+
+/// キャッシュ読み取りを抽象化するポート
+pub(crate) trait CachePort {
+    fn check(&self, repo_id: &str) -> CacheState;
+}
+
+/// main に伝える表示アクション
+pub(crate) enum DisplayAction {
+    /// そのまま表示する（バックグラウンドリフレッシュ不要）
+    Display(String),
+    /// 表示してからバックグラウンドリフレッシュを要求する
+    DisplayAndRefresh(String),
+    /// "? loading" を表示してバックグラウンドリフレッシュを要求する
+    Loading,
+}
+
+/// キャッシュ方針に基づいて表示アクションを決定する
+pub(crate) fn resolve(repo_id: Option<&str>, cache: &impl CachePort) -> DisplayAction {
+    let Some(id) = repo_id else {
+        return DisplayAction::Loading;
+    };
+    match cache.check(id) {
+        CacheState::Fresh(s) => DisplayAction::Display(s),
+        CacheState::Stale(s) => DisplayAction::DisplayAndRefresh(s),
+        CacheState::Miss => DisplayAction::Loading,
+    }
+}

--- a/src/application/cache.rs
+++ b/src/application/cache.rs
@@ -16,18 +16,13 @@ pub(crate) enum DisplayAction {
     Display(String),
     /// 表示してからバックグラウンドリフレッシュを要求する
     DisplayAndRefresh(String),
-    /// "? loading" を表示してバックグラウンドリフレッシュを要求する（git リポジトリは存在する）
+    /// "? loading" を表示してバックグラウンドリフレッシュを要求する（キャッシュミス）
     LoadingWithRefresh,
-    /// "? loading" を表示するのみ（git リポジトリが取得できない）
-    Loading,
 }
 
 /// キャッシュ方針に基づいて表示アクションを決定する
-pub(crate) fn resolve(repo_id: Option<&str>, cache: &impl CachePort) -> DisplayAction {
-    let Some(id) = repo_id else {
-        return DisplayAction::Loading;
-    };
-    match cache.check(id) {
+pub(crate) fn resolve(repo_id: &str, cache: &impl CachePort) -> DisplayAction {
+    match cache.check(repo_id) {
         CacheState::Fresh(s) => DisplayAction::Display(s),
         CacheState::Stale(s) => DisplayAction::DisplayAndRefresh(s),
         CacheState::Miss => DisplayAction::LoadingWithRefresh,

--- a/src/application/ci_checks.rs
+++ b/src/application/ci_checks.rs
@@ -1,20 +1,10 @@
 use crate::application::OutputToken;
-use crate::application::errors::{ErrorLogger, ErrorPresenter};
 use crate::domain::ci_checks::{CheckBucket, CiChecksRepository, CiStatus};
+use crate::domain::error::RepositoryError;
 
-/// CI チェック結果を取得する。失敗時は `None` を返してエラー出力する。
-pub fn fetch(
-    repo: &impl CiChecksRepository,
-    err_logger: &impl ErrorLogger,
-    err_presenter: &impl ErrorPresenter,
-) -> Option<Vec<CheckBucket>> {
-    match repo.fetch_check_buckets() {
-        Ok(buckets) => Some(buckets),
-        Err(e) => {
-            super::errors::handle(e, err_logger, err_presenter);
-            None
-        }
-    }
+/// CI チェック結果を取得する。失敗時は `Err` を返す（エラー表示は呼び出し元が担う）。
+pub fn fetch(repo: &impl CiChecksRepository) -> Result<Vec<CheckBucket>, RepositoryError> {
+    repo.fetch_check_buckets()
 }
 
 /// CI チェック結果を集約・評価し、該当するトークンを返す

--- a/src/application/prompt.rs
+++ b/src/application/prompt.rs
@@ -1,0 +1,76 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use crate::application::cache::DisplayAction;
+use crate::application::errors::{ErrorPresenter, ErrorToken};
+
+/// キャッシュ方針に基づいて表示し、必要に応じてバックグラウンドリフレッシュを起動する。
+///
+/// git リポジトリでない場合は何も出力しない。
+pub fn run_cached() {
+    let Some(repo_id) = crate::infra::repo_id::get() else {
+        return;
+    };
+    let cache = crate::infra::cache::CacheStore;
+    match crate::application::cache::resolve(&repo_id, &cache) {
+        DisplayAction::Display(s) => {
+            print!("{s}");
+        }
+        DisplayAction::DisplayAndRefresh(s) => {
+            print!("{s}");
+            crate::infra::refresh_lock::maybe_spawn_refresh(&repo_id);
+        }
+        DisplayAction::LoadingWithRefresh => {
+            print!("? loading");
+            crate::infra::refresh_lock::maybe_spawn_refresh(&repo_id);
+        }
+    }
+}
+
+/// gh を直接呼んでキャッシュを更新する（stdout に出力しない）。
+///
+/// エラー発生時は既存キャッシュを上書きしない。
+pub fn run_refresh() {
+    let Some(id) = crate::infra::repo_id::get() else {
+        return;
+    };
+    if let Some(output) = fetch_silent() {
+        crate::infra::cache::write(&id, &output);
+    }
+    crate::infra::refresh_lock::release(&id);
+}
+
+/// gh を直接呼んで結果を stdout に出力する（キャッシュを使わない）。
+pub fn run_direct() {
+    let tokens = crate::application::run(
+        &crate::infra::gh::GhClient::new(),
+        &crate::infra::logger::Logger,
+        &crate::presentation::Presenter,
+    );
+    if !tokens.is_empty() {
+        crate::presentation::display(&tokens);
+    }
+}
+
+/// gh を呼んで結果を文字列で返す。エラー発生時は `None` を返す（空文字と区別するため）。
+fn fetch_silent() -> Option<String> {
+    struct TrackingPresenter(AtomicBool);
+
+    impl ErrorPresenter for TrackingPresenter {
+        fn show_error(&self, _token: ErrorToken) {
+            self.0.store(true, Ordering::Relaxed);
+        }
+    }
+
+    let presenter = TrackingPresenter(AtomicBool::new(false));
+    let tokens = crate::application::run(
+        &crate::infra::gh::GhClient::new(),
+        &crate::infra::logger::Logger,
+        &presenter,
+    );
+
+    if presenter.0.load(Ordering::Relaxed) {
+        None
+    } else {
+        Some(crate::presentation::render_to_string(&tokens))
+    }
+}

--- a/src/application/prompt.rs
+++ b/src/application/prompt.rs
@@ -1,58 +1,60 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use crate::application::cache::DisplayAction;
-use crate::application::errors::{ErrorPresenter, ErrorToken};
+use crate::application::cache::{CachePort, DisplayAction};
+use crate::application::errors::{ErrorPresenter, ErrorToken, ErrorLogger};
+use crate::application::OutputToken;
+use crate::domain::{
+    branch_sync::BranchSyncRepository, ci_checks::CiChecksRepository,
+    merge_ready::MergeReadinessRepository, pr_state::PrStateRepository, review::ReviewRepository,
+};
 
-/// キャッシュ方針に基づいて表示し、必要に応じてバックグラウンドリフレッシュを起動する。
+/// git リポジトリ ID を取得するポート
+pub trait RepoIdPort {
+    fn get(&self) -> Option<String>;
+}
+
+/// キャッシュ表示の結果として CLI 層が実行すべき意図を表す
+pub enum PromptEffect {
+    /// そのまま表示（バックグラウンドリフレッシュ不要）
+    Show(String),
+    /// 表示してからバックグラウンドリフレッシュを要求する
+    ShowAndRefresh { output: String, repo_id: String },
+    /// "? loading" を表示してバックグラウンドリフレッシュを要求する（キャッシュミス）
+    ShowLoadingAndRefresh { repo_id: String },
+    /// 何も表示しない（git リポジトリ外など）
+    NoOutput,
+}
+
+/// キャッシュ方針に基づいて表示意図を返す（副作用なし）。
 ///
-/// git リポジトリでない場合は何も出力しない。
-pub fn run_cached() {
-    let Some(repo_id) = crate::infra::repo_id::get() else {
-        return;
+/// git リポジトリ外の場合は [`PromptEffect::NoOutput`] を返す。
+pub fn resolve_cached(repo_id: &impl RepoIdPort, cache: &impl CachePort) -> PromptEffect {
+    let Some(id) = repo_id.get() else {
+        return PromptEffect::NoOutput;
     };
-    let cache = crate::infra::cache::CacheStore;
-    match crate::application::cache::resolve(&repo_id, &cache) {
-        DisplayAction::Display(s) => {
-            print!("{s}");
-        }
-        DisplayAction::DisplayAndRefresh(s) => {
-            print!("{s}");
-            crate::infra::refresh_lock::maybe_spawn_refresh(&repo_id);
-        }
-        DisplayAction::LoadingWithRefresh => {
-            print!("? loading");
-            crate::infra::refresh_lock::maybe_spawn_refresh(&repo_id);
-        }
+    match crate::application::cache::resolve(&id, cache) {
+        DisplayAction::Display(s) => PromptEffect::Show(s),
+        DisplayAction::DisplayAndRefresh(s) => PromptEffect::ShowAndRefresh {
+            output: s,
+            repo_id: id,
+        },
+        DisplayAction::LoadingWithRefresh => PromptEffect::ShowLoadingAndRefresh { repo_id: id },
     }
 }
 
-/// gh を直接呼んでキャッシュを更新する（stdout に出力しない）。
+/// gh を呼んで出力トークンを返す。エラー発生時は `None` を返す（キャッシュ書き込み回避）。
 ///
-/// エラー発生時は既存キャッシュを上書きしない。
-pub fn run_refresh() {
-    let Some(id) = crate::infra::repo_id::get() else {
-        return;
-    };
-    if let Some(output) = fetch_silent() {
-        crate::infra::cache::write(&id, &output);
-    }
-    crate::infra::refresh_lock::release(&id);
-}
-
-/// gh を直接呼んで結果を stdout に出力する（キャッシュを使わない）。
-pub fn run_direct() {
-    let tokens = crate::application::run(
-        &crate::infra::gh::GhClient::new(),
-        &crate::infra::logger::Logger,
-        &crate::presentation::Presenter,
-    );
-    if !tokens.is_empty() {
-        crate::presentation::display(&tokens);
-    }
-}
-
-/// gh を呼んで結果を文字列で返す。エラー発生時は `None` を返す（空文字と区別するため）。
-fn fetch_silent() -> Option<String> {
+/// バックグラウンドリフレッシュ用。エラーは stderr に出力せず内部追跡のみ行う。
+pub fn fetch_output<C, L>(client: &C, logger: &L) -> Option<Vec<OutputToken>>
+where
+    C: PrStateRepository
+        + BranchSyncRepository
+        + CiChecksRepository
+        + ReviewRepository
+        + MergeReadinessRepository
+        + Sync,
+    L: ErrorLogger + Sync,
+{
     struct TrackingPresenter(AtomicBool);
 
     impl ErrorPresenter for TrackingPresenter {
@@ -62,15 +64,11 @@ fn fetch_silent() -> Option<String> {
     }
 
     let presenter = TrackingPresenter(AtomicBool::new(false));
-    let tokens = crate::application::run(
-        &crate::infra::gh::GhClient::new(),
-        &crate::infra::logger::Logger,
-        &presenter,
-    );
+    let tokens = crate::application::run(client, logger, &presenter);
 
     if presenter.0.load(Ordering::Relaxed) {
         None
     } else {
-        Some(crate::presentation::render_to_string(&tokens))
+        Some(tokens)
     }
 }

--- a/src/application/prompt.rs
+++ b/src/application/prompt.rs
@@ -1,8 +1,8 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use crate::application::cache::{CachePort, DisplayAction};
-use crate::application::errors::{ErrorPresenter, ErrorToken, ErrorLogger};
 use crate::application::OutputToken;
+use crate::application::cache::{CachePort, DisplayAction};
+use crate::application::errors::{ErrorLogger, ErrorPresenter, ErrorToken};
 use crate::domain::{
     branch_sync::BranchSyncRepository, ci_checks::CiChecksRepository,
     merge_ready::MergeReadinessRepository, pr_state::PrStateRepository, review::ReviewRepository,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,4 @@
 mod args;
-mod help;
 mod prompt;
 
 use args::{Cli, Command};

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,7 +8,7 @@ use clap::{CommandFactory, Parser};
 pub(crate) fn run() {
     let cli = Cli::parse();
     match cli.command {
-        Some(Command::Prompt(args)) => prompt::run(args),
+        Some(Command::Prompt(args)) => prompt::run(&args),
         None => {
             let _ = Cli::command().print_help();
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,7 +8,7 @@ use clap::{CommandFactory, Parser};
 pub(crate) fn run() {
     let cli = Cli::parse();
     match cli.command {
-        Some(Command::Prompt) => prompt::run_check(),
+        Some(Command::Prompt(args)) => prompt::run(args),
         None => {
             let _ = Cli::command().print_help();
         }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -26,4 +26,7 @@ pub(crate) struct PromptArgs {
     /// Fetch fresh data and update cache without displaying output
     #[arg(long, hide = true, conflicts_with = "no_cache")]
     pub(crate) refresh: bool,
+    /// Repository ID for lock release (passed by parent process via --refresh)
+    #[arg(long, hide = true, requires = "refresh")]
+    pub(crate) repo_id: Option<String>,
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -16,6 +16,6 @@ pub(crate) struct Cli {
 #[derive(Subcommand)]
 pub(crate) enum Command {
     /// Show PR merge status for your shell prompt
-    #[command(after_help = super::help::PROMPT_AFTER_HELP)]
+    #[command(after_help = super::prompt::PROMPT_AFTER_HELP)]
     Prompt(PromptArgs),
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,4 +1,6 @@
-use clap::{Args, Parser, Subcommand};
+use clap::{Parser, Subcommand};
+
+use super::prompt::PromptArgs;
 
 #[derive(Parser)]
 #[command(
@@ -16,17 +18,4 @@ pub(crate) enum Command {
     /// Show PR merge status for your shell prompt
     #[command(after_help = super::help::PROMPT_AFTER_HELP)]
     Prompt(PromptArgs),
-}
-
-#[derive(Args)]
-pub(crate) struct PromptArgs {
-    /// Bypass cache and fetch fresh data directly
-    #[arg(long)]
-    pub(crate) no_cache: bool,
-    /// Fetch fresh data and update cache without displaying output
-    #[arg(long, hide = true, conflicts_with = "no_cache")]
-    pub(crate) refresh: bool,
-    /// Repository ID for lock release (passed by parent process via --refresh)
-    #[arg(long, hide = true, requires = "refresh")]
-    pub(crate) repo_id: Option<String>,
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -16,6 +16,6 @@ pub(crate) struct Cli {
 #[derive(Subcommand)]
 pub(crate) enum Command {
     /// Show PR merge status for your shell prompt
-    #[command(after_help = super::prompt::PROMPT_AFTER_HELP)]
+    #[command(after_help = super::prompt::AFTER_HELP)]
     Prompt(PromptArgs),
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -24,6 +24,6 @@ pub(crate) struct PromptArgs {
     #[arg(long)]
     pub(crate) no_cache: bool,
     /// Fetch fresh data and update cache without displaying output
-    #[arg(long, hide = true)]
+    #[arg(long, hide = true, conflicts_with = "no_cache")]
     pub(crate) refresh: bool,
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,4 +1,4 @@
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 
 #[derive(Parser)]
 #[command(
@@ -15,5 +15,15 @@ pub(crate) struct Cli {
 pub(crate) enum Command {
     /// Show PR merge status for your shell prompt
     #[command(after_help = super::help::PROMPT_AFTER_HELP)]
-    Prompt,
+    Prompt(PromptArgs),
+}
+
+#[derive(Args)]
+pub(crate) struct PromptArgs {
+    /// Bypass cache and fetch fresh data directly
+    #[arg(long)]
+    pub(crate) no_cache: bool,
+    /// Fetch fresh data and update cache without displaying output
+    #[arg(long, hide = true)]
+    pub(crate) refresh: bool,
 }

--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -1,8 +1,0 @@
-pub(super) const PROMPT_AFTER_HELP: &str = "Output tokens:
-  ✓ merge-ready    Ready to merge
-  ⚠ review         Review requested
-  ⚠ ci-action      CI checks in progress
-  ✗ ci-fail        CI checks failed
-  ✗ conflict       Branch has merge conflicts
-  ✗ update-branch  Branch is behind base branch
-  ? sync-unknown   Branch sync status unknown";

--- a/src/cli/prompt.rs
+++ b/src/cli/prompt.rs
@@ -3,7 +3,7 @@ mod cached;
 mod direct;
 mod refresh;
 
-pub(super) use args::{PROMPT_AFTER_HELP, PromptArgs};
+pub(super) use args::{AFTER_HELP, PromptArgs};
 
 pub(crate) fn run(args: &PromptArgs) {
     if args.refresh {

--- a/src/cli/prompt.rs
+++ b/src/cli/prompt.rs
@@ -1,4 +1,46 @@
-pub(crate) fn run_check() {
+use crate::application::cache::DisplayAction;
+use crate::application::errors::{ErrorPresenter, ErrorToken};
+use crate::cli::args::PromptArgs;
+
+pub(crate) fn run(args: PromptArgs) {
+    if args.refresh {
+        run_refresh();
+    } else if args.no_cache {
+        run_direct();
+    } else {
+        run_cached();
+    }
+}
+
+/// キャッシュ方針に基づいて表示し、必要に応じてバックグラウンドリフレッシュを起動する
+fn run_cached() {
+    let cache = crate::infra::cache::CacheStore;
+    match crate::application::cache::resolve(crate::infra::repo_id::get().as_deref(), &cache) {
+        DisplayAction::Display(s) => {
+            print!("{s}");
+        }
+        DisplayAction::DisplayAndRefresh(s) => {
+            print!("{s}");
+            spawn_background_refresh();
+        }
+        DisplayAction::Loading => {
+            print!("? loading");
+            spawn_background_refresh();
+        }
+    }
+}
+
+/// gh を直接呼んでキャッシュを更新する（stdout に出力しない）
+fn run_refresh() {
+    let Some(id) = crate::infra::repo_id::get() else {
+        return;
+    };
+    let output = run_silent();
+    crate::infra::cache::write(&id, &output);
+}
+
+/// gh を直接呼んで結果を stdout に出力する（キャッシュを使わない）
+fn run_direct() {
     let tokens = crate::application::run(
         &crate::infra::gh::GhClient::new(),
         &crate::infra::logger::Logger,
@@ -7,4 +49,32 @@ pub(crate) fn run_check() {
     if !tokens.is_empty() {
         crate::presentation::display(&tokens);
     }
+}
+
+/// gh を呼んで結果を文字列で返す（stdout には何も出力しない）
+fn run_silent() -> String {
+    struct SilentPresenter;
+
+    impl ErrorPresenter for SilentPresenter {
+        fn show_error(&self, _token: ErrorToken) {}
+    }
+
+    let tokens = crate::application::run(
+        &crate::infra::gh::GhClient::new(),
+        &crate::infra::logger::Logger,
+        &SilentPresenter,
+    );
+    crate::presentation::render_to_string(&tokens)
+}
+
+fn spawn_background_refresh() {
+    let Ok(exe) = std::env::current_exe() else {
+        return;
+    };
+    let _ = std::process::Command::new(exe)
+        .args(["prompt", "--refresh"])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn();
 }

--- a/src/cli/prompt.rs
+++ b/src/cli/prompt.rs
@@ -1,114 +1,11 @@
-use std::sync::atomic::{AtomicBool, Ordering};
-
-use crate::application::cache::DisplayAction;
-use crate::application::errors::{ErrorPresenter, ErrorToken};
 use crate::cli::args::PromptArgs;
 
 pub(crate) fn run(args: &PromptArgs) {
     if args.refresh {
-        run_refresh();
+        crate::application::prompt::run_refresh();
     } else if args.no_cache {
-        run_direct();
+        crate::application::prompt::run_direct();
     } else {
-        run_cached();
+        crate::application::prompt::run_cached();
     }
-}
-
-/// キャッシュ方針に基づいて表示し、必要に応じてバックグラウンドリフレッシュを起動する
-///
-/// git リポジトリでない場合は何も出力しない（`run_direct` と同じ挙動）。
-fn run_cached() {
-    let Some(repo_id) = crate::infra::repo_id::get() else {
-        return;
-    };
-    let cache = crate::infra::cache::CacheStore;
-    match crate::application::cache::resolve(&repo_id, &cache) {
-        DisplayAction::Display(s) => {
-            print!("{s}");
-        }
-        DisplayAction::DisplayAndRefresh(s) => {
-            print!("{s}");
-            maybe_spawn_refresh(&repo_id);
-        }
-        DisplayAction::LoadingWithRefresh => {
-            print!("? loading");
-            maybe_spawn_refresh(&repo_id);
-        }
-    }
-}
-
-/// gh を直接呼んでキャッシュを更新する（stdout に出力しない）
-///
-/// エラー発生時は既存キャッシュを上書きしない。
-fn run_refresh() {
-    let Some(id) = crate::infra::repo_id::get() else {
-        return;
-    };
-    if let Some(output) = run_silent() {
-        crate::infra::cache::write(&id, &output);
-    }
-    crate::infra::cache::release_refresh_lock(&id);
-}
-
-/// gh を直接呼んで結果を stdout に出力する（キャッシュを使わない）
-fn run_direct() {
-    let tokens = crate::application::run(
-        &crate::infra::gh::GhClient::new(),
-        &crate::infra::logger::Logger,
-        &crate::presentation::Presenter,
-    );
-    if !tokens.is_empty() {
-        crate::presentation::display(&tokens);
-    }
-}
-
-/// gh を呼んで結果を文字列で返す。エラー発生時は `None` を返す（空文字と区別するため）。
-fn run_silent() -> Option<String> {
-    struct TrackingPresenter(AtomicBool);
-
-    impl ErrorPresenter for TrackingPresenter {
-        fn show_error(&self, _token: ErrorToken) {
-            self.0.store(true, Ordering::Relaxed);
-        }
-    }
-
-    let presenter = TrackingPresenter(AtomicBool::new(false));
-    let tokens = crate::application::run(
-        &crate::infra::gh::GhClient::new(),
-        &crate::infra::logger::Logger,
-        &presenter,
-    );
-
-    if presenter.0.load(Ordering::Relaxed) {
-        None
-    } else {
-        Some(crate::presentation::render_to_string(&tokens))
-    }
-}
-
-/// ロックを取得できた場合のみバックグラウンドリフレッシュを起動する（多重起動抑止）
-fn maybe_spawn_refresh(repo_id: &str) {
-    if !crate::infra::cache::try_acquire_refresh_lock(repo_id) {
-        return;
-    }
-    let Ok(exe) = std::env::current_exe() else {
-        crate::infra::cache::release_refresh_lock(repo_id);
-        return;
-    };
-    match std::process::Command::new(exe)
-        .args(["prompt", "--refresh"])
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn()
-    {
-        Ok(child) => {
-            // 子 PID をロックファイルへ書き込む（kill -0 による生存確認に使用）
-            crate::infra::cache::update_lock_pid(repo_id, child.id());
-        }
-        Err(_) => {
-            crate::infra::cache::release_refresh_lock(repo_id);
-        }
-    }
-    // ロックは子プロセス（run_refresh の末尾）が解放する
 }

--- a/src/cli/prompt.rs
+++ b/src/cli/prompt.rs
@@ -1,11 +1,67 @@
+use crate::application::prompt::{PromptEffect, RepoIdPort};
 use crate::cli::args::PromptArgs;
+
+struct InfraRepoIdPort;
+
+impl RepoIdPort for InfraRepoIdPort {
+    fn get(&self) -> Option<String> {
+        crate::infra::repo_id::get()
+    }
+}
 
 pub(crate) fn run(args: &PromptArgs) {
     if args.refresh {
-        crate::application::prompt::run_refresh();
+        run_refresh();
     } else if args.no_cache {
-        crate::application::prompt::run_direct();
+        run_direct();
     } else {
-        crate::application::prompt::run_cached();
+        run_cached();
+    }
+}
+
+/// キャッシュ方針に基づいて表示し、必要に応じてバックグラウンドリフレッシュを起動する。
+fn run_cached() {
+    let cache = crate::infra::cache::CacheStore;
+    match crate::application::prompt::resolve_cached(&InfraRepoIdPort, &cache) {
+        PromptEffect::NoOutput => {}
+        PromptEffect::Show(s) => print!("{s}"),
+        PromptEffect::ShowAndRefresh { output, repo_id } => {
+            print!("{output}");
+            crate::infra::refresh_lock::maybe_spawn_refresh(&repo_id);
+        }
+        PromptEffect::ShowLoadingAndRefresh { repo_id } => {
+            print!("? loading");
+            crate::infra::refresh_lock::maybe_spawn_refresh(&repo_id);
+        }
+    }
+}
+
+/// gh を直接呼んでキャッシュを更新する（stdout に出力しない）。
+///
+/// エラー発生時は既存キャッシュを上書きしない。
+fn run_refresh() {
+    let Some(repo_id) = crate::infra::repo_id::get() else {
+        return;
+    };
+    let tokens = crate::application::prompt::fetch_output(
+        &crate::infra::gh::GhClient::new(),
+        &crate::infra::logger::Logger,
+    );
+    if let Some(tokens) = tokens {
+        let output = crate::presentation::render_to_string(&tokens);
+        crate::infra::cache::write(&repo_id, &output);
+    }
+    crate::infra::refresh_lock::release(&repo_id);
+}
+
+/// gh を直接呼んで結果を stdout に出力する（キャッシュを使わない）。
+fn run_direct() {
+    let tokens = crate::application::run(
+        &crate::infra::gh::GhClient::new(),
+        &crate::infra::logger::Logger,
+        &crate::presentation::Presenter,
+    );
+    if !tokens.is_empty() {
+        crate::presentation::display(&tokens);
     }
 }

--- a/src/cli/prompt.rs
+++ b/src/cli/prompt.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use crate::application::cache::DisplayAction;
 use crate::application::errors::{ErrorPresenter, ErrorToken};
 use crate::cli::args::PromptArgs;
@@ -14,29 +16,41 @@ pub(crate) fn run(args: &PromptArgs) {
 
 /// キャッシュ方針に基づいて表示し、必要に応じてバックグラウンドリフレッシュを起動する
 fn run_cached() {
+    let repo_id = crate::infra::repo_id::get();
     let cache = crate::infra::cache::CacheStore;
-    match crate::application::cache::resolve(crate::infra::repo_id::get().as_deref(), &cache) {
+    match crate::application::cache::resolve(repo_id.as_deref(), &cache) {
         DisplayAction::Display(s) => {
             print!("{s}");
         }
         DisplayAction::DisplayAndRefresh(s) => {
             print!("{s}");
-            spawn_background_refresh();
+            if let Some(ref id) = repo_id {
+                maybe_spawn_refresh(id);
+            }
+        }
+        DisplayAction::LoadingWithRefresh => {
+            print!("? loading");
+            if let Some(ref id) = repo_id {
+                maybe_spawn_refresh(id);
+            }
         }
         DisplayAction::Loading => {
             print!("? loading");
-            spawn_background_refresh();
         }
     }
 }
 
 /// gh を直接呼んでキャッシュを更新する（stdout に出力しない）
+///
+/// エラー発生時は既存キャッシュを上書きしない。
 fn run_refresh() {
     let Some(id) = crate::infra::repo_id::get() else {
         return;
     };
-    let output = run_silent();
-    crate::infra::cache::write(&id, &output);
+    if let Some(output) = run_silent() {
+        crate::infra::cache::write(&id, &output);
+    }
+    crate::infra::cache::release_refresh_lock(&id);
 }
 
 /// gh を直接呼んで結果を stdout に出力する（キャッシュを使わない）
@@ -51,30 +65,48 @@ fn run_direct() {
     }
 }
 
-/// gh を呼んで結果を文字列で返す（stdout には何も出力しない）
-fn run_silent() -> String {
-    struct SilentPresenter;
+/// gh を呼んで結果を文字列で返す。エラー発生時は `None` を返す（空文字と区別するため）。
+fn run_silent() -> Option<String> {
+    struct TrackingPresenter(AtomicBool);
 
-    impl ErrorPresenter for SilentPresenter {
-        fn show_error(&self, _token: ErrorToken) {}
+    impl ErrorPresenter for TrackingPresenter {
+        fn show_error(&self, _token: ErrorToken) {
+            self.0.store(true, Ordering::Relaxed);
+        }
     }
 
+    let presenter = TrackingPresenter(AtomicBool::new(false));
     let tokens = crate::application::run(
         &crate::infra::gh::GhClient::new(),
         &crate::infra::logger::Logger,
-        &SilentPresenter,
+        &presenter,
     );
-    crate::presentation::render_to_string(&tokens)
+
+    if presenter.0.load(Ordering::Relaxed) {
+        None
+    } else {
+        Some(crate::presentation::render_to_string(&tokens))
+    }
 }
 
-fn spawn_background_refresh() {
+/// ロックを取得できた場合のみバックグラウンドリフレッシュを起動する（多重起動抑止）
+fn maybe_spawn_refresh(repo_id: &str) {
+    if !crate::infra::cache::try_acquire_refresh_lock(repo_id) {
+        return;
+    }
     let Ok(exe) = std::env::current_exe() else {
+        crate::infra::cache::release_refresh_lock(repo_id);
         return;
     };
-    let _ = std::process::Command::new(exe)
+    if std::process::Command::new(exe)
         .args(["prompt", "--refresh"])
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
-        .spawn();
+        .spawn()
+        .is_err()
+    {
+        crate::infra::cache::release_refresh_lock(repo_id);
+    }
+    // 正常起動時はロックを子プロセス（run_refresh）が解放する
 }

--- a/src/cli/prompt.rs
+++ b/src/cli/prompt.rs
@@ -15,27 +15,24 @@ pub(crate) fn run(args: &PromptArgs) {
 }
 
 /// キャッシュ方針に基づいて表示し、必要に応じてバックグラウンドリフレッシュを起動する
+///
+/// git リポジトリでない場合は何も出力しない（`run_direct` と同じ挙動）。
 fn run_cached() {
-    let repo_id = crate::infra::repo_id::get();
+    let Some(repo_id) = crate::infra::repo_id::get() else {
+        return;
+    };
     let cache = crate::infra::cache::CacheStore;
-    match crate::application::cache::resolve(repo_id.as_deref(), &cache) {
+    match crate::application::cache::resolve(&repo_id, &cache) {
         DisplayAction::Display(s) => {
             print!("{s}");
         }
         DisplayAction::DisplayAndRefresh(s) => {
             print!("{s}");
-            if let Some(ref id) = repo_id {
-                maybe_spawn_refresh(id);
-            }
+            maybe_spawn_refresh(&repo_id);
         }
         DisplayAction::LoadingWithRefresh => {
             print!("? loading");
-            if let Some(ref id) = repo_id {
-                maybe_spawn_refresh(id);
-            }
-        }
-        DisplayAction::Loading => {
-            print!("? loading");
+            maybe_spawn_refresh(&repo_id);
         }
     }
 }

--- a/src/cli/prompt.rs
+++ b/src/cli/prompt.rs
@@ -1,109 +1,27 @@
 mod args;
-
-use std::process::Stdio;
-
-use crate::application::prompt::{PromptEffect, RepoIdPort};
+mod cached;
+mod direct;
+mod refresh;
 
 pub(super) use args::PromptArgs;
-
-struct InfraRepoIdPort;
-
-impl RepoIdPort for InfraRepoIdPort {
-    fn get(&self) -> Option<String> {
-        crate::infra::repo_id::get()
-    }
-}
 
 pub(crate) fn run(args: &PromptArgs) {
     if args.refresh {
         match args.repo_id.as_deref() {
             Some(id) => {
                 // 親プロセスから --repo-id で渡された場合（通常パス）: git 再取得なし
-                run_refresh(id);
+                refresh::run_refresh(id);
             }
             None => {
                 // 手動実行など親なしの場合: git から取得（この場合ロック孤児は発生しない）
                 if let Some(id) = crate::infra::repo_id::get() {
-                    run_refresh(&id);
+                    refresh::run_refresh(&id);
                 }
             }
         }
     } else if args.no_cache {
-        run_direct();
+        direct::run_direct();
     } else {
-        run_cached();
-    }
-}
-
-/// キャッシュ方針に基づいて表示し、必要に応じてバックグラウンドリフレッシュを起動する。
-fn run_cached() {
-    let cache = crate::infra::cache::CacheStore;
-    match crate::application::prompt::resolve_cached(&InfraRepoIdPort, &cache) {
-        PromptEffect::NoOutput => {}
-        PromptEffect::Show(s) => print!("{s}"),
-        PromptEffect::ShowAndRefresh { output, repo_id } => {
-            print!("{output}");
-            spawn_refresh_if_needed(&repo_id);
-        }
-        PromptEffect::ShowLoadingAndRefresh { repo_id } => {
-            print!("? loading");
-            spawn_refresh_if_needed(&repo_id);
-        }
-    }
-}
-
-/// gh を直接呼んでキャッシュを更新する（stdout に出力しない）。
-///
-/// `repo_id` は親プロセスから `--repo-id` 引数で受け取る。
-/// git から再取得しないため、ブランチ切替・git 一時失敗時でもロック解放が保証される。
-fn run_refresh(repo_id: &str) {
-    let tokens = crate::application::prompt::fetch_output(
-        &crate::infra::gh::GhClient::new(),
-        &crate::infra::logger::Logger,
-    );
-    if let Some(tokens) = tokens {
-        let output = crate::presentation::render_to_string(&tokens);
-        crate::infra::cache::write(repo_id, &output);
-    }
-    crate::infra::refresh_lock::release(repo_id);
-}
-
-/// ロックを取得できた場合のみバックグラウンドリフレッシュを起動する（多重起動抑止）。
-///
-/// spawn 時に `--repo-id` を渡すことで子プロセスが同じ `repo_id` でロックを解放できる。
-fn spawn_refresh_if_needed(repo_id: &str) {
-    if !crate::infra::refresh_lock::try_acquire(repo_id) {
-        return;
-    }
-    let Ok(exe) = std::env::current_exe() else {
-        crate::infra::refresh_lock::release(repo_id);
-        return;
-    };
-    match std::process::Command::new(exe)
-        .args(["prompt", "--refresh", "--repo-id", repo_id])
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-    {
-        Ok(child) => {
-            // 子 PID をロックファイルへ書き込む（kill -0 による生存確認に使用）
-            crate::infra::refresh_lock::update_pid(repo_id, child.id());
-        }
-        Err(_) => {
-            crate::infra::refresh_lock::release(repo_id);
-        }
-    }
-}
-
-/// gh を直接呼んで結果を stdout に出力する（キャッシュを使わない）。
-fn run_direct() {
-    let tokens = crate::application::run(
-        &crate::infra::gh::GhClient::new(),
-        &crate::infra::logger::Logger,
-        &crate::presentation::Presenter,
-    );
-    if !tokens.is_empty() {
-        crate::presentation::display(&tokens);
+        cached::run_cached();
     }
 }

--- a/src/cli/prompt.rs
+++ b/src/cli/prompt.rs
@@ -1,7 +1,10 @@
+mod args;
+
 use std::process::Stdio;
 
 use crate::application::prompt::{PromptEffect, RepoIdPort};
-use crate::cli::args::PromptArgs;
+
+pub(super) use args::PromptArgs;
 
 struct InfraRepoIdPort;
 

--- a/src/cli/prompt.rs
+++ b/src/cli/prompt.rs
@@ -3,7 +3,7 @@ mod cached;
 mod direct;
 mod refresh;
 
-pub(super) use args::PromptArgs;
+pub(super) use args::{PROMPT_AFTER_HELP, PromptArgs};
 
 pub(crate) fn run(args: &PromptArgs) {
     if args.refresh {

--- a/src/cli/prompt.rs
+++ b/src/cli/prompt.rs
@@ -95,15 +95,20 @@ fn maybe_spawn_refresh(repo_id: &str) {
         crate::infra::cache::release_refresh_lock(repo_id);
         return;
     };
-    if std::process::Command::new(exe)
+    match std::process::Command::new(exe)
         .args(["prompt", "--refresh"])
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .spawn()
-        .is_err()
     {
-        crate::infra::cache::release_refresh_lock(repo_id);
+        Ok(child) => {
+            // 子 PID をロックファイルへ書き込む（kill -0 による生存確認に使用）
+            crate::infra::cache::update_lock_pid(repo_id, child.id());
+        }
+        Err(_) => {
+            crate::infra::cache::release_refresh_lock(repo_id);
+        }
     }
-    // 正常起動時はロックを子プロセス（run_refresh）が解放する
+    // ロックは子プロセス（run_refresh の末尾）が解放する
 }

--- a/src/cli/prompt.rs
+++ b/src/cli/prompt.rs
@@ -2,7 +2,7 @@ use crate::application::cache::DisplayAction;
 use crate::application::errors::{ErrorPresenter, ErrorToken};
 use crate::cli::args::PromptArgs;
 
-pub(crate) fn run(args: PromptArgs) {
+pub(crate) fn run(args: &PromptArgs) {
     if args.refresh {
         run_refresh();
     } else if args.no_cache {

--- a/src/cli/prompt.rs
+++ b/src/cli/prompt.rs
@@ -1,3 +1,5 @@
+use std::process::Stdio;
+
 use crate::application::prompt::{PromptEffect, RepoIdPort};
 use crate::cli::args::PromptArgs;
 
@@ -11,7 +13,18 @@ impl RepoIdPort for InfraRepoIdPort {
 
 pub(crate) fn run(args: &PromptArgs) {
     if args.refresh {
-        run_refresh();
+        match args.repo_id.as_deref() {
+            Some(id) => {
+                // 親プロセスから --repo-id で渡された場合（通常パス）: git 再取得なし
+                run_refresh(id);
+            }
+            None => {
+                // 手動実行など親なしの場合: git から取得（この場合ロック孤児は発生しない）
+                if let Some(id) = crate::infra::repo_id::get() {
+                    run_refresh(&id);
+                }
+            }
+        }
     } else if args.no_cache {
         run_direct();
     } else {
@@ -27,31 +40,57 @@ fn run_cached() {
         PromptEffect::Show(s) => print!("{s}"),
         PromptEffect::ShowAndRefresh { output, repo_id } => {
             print!("{output}");
-            crate::infra::refresh_lock::maybe_spawn_refresh(&repo_id);
+            spawn_refresh_if_needed(&repo_id);
         }
         PromptEffect::ShowLoadingAndRefresh { repo_id } => {
             print!("? loading");
-            crate::infra::refresh_lock::maybe_spawn_refresh(&repo_id);
+            spawn_refresh_if_needed(&repo_id);
         }
     }
 }
 
 /// gh を直接呼んでキャッシュを更新する（stdout に出力しない）。
 ///
-/// エラー発生時は既存キャッシュを上書きしない。
-fn run_refresh() {
-    let Some(repo_id) = crate::infra::repo_id::get() else {
-        return;
-    };
+/// `repo_id` は親プロセスから `--repo-id` 引数で受け取る。
+/// git から再取得しないため、ブランチ切替・git 一時失敗時でもロック解放が保証される。
+fn run_refresh(repo_id: &str) {
     let tokens = crate::application::prompt::fetch_output(
         &crate::infra::gh::GhClient::new(),
         &crate::infra::logger::Logger,
     );
     if let Some(tokens) = tokens {
         let output = crate::presentation::render_to_string(&tokens);
-        crate::infra::cache::write(&repo_id, &output);
+        crate::infra::cache::write(repo_id, &output);
     }
-    crate::infra::refresh_lock::release(&repo_id);
+    crate::infra::refresh_lock::release(repo_id);
+}
+
+/// ロックを取得できた場合のみバックグラウンドリフレッシュを起動する（多重起動抑止）。
+///
+/// spawn 時に `--repo-id` を渡すことで子プロセスが同じ `repo_id` でロックを解放できる。
+fn spawn_refresh_if_needed(repo_id: &str) {
+    if !crate::infra::refresh_lock::try_acquire(repo_id) {
+        return;
+    }
+    let Ok(exe) = std::env::current_exe() else {
+        crate::infra::refresh_lock::release(repo_id);
+        return;
+    };
+    match std::process::Command::new(exe)
+        .args(["prompt", "--refresh", "--repo-id", repo_id])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        Ok(child) => {
+            // 子 PID をロックファイルへ書き込む（kill -0 による生存確認に使用）
+            crate::infra::refresh_lock::update_pid(repo_id, child.id());
+        }
+        Err(_) => {
+            crate::infra::refresh_lock::release(repo_id);
+        }
+    }
 }
 
 /// gh を直接呼んで結果を stdout に出力する（キャッシュを使わない）。

--- a/src/cli/prompt/args.rs
+++ b/src/cli/prompt/args.rs
@@ -1,0 +1,14 @@
+use clap::Args;
+
+#[derive(Args)]
+pub(crate) struct PromptArgs {
+    /// Bypass cache and fetch fresh data directly
+    #[arg(long)]
+    pub(crate) no_cache: bool,
+    /// Fetch fresh data and update cache without displaying output
+    #[arg(long, hide = true, conflicts_with = "no_cache")]
+    pub(crate) refresh: bool,
+    /// Repository ID for lock release (passed by parent process via --refresh)
+    #[arg(long, hide = true, requires = "refresh")]
+    pub(crate) repo_id: Option<String>,
+}

--- a/src/cli/prompt/args.rs
+++ b/src/cli/prompt/args.rs
@@ -1,6 +1,6 @@
 use clap::Args;
 
-pub(crate) const PROMPT_AFTER_HELP: &str = "Output tokens:
+pub(crate) const AFTER_HELP: &str = "Output tokens:
   ✓ merge-ready    Ready to merge
   ⚠ review         Review requested
   ⚠ ci-action      CI checks in progress

--- a/src/cli/prompt/args.rs
+++ b/src/cli/prompt/args.rs
@@ -1,5 +1,14 @@
 use clap::Args;
 
+pub(crate) const PROMPT_AFTER_HELP: &str = "Output tokens:
+  ✓ merge-ready    Ready to merge
+  ⚠ review         Review requested
+  ⚠ ci-action      CI checks in progress
+  ✗ ci-fail        CI checks failed
+  ✗ conflict       Branch has merge conflicts
+  ✗ update-branch  Branch is behind base branch
+  ? sync-unknown   Branch sync status unknown";
+
 #[derive(Args)]
 pub(crate) struct PromptArgs {
     /// Bypass cache and fetch fresh data directly

--- a/src/cli/prompt/cached.rs
+++ b/src/cli/prompt/cached.rs
@@ -1,0 +1,56 @@
+use std::process::Stdio;
+
+use crate::application::prompt::{PromptEffect, RepoIdPort};
+
+struct InfraRepoIdPort;
+
+impl RepoIdPort for InfraRepoIdPort {
+    fn get(&self) -> Option<String> {
+        crate::infra::repo_id::get()
+    }
+}
+
+/// キャッシュ方針に基づいて表示し、必要に応じてバックグラウンドリフレッシュを起動する。
+pub(super) fn run_cached() {
+    let cache = crate::infra::cache::CacheStore;
+    match crate::application::prompt::resolve_cached(&InfraRepoIdPort, &cache) {
+        PromptEffect::NoOutput => {}
+        PromptEffect::Show(s) => print!("{s}"),
+        PromptEffect::ShowAndRefresh { output, repo_id } => {
+            print!("{output}");
+            spawn_refresh_if_needed(&repo_id);
+        }
+        PromptEffect::ShowLoadingAndRefresh { repo_id } => {
+            print!("? loading");
+            spawn_refresh_if_needed(&repo_id);
+        }
+    }
+}
+
+/// ロックを取得できた場合のみバックグラウンドリフレッシュを起動する（多重起動抑止）。
+///
+/// spawn 時に `--repo-id` を渡すことで子プロセスが同じ `repo_id` でロックを解放できる。
+fn spawn_refresh_if_needed(repo_id: &str) {
+    if !crate::infra::refresh_lock::try_acquire(repo_id) {
+        return;
+    }
+    let Ok(exe) = std::env::current_exe() else {
+        crate::infra::refresh_lock::release(repo_id);
+        return;
+    };
+    match std::process::Command::new(exe)
+        .args(["prompt", "--refresh", "--repo-id", repo_id])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        Ok(child) => {
+            // 子 PID をロックファイルへ書き込む（kill -0 による生存確認に使用）
+            crate::infra::refresh_lock::update_pid(repo_id, child.id());
+        }
+        Err(_) => {
+            crate::infra::refresh_lock::release(repo_id);
+        }
+    }
+}

--- a/src/cli/prompt/direct.rs
+++ b/src/cli/prompt/direct.rs
@@ -1,0 +1,11 @@
+/// gh を直接呼んで結果を stdout に出力する（キャッシュを使わない）。
+pub(super) fn run_direct() {
+    let tokens = crate::application::run(
+        &crate::infra::gh::GhClient::new(),
+        &crate::infra::logger::Logger,
+        &crate::presentation::Presenter,
+    );
+    if !tokens.is_empty() {
+        crate::presentation::display(&tokens);
+    }
+}

--- a/src/cli/prompt/refresh.rs
+++ b/src/cli/prompt/refresh.rs
@@ -1,0 +1,15 @@
+/// gh を直接呼んでキャッシュを更新する（stdout に出力しない）。
+///
+/// `repo_id` は親プロセスから `--repo-id` 引数で受け取る。
+/// git から再取得しないため、ブランチ切替・git 一時失敗時でもロック解放が保証される。
+pub(super) fn run_refresh(repo_id: &str) {
+    let tokens = crate::application::prompt::fetch_output(
+        &crate::infra::gh::GhClient::new(),
+        &crate::infra::logger::Logger,
+    );
+    if let Some(tokens) = tokens {
+        let output = crate::presentation::render_to_string(&tokens);
+        crate::infra::cache::write(repo_id, &output);
+    }
+    crate::infra::refresh_lock::release(repo_id);
+}

--- a/src/infra.rs
+++ b/src/infra.rs
@@ -1,4 +1,5 @@
 pub mod cache;
 pub mod gh;
 pub mod logger;
+pub mod refresh_lock;
 pub mod repo_id;

--- a/src/infra.rs
+++ b/src/infra.rs
@@ -1,2 +1,4 @@
+pub mod cache;
 pub mod gh;
 pub mod logger;
+pub mod repo_id;

--- a/src/infra/cache.rs
+++ b/src/infra/cache.rs
@@ -3,6 +3,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
+use crate::application::cache::{CachePort, CacheState};
+
 const DEFAULT_STALE_TTL_SECS: u64 = 5;
 const CACHE_DIR_NAME: &str = "merge-ready";
 
@@ -12,39 +14,49 @@ struct StateJson {
     output: String,
 }
 
-/// キャッシュの状態
-pub enum CacheStatus {
-    /// `stale_ttl` 以内: 即出力、バックグラウンドリフレッシュなし
+/// キャッシュストア（ファイルシステムバックエンド）
+pub struct CacheStore;
+
+impl CachePort for CacheStore {
+    fn check(&self, repo_id: &str) -> CacheState {
+        match check_raw(repo_id) {
+            RawCacheStatus::Fresh(s) => CacheState::Fresh(s),
+            RawCacheStatus::Stale(s) => CacheState::Stale(s),
+            RawCacheStatus::Miss => CacheState::Miss,
+        }
+    }
+}
+
+/// キャッシュの内部状態（infra 層内部でのみ使用）
+enum RawCacheStatus {
     Fresh(String),
-    /// `stale_ttl` 超過: 即出力 + バックグラウンドリフレッシュ
     Stale(String),
-    /// キャッシュなし: `? loading` を表示してバックグラウンドリフレッシュ
     Miss,
 }
 
 /// `repo_id` に対応するキャッシュの状態を返す。
 ///
-/// キャッシュファイルが存在しない、または読み込めない場合は [`CacheStatus::Miss`] を返す。
-pub fn check(repo_id: &str) -> CacheStatus {
+/// キャッシュファイルが存在しない、または読み込めない場合は [`RawCacheStatus::Miss`] を返す。
+fn check_raw(repo_id: &str) -> RawCacheStatus {
     let Some(state_path) = cache_path(repo_id) else {
-        return CacheStatus::Miss;
+        return RawCacheStatus::Miss;
     };
 
     let Ok(content) = fs::read_to_string(&state_path) else {
-        return CacheStatus::Miss;
+        return RawCacheStatus::Miss;
     };
 
     let Ok(state) = serde_json::from_str::<StateJson>(&content) else {
-        return CacheStatus::Miss;
+        return RawCacheStatus::Miss;
     };
 
     let now = now_secs();
     let age = now.saturating_sub(state.fetched_at_secs);
 
     if age <= stale_ttl_secs() {
-        CacheStatus::Fresh(state.output)
+        RawCacheStatus::Fresh(state.output)
     } else {
-        CacheStatus::Stale(state.output)
+        RawCacheStatus::Stale(state.output)
     }
 }
 
@@ -52,6 +64,7 @@ pub fn check(repo_id: &str) -> CacheStatus {
 ///
 /// ディレクトリが存在しない場合は自動的に作成する。
 /// 書き込み失敗は静かに握り潰す。
+#[allow(dead_code)]
 pub fn write(repo_id: &str, output: &str) {
     let Some(state_path) = cache_path(repo_id) else {
         return;

--- a/src/infra/cache.rs
+++ b/src/infra/cache.rs
@@ -1,0 +1,98 @@
+use std::fs;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+const DEFAULT_STALE_TTL_SECS: u64 = 5;
+const CACHE_DIR_NAME: &str = "merge-ready";
+
+#[derive(Serialize, Deserialize)]
+struct StateJson {
+    fetched_at_secs: u64,
+    output: String,
+}
+
+/// キャッシュの状態
+pub enum CacheStatus {
+    /// `stale_ttl` 以内: 即出力、バックグラウンドリフレッシュなし
+    Fresh(String),
+    /// `stale_ttl` 超過: 即出力 + バックグラウンドリフレッシュ
+    Stale(String),
+    /// キャッシュなし: `? loading` を表示してバックグラウンドリフレッシュ
+    Miss,
+}
+
+/// `repo_id` に対応するキャッシュの状態を返す。
+///
+/// キャッシュファイルが存在しない、または読み込めない場合は [`CacheStatus::Miss`] を返す。
+pub fn check(repo_id: &str) -> CacheStatus {
+    let Some(state_path) = cache_path(repo_id) else {
+        return CacheStatus::Miss;
+    };
+
+    let Ok(content) = fs::read_to_string(&state_path) else {
+        return CacheStatus::Miss;
+    };
+
+    let Ok(state) = serde_json::from_str::<StateJson>(&content) else {
+        return CacheStatus::Miss;
+    };
+
+    let now = now_secs();
+    let age = now.saturating_sub(state.fetched_at_secs);
+
+    if age <= stale_ttl_secs() {
+        CacheStatus::Fresh(state.output)
+    } else {
+        CacheStatus::Stale(state.output)
+    }
+}
+
+/// キャッシュに出力文字列を書き込む。
+///
+/// ディレクトリが存在しない場合は自動的に作成する。
+/// 書き込み失敗は静かに握り潰す。
+pub fn write(repo_id: &str, output: &str) {
+    let Some(state_path) = cache_path(repo_id) else {
+        return;
+    };
+
+    if let Some(parent) = state_path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+
+    let state = StateJson {
+        fetched_at_secs: now_secs(),
+        output: output.to_owned(),
+    };
+
+    let Ok(content) = serde_json::to_string(&state) else {
+        return;
+    };
+
+    let _ = fs::write(state_path, content);
+}
+
+fn cache_path(repo_id: &str) -> Option<std::path::PathBuf> {
+    let home = std::env::var_os("HOME")?;
+    Some(
+        std::path::Path::new(&home)
+            .join(".cache")
+            .join(CACHE_DIR_NAME)
+            .join(repo_id)
+            .join("state.json"),
+    )
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs())
+}
+
+fn stale_ttl_secs() -> u64 {
+    std::env::var("MERGE_READY_STALE_TTL")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_STALE_TTL_SECS)
+}

--- a/src/infra/cache.rs
+++ b/src/infra/cache.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::application::cache::{CachePort, CacheState};
 
 const DEFAULT_STALE_TTL_SECS: u64 = 5;
+const LOCK_TTL_SECS: u64 = 30;
 const CACHE_DIR_NAME: &str = "merge-ready";
 
 #[derive(Serialize, Deserialize)]
@@ -83,6 +84,54 @@ pub fn write(repo_id: &str, output: &str) {
     };
 
     let _ = fs::write(state_path, content);
+}
+
+/// リフレッシュロックを取得する。成功時は `true`、既に起動中なら `false` を返す。
+///
+/// ロックファイルが `LOCK_TTL_SECS` より古い場合は stale とみなし再取得する。
+pub fn try_acquire_refresh_lock(repo_id: &str) -> bool {
+    let Some(path) = lock_path(repo_id) else {
+        return false;
+    };
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+
+    // stale なロックは除去して再取得を試みる
+    if path.exists() {
+        let is_fresh = fs::metadata(&path)
+            .and_then(|m| m.modified())
+            .ok()
+            .and_then(|t| SystemTime::now().duration_since(t).ok())
+            .is_some_and(|age| age.as_secs() <= LOCK_TTL_SECS);
+        if is_fresh {
+            return false;
+        }
+        let _ = fs::remove_file(&path);
+    }
+
+    fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+        .is_ok()
+}
+
+/// リフレッシュロックを解放する。
+pub fn release_refresh_lock(repo_id: &str) {
+    if let Some(path) = lock_path(repo_id) {
+        let _ = fs::remove_file(path);
+    }
+}
+
+fn lock_path(repo_id: &str) -> Option<std::path::PathBuf> {
+    let home = std::env::var_os("HOME")?;
+    Some(
+        std::path::Path::new(&home)
+            .join(".cache")
+            .join(CACHE_DIR_NAME)
+            .join(format!("{repo_id}.lock")),
+    )
 }
 
 fn cache_path(repo_id: &str) -> Option<std::path::PathBuf> {

--- a/src/infra/cache.rs
+++ b/src/infra/cache.rs
@@ -82,7 +82,12 @@ pub fn write(repo_id: &str, output: &str) {
         return;
     };
 
-    let _ = fs::write(state_path, content);
+    // temp ファイルへ書き込んでから rename でアトミック置換（部分書き込み防止）
+    let temp_path = state_path.with_extension("tmp");
+    if fs::write(&temp_path, &content).is_err() {
+        return;
+    }
+    let _ = fs::rename(&temp_path, &state_path);
 }
 
 fn cache_path(repo_id: &str) -> Option<std::path::PathBuf> {

--- a/src/infra/cache.rs
+++ b/src/infra/cache.rs
@@ -6,7 +6,8 @@ use serde::{Deserialize, Serialize};
 use crate::application::cache::{CachePort, CacheState};
 
 const DEFAULT_STALE_TTL_SECS: u64 = 5;
-const LOCK_TTL_SECS: u64 = 30;
+/// PID 未書き込み状態のロックファイルに対する猶予期間（親プロセスがクラッシュした場合の安全弁）
+const EMPTY_LOCK_TTL_SECS: u64 = 5;
 const CACHE_DIR_NAME: &str = "merge-ready";
 
 #[derive(Serialize, Deserialize)]
@@ -88,7 +89,9 @@ pub fn write(repo_id: &str, output: &str) {
 
 /// リフレッシュロックを取得する。成功時は `true`、既に起動中なら `false` を返す。
 ///
-/// ロックファイルが `LOCK_TTL_SECS` より古い場合は stale とみなし再取得する。
+/// ロックファイルが存在する場合は PID で生存確認（`kill -0`）を行い、
+/// プロセスが死んでいれば stale とみなして除去し再取得する。
+/// これにより gh が 30 秒超かかる場合でも重複起動を防げる。
 pub fn try_acquire_refresh_lock(repo_id: &str) -> bool {
     let Some(path) = lock_path(repo_id) else {
         return false;
@@ -97,18 +100,10 @@ pub fn try_acquire_refresh_lock(repo_id: &str) -> bool {
         let _ = fs::create_dir_all(parent);
     }
 
-    // stale なロックは除去して再取得を試みる
-    if path.exists() {
-        let is_fresh = fs::metadata(&path)
-            .and_then(|m| m.modified())
-            .ok()
-            .and_then(|t| SystemTime::now().duration_since(t).ok())
-            .is_some_and(|age| age.as_secs() <= LOCK_TTL_SECS);
-        if is_fresh {
-            return false;
-        }
-        let _ = fs::remove_file(&path);
+    if path.exists() && is_lock_alive(&path) {
+        return false;
     }
+    let _ = fs::remove_file(&path);
 
     fs::OpenOptions::new()
         .write(true)
@@ -117,11 +112,44 @@ pub fn try_acquire_refresh_lock(repo_id: &str) -> bool {
         .is_ok()
 }
 
+/// spawn 後に子プロセスの PID をロックファイルへ書き込む。
+pub fn update_lock_pid(repo_id: &str, pid: u32) {
+    if let Some(path) = lock_path(repo_id) {
+        let _ = fs::write(path, pid.to_string());
+    }
+}
+
 /// リフレッシュロックを解放する。
 pub fn release_refresh_lock(repo_id: &str) {
     if let Some(path) = lock_path(repo_id) {
         let _ = fs::remove_file(path);
     }
+}
+
+/// ロックファイルが示すプロセスが生存しているかを確認する。
+///
+/// - PID あり → `kill -0 <pid>` でプロセス生存確認
+/// - PID なし（直前に取得済みで未書き込み）→ mtime が `EMPTY_LOCK_TTL_SECS` 以内なら生存扱い
+fn is_lock_alive(path: &std::path::Path) -> bool {
+    let content = fs::read_to_string(path).unwrap_or_default();
+    let trimmed = content.trim();
+
+    if trimmed.is_empty() {
+        // 親が lock を取得した直後で PID 未書き込み状態。短い猶予期間で生存扱いとする
+        return fs::metadata(path)
+            .and_then(|m| m.modified())
+            .ok()
+            .and_then(|t| SystemTime::now().duration_since(t).ok())
+            .is_some_and(|age| age.as_secs() < EMPTY_LOCK_TTL_SECS);
+    }
+
+    trimmed.parse::<u32>().is_ok_and(|pid| {
+        std::process::Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .stderr(std::process::Stdio::null())
+            .status()
+            .is_ok_and(|s| s.success())
+    })
 }
 
 fn lock_path(repo_id: &str) -> Option<std::path::PathBuf> {

--- a/src/infra/cache.rs
+++ b/src/infra/cache.rs
@@ -64,7 +64,6 @@ fn check_raw(repo_id: &str) -> RawCacheStatus {
 ///
 /// ディレクトリが存在しない場合は自動的に作成する。
 /// 書き込み失敗は静かに握り潰す。
-#[allow(dead_code)]
 pub fn write(repo_id: &str, output: &str) {
     let Some(state_path) = cache_path(repo_id) else {
         return;

--- a/src/infra/cache.rs
+++ b/src/infra/cache.rs
@@ -8,6 +8,8 @@ use crate::application::cache::{CachePort, CacheState};
 const DEFAULT_STALE_TTL_SECS: u64 = 5;
 /// PID 未書き込み状態のロックファイルに対する猶予期間（親プロセスがクラッシュした場合の安全弁）
 const EMPTY_LOCK_TTL_SECS: u64 = 5;
+/// リフレッシュ子プロセスがハングした場合のロック強制解除までの最大年齢（gh タイムアウト安全弁）
+const MAX_LOCK_AGE_SECS: u64 = 60;
 const CACHE_DIR_NAME: &str = "merge-ready";
 
 #[derive(Serialize, Deserialize)]
@@ -128,19 +130,23 @@ pub fn release_refresh_lock(repo_id: &str) {
 
 /// ロックファイルが示すプロセスが生存しているかを確認する。
 ///
+/// - 最大年齢（`MAX_LOCK_AGE_SECS`）を超えている → stale（gh ハング時の安全弁）
 /// - PID あり → `kill -0 <pid>` でプロセス生存確認
 /// - PID なし（直前に取得済みで未書き込み）→ mtime が `EMPTY_LOCK_TTL_SECS` 以内なら生存扱い
 fn is_lock_alive(path: &std::path::Path) -> bool {
+    let age = lock_age_secs(path);
+
+    // 最大年齢チェック: PID が生きていても一定時間後は stale とみなす
+    if age.is_some_and(|a| a >= MAX_LOCK_AGE_SECS) {
+        return false;
+    }
+
     let content = fs::read_to_string(path).unwrap_or_default();
     let trimmed = content.trim();
 
     if trimmed.is_empty() {
         // 親が lock を取得した直後で PID 未書き込み状態。短い猶予期間で生存扱いとする
-        return fs::metadata(path)
-            .and_then(|m| m.modified())
-            .ok()
-            .and_then(|t| SystemTime::now().duration_since(t).ok())
-            .is_some_and(|age| age.as_secs() < EMPTY_LOCK_TTL_SECS);
+        return age.is_some_and(|a| a < EMPTY_LOCK_TTL_SECS);
     }
 
     trimmed.parse::<u32>().is_ok_and(|pid| {
@@ -150,6 +156,15 @@ fn is_lock_alive(path: &std::path::Path) -> bool {
             .status()
             .is_ok_and(|s| s.success())
     })
+}
+
+/// ロックファイルの作成からの経過秒数を返す。取得失敗時は `None`。
+fn lock_age_secs(path: &std::path::Path) -> Option<u64> {
+    fs::metadata(path)
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|t| SystemTime::now().duration_since(t).ok())
+        .map(|d| d.as_secs())
 }
 
 fn lock_path(repo_id: &str) -> Option<std::path::PathBuf> {

--- a/src/infra/cache.rs
+++ b/src/infra/cache.rs
@@ -1,5 +1,4 @@
 use std::fs;
-use std::io::Write as _;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
@@ -84,93 +83,6 @@ pub fn write(repo_id: &str, output: &str) {
     };
 
     let _ = fs::write(state_path, content);
-}
-
-/// リフレッシュロックを取得する。成功時は `true`、既に起動中なら `false` を返す。
-///
-/// ロックファイルが存在する場合は PID で生存確認（`kill -0`）を行い、
-/// プロセスが死んでいれば stale とみなして除去し再取得する。
-///
-/// ロック取得直後に自プロセスの PID を書き込むため、ロックファイルが空になる瞬間は存在しない。
-/// 空ファイル＝クラッシュ等で書き込まれなかった異常状態として「死んでいる」と判定する。
-pub fn try_acquire_refresh_lock(repo_id: &str) -> bool {
-    let Some(path) = lock_path(repo_id) else {
-        return false;
-    };
-    if let Some(parent) = path.parent() {
-        let _ = fs::create_dir_all(parent);
-    }
-
-    if let Ok(mut f) = fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(&path)
-    {
-        // 取得直後に自 PID を書き込む（空ファイル期間をなくす）
-        let _ = f.write_all(std::process::id().to_string().as_bytes());
-        return true;
-    }
-
-    // ロックファイルが既存: 生存確認して死んでいれば再取得
-    if is_lock_alive(&path) {
-        return false;
-    }
-    let _ = fs::remove_file(&path);
-    if let Ok(mut f) = fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(&path)
-    {
-        let _ = f.write_all(std::process::id().to_string().as_bytes());
-        true
-    } else {
-        false
-    }
-}
-
-/// spawn 後に子プロセスの PID をロックファイルへ上書きする。
-pub fn update_lock_pid(repo_id: &str, pid: u32) {
-    if let Some(path) = lock_path(repo_id) {
-        let _ = fs::write(path, pid.to_string());
-    }
-}
-
-/// リフレッシュロックを解放する。
-pub fn release_refresh_lock(repo_id: &str) {
-    if let Some(path) = lock_path(repo_id) {
-        let _ = fs::remove_file(path);
-    }
-}
-
-/// ロックファイルが示すプロセスが生存しているかを確認する。
-///
-/// - PID あり → `kill -0 <pid>` でプロセス生存確認
-/// - PID なし（空ファイル）→ 異常状態として dead 扱い
-fn is_lock_alive(path: &std::path::Path) -> bool {
-    let content = fs::read_to_string(path).unwrap_or_default();
-    let trimmed = content.trim();
-
-    if trimmed.is_empty() {
-        return false;
-    }
-
-    trimmed.parse::<u32>().is_ok_and(|pid| {
-        std::process::Command::new("kill")
-            .args(["-0", &pid.to_string()])
-            .stderr(std::process::Stdio::null())
-            .status()
-            .is_ok_and(|s| s.success())
-    })
-}
-
-fn lock_path(repo_id: &str) -> Option<std::path::PathBuf> {
-    let home = std::env::var_os("HOME")?;
-    Some(
-        std::path::Path::new(&home)
-            .join(".cache")
-            .join(CACHE_DIR_NAME)
-            .join(format!("{repo_id}.lock")),
-    )
 }
 
 fn cache_path(repo_id: &str) -> Option<std::path::PathBuf> {

--- a/src/infra/cache.rs
+++ b/src/infra/cache.rs
@@ -82,12 +82,14 @@ pub fn write(repo_id: &str, output: &str) {
         return;
     };
 
-    // temp ファイルへ書き込んでから rename でアトミック置換（部分書き込み防止）
-    let temp_path = state_path.with_extension("tmp");
+    // PID ベースの tmp 名でプロセス間衝突を防ぎ、rename でアトミック置換（部分書き込み防止）
+    let temp_path = state_path.with_extension(format!("tmp.{}", std::process::id()));
     if fs::write(&temp_path, &content).is_err() {
         return;
     }
-    let _ = fs::rename(&temp_path, &state_path);
+    if fs::rename(&temp_path, &state_path).is_err() {
+        let _ = fs::remove_file(&temp_path); // rename 失敗時に tmp 残留防止
+    }
 }
 
 fn cache_path(repo_id: &str) -> Option<std::path::PathBuf> {

--- a/src/infra/cache.rs
+++ b/src/infra/cache.rs
@@ -91,8 +91,7 @@ fn cache_path(repo_id: &str) -> Option<std::path::PathBuf> {
         std::path::Path::new(&home)
             .join(".cache")
             .join(CACHE_DIR_NAME)
-            .join(repo_id)
-            .join("state.json"),
+            .join(format!("{repo_id}.json")),
     )
 }
 

--- a/src/infra/cache.rs
+++ b/src/infra/cache.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::io::Write as _;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
@@ -6,10 +7,6 @@ use serde::{Deserialize, Serialize};
 use crate::application::cache::{CachePort, CacheState};
 
 const DEFAULT_STALE_TTL_SECS: u64 = 5;
-/// PID 未書き込み状態のロックファイルに対する猶予期間（親プロセスがクラッシュした場合の安全弁）
-const EMPTY_LOCK_TTL_SECS: u64 = 5;
-/// リフレッシュ子プロセスがハングした場合のロック強制解除までの最大年齢（gh タイムアウト安全弁）
-const MAX_LOCK_AGE_SECS: u64 = 60;
 const CACHE_DIR_NAME: &str = "merge-ready";
 
 #[derive(Serialize, Deserialize)]
@@ -93,7 +90,9 @@ pub fn write(repo_id: &str, output: &str) {
 ///
 /// ロックファイルが存在する場合は PID で生存確認（`kill -0`）を行い、
 /// プロセスが死んでいれば stale とみなして除去し再取得する。
-/// これにより gh が 30 秒超かかる場合でも重複起動を防げる。
+///
+/// ロック取得直後に自プロセスの PID を書き込むため、ロックファイルが空になる瞬間は存在しない。
+/// 空ファイル＝クラッシュ等で書き込まれなかった異常状態として「死んでいる」と判定する。
 pub fn try_acquire_refresh_lock(repo_id: &str) -> bool {
     let Some(path) = lock_path(repo_id) else {
         return false;
@@ -102,19 +101,34 @@ pub fn try_acquire_refresh_lock(repo_id: &str) -> bool {
         let _ = fs::create_dir_all(parent);
     }
 
-    if path.exists() && is_lock_alive(&path) {
-        return false;
-    }
-    let _ = fs::remove_file(&path);
-
-    fs::OpenOptions::new()
+    if let Ok(mut f) = fs::OpenOptions::new()
         .write(true)
         .create_new(true)
         .open(&path)
-        .is_ok()
+    {
+        // 取得直後に自 PID を書き込む（空ファイル期間をなくす）
+        let _ = f.write_all(std::process::id().to_string().as_bytes());
+        return true;
+    }
+
+    // ロックファイルが既存: 生存確認して死んでいれば再取得
+    if is_lock_alive(&path) {
+        return false;
+    }
+    let _ = fs::remove_file(&path);
+    if let Ok(mut f) = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+    {
+        let _ = f.write_all(std::process::id().to_string().as_bytes());
+        true
+    } else {
+        false
+    }
 }
 
-/// spawn 後に子プロセスの PID をロックファイルへ書き込む。
+/// spawn 後に子プロセスの PID をロックファイルへ上書きする。
 pub fn update_lock_pid(repo_id: &str, pid: u32) {
     if let Some(path) = lock_path(repo_id) {
         let _ = fs::write(path, pid.to_string());
@@ -130,23 +144,14 @@ pub fn release_refresh_lock(repo_id: &str) {
 
 /// ロックファイルが示すプロセスが生存しているかを確認する。
 ///
-/// - 最大年齢（`MAX_LOCK_AGE_SECS`）を超えている → stale（gh ハング時の安全弁）
 /// - PID あり → `kill -0 <pid>` でプロセス生存確認
-/// - PID なし（直前に取得済みで未書き込み）→ mtime が `EMPTY_LOCK_TTL_SECS` 以内なら生存扱い
+/// - PID なし（空ファイル）→ 異常状態として dead 扱い
 fn is_lock_alive(path: &std::path::Path) -> bool {
-    let age = lock_age_secs(path);
-
-    // 最大年齢チェック: PID が生きていても一定時間後は stale とみなす
-    if age.is_some_and(|a| a >= MAX_LOCK_AGE_SECS) {
-        return false;
-    }
-
     let content = fs::read_to_string(path).unwrap_or_default();
     let trimmed = content.trim();
 
     if trimmed.is_empty() {
-        // 親が lock を取得した直後で PID 未書き込み状態。短い猶予期間で生存扱いとする
-        return age.is_some_and(|a| a < EMPTY_LOCK_TTL_SECS);
+        return false;
     }
 
     trimmed.parse::<u32>().is_ok_and(|pid| {
@@ -156,15 +161,6 @@ fn is_lock_alive(path: &std::path::Path) -> bool {
             .status()
             .is_ok_and(|s| s.success())
     })
-}
-
-/// ロックファイルの作成からの経過秒数を返す。取得失敗時は `None`。
-fn lock_age_secs(path: &std::path::Path) -> Option<u64> {
-    fs::metadata(path)
-        .and_then(|m| m.modified())
-        .ok()
-        .and_then(|t| SystemTime::now().duration_since(t).ok())
-        .map(|d| d.as_secs())
 }
 
 fn lock_path(repo_id: &str) -> Option<std::path::PathBuf> {

--- a/src/infra/gh.rs
+++ b/src/infra/gh.rs
@@ -1,6 +1,6 @@
-use std::cell::OnceCell;
 use std::io::ErrorKind;
 use std::process::Command;
+use std::sync::OnceLock;
 
 use serde::Deserialize;
 
@@ -51,13 +51,15 @@ struct GhCompare {
 
 pub struct GhClient {
     /// `gh pr view` の結果をキャッシュする（複数トレイト実装によるコマンド多重実行を防ぐ）
-    pr_view_cache: OnceCell<GhPrView>,
+    ///
+    /// `OnceLock` を使用してスレッド間でのキャッシュ共有を安全にする（並列フェッチ対応）。
+    pr_view_cache: OnceLock<GhPrView>,
 }
 
 impl GhClient {
     pub fn new() -> Self {
         Self {
-            pr_view_cache: OnceCell::new(),
+            pr_view_cache: OnceLock::new(),
         }
     }
 

--- a/src/infra/refresh_lock.rs
+++ b/src/infra/refresh_lock.rs
@@ -71,33 +71,6 @@ pub fn release(repo_id: &str) {
     }
 }
 
-/// ロックを取得できた場合のみバックグラウンドリフレッシュを起動する（多重起動抑止）。
-pub fn maybe_spawn_refresh(repo_id: &str) {
-    if !try_acquire(repo_id) {
-        return;
-    }
-    let Ok(exe) = std::env::current_exe() else {
-        release(repo_id);
-        return;
-    };
-    match std::process::Command::new(exe)
-        .args(["prompt", "--refresh"])
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn()
-    {
-        Ok(child) => {
-            // 子 PID をロックファイルへ書き込む（kill -0 による生存確認に使用）
-            update_pid(repo_id, child.id());
-        }
-        Err(_) => {
-            release(repo_id);
-        }
-    }
-    // ロックは子プロセス（run_refresh の末尾）が解放する
-}
-
 /// ロックファイルをアトミックに作成し、ハンドルを保持したまま自 PID と取得時刻を JSON で書き込む。
 ///
 /// `create_new(true)`（`O_CREAT | O_EXCL`）でアトミックにファイルを作成後、

--- a/src/infra/refresh_lock.rs
+++ b/src/infra/refresh_lock.rs
@@ -225,7 +225,11 @@ mod tests {
         let content = std::fs::read_to_string(&path).unwrap();
         let lock: LockFile =
             serde_json::from_str(&content).expect("lock file should contain valid JSON");
-        assert_eq!(lock.pid, std::process::id(), "pid should match current process");
+        assert_eq!(
+            lock.pid,
+            std::process::id(),
+            "pid should match current process"
+        );
         assert!(lock.locked_at > 0, "locked_at should be non-zero");
     }
 

--- a/src/infra/refresh_lock.rs
+++ b/src/infra/refresh_lock.rs
@@ -265,4 +265,34 @@ mod tests {
         std::fs::write(&path, b"").unwrap();
         assert!(!is_alive(&path));
     }
+
+    /// `is_alive` の age 境界: `locked_at = now - 119` はまだ有効（< MAX_LOCK_AGE_SECS）。
+    ///
+    /// PID には現プロセスを使うことで `kill -0` が成功する状況を再現する。
+    #[test]
+    fn is_alive_returns_true_when_age_is_below_max() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.lock");
+        let lock = LockFile {
+            pid: std::process::id(),
+            locked_at: now_secs() - (MAX_LOCK_AGE_SECS - 1),
+        };
+        std::fs::write(&path, serde_json::to_string(&lock).unwrap()).unwrap();
+        assert!(is_alive(&path), "age 119s should still be alive");
+    }
+
+    /// `is_alive` の age 境界: `locked_at = now - 120` は失効（>= MAX_LOCK_AGE_SECS）。
+    ///
+    /// PID が生きていても age だけで dead 判定されることを確認する。
+    #[test]
+    fn is_alive_returns_false_when_age_equals_max() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.lock");
+        let lock = LockFile {
+            pid: std::process::id(),
+            locked_at: now_secs() - MAX_LOCK_AGE_SECS,
+        };
+        std::fs::write(&path, serde_json::to_string(&lock).unwrap()).unwrap();
+        assert!(!is_alive(&path), "age 120s should be expired");
+    }
 }

--- a/src/infra/refresh_lock.rs
+++ b/src/infra/refresh_lock.rs
@@ -1,14 +1,32 @@
 use std::fs;
-use std::io::Write as _;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
 
 const CACHE_DIR_NAME: &str = "merge-ready";
+
+/// PID 再利用安全弁としてのロック最大有効期間。
+///
+/// 子プロセスがクラッシュしてロックを解放できなかった場合、OS が同 PID を別プロセスに
+/// 再利用すると `kill -0` が誤って true を返し続ける。`locked_at` との組み合わせで
+/// 一定時間後に強制失効させることで影響を抑える。
+///
+/// gh コマンドのハング問題（#17）とは別問題。#17 で gh タイムアウトが確定したら再調整する。
+const MAX_LOCK_AGE_SECS: u64 = 120;
+
+#[derive(Serialize, Deserialize)]
+struct LockFile {
+    pid: u32,
+    locked_at: u64,
+}
 
 /// リフレッシュロックを取得する。成功時は `true`、既に起動中なら `false` を返す。
 ///
 /// `create_new(true)`（`O_CREAT | O_EXCL`）でアトミックにファイルを作成し、
-/// 直後に自プロセスの PID を書き込む。これにより空ファイルが存在する瞬間をなくす。
+/// 直後に自プロセスの PID と取得時刻を JSON で書き込む。
+/// これにより空ファイルが存在する瞬間をなくす。
 ///
-/// ロックファイルが既存の場合は PID で生存確認（`kill -0`）を行い、
+/// ロックファイルが既存の場合は PID と age で生存確認を行い、
 /// プロセスが死んでいれば除去して再取得する。
 pub fn try_acquire(repo_id: &str) -> bool {
     let Some(path) = lock_path(repo_id) else {
@@ -31,9 +49,17 @@ pub fn try_acquire(repo_id: &str) -> bool {
 }
 
 /// spawn 後に子プロセスの PID をロックファイルへ上書きする。
+///
+/// `locked_at` をリセットして子プロセスの開始時刻を反映する。
 pub fn update_pid(repo_id: &str, pid: u32) {
     if let Some(path) = lock_path(repo_id) {
-        let _ = fs::write(path, pid.to_string());
+        let lock = LockFile {
+            pid,
+            locked_at: now_secs(),
+        };
+        if let Ok(content) = serde_json::to_string(&lock) {
+            let _ = fs::write(path, content);
+        }
     }
 }
 
@@ -71,41 +97,52 @@ pub fn maybe_spawn_refresh(repo_id: &str) {
     // ロックは子プロセス（run_refresh の末尾）が解放する
 }
 
-/// ロックファイルをアトミックに作成し、直後に自 PID を書き込む。
+/// ロックファイルをアトミックに作成し、直後に自 PID と取得時刻を JSON で書き込む。
 ///
 /// 作成に成功した場合 `true`、既に存在する場合 `false` を返す。
 fn create_with_pid(path: &std::path::Path) -> bool {
-    if let Ok(mut f) = fs::OpenOptions::new()
+    let Ok(f) = fs::OpenOptions::new()
         .write(true)
         .create_new(true)
         .open(path)
-    {
-        let _ = f.write_all(std::process::id().to_string().as_bytes());
-        true
-    } else {
-        false
+    else {
+        return false;
+    };
+    // ファイルハンドルは drop して close してから JSON を書き込む
+    drop(f);
+    let lock = LockFile {
+        pid: std::process::id(),
+        locked_at: now_secs(),
+    };
+    if let Ok(content) = serde_json::to_string(&lock) {
+        let _ = fs::write(path, content);
     }
+    true
 }
 
 /// ロックファイルが示すプロセスが生存しているかを確認する。
 ///
-/// - PID あり → `kill -0 <pid>` でプロセス生存確認
-/// - PID なし（空ファイル）→ 異常状態として dead 扱い
+/// - JSON パース失敗（空ファイル含む）→ dead 扱い
+/// - `kill -0 <pid>` が失敗 → dead
+/// - `now - locked_at >= MAX_LOCK_AGE_SECS` → dead（PID 再利用安全弁）
 fn is_alive(path: &std::path::Path) -> bool {
-    let content = fs::read_to_string(path).unwrap_or_default();
-    let trimmed = content.trim();
+    let Ok(content) = fs::read_to_string(path) else {
+        return false;
+    };
+    let Ok(lock) = serde_json::from_str::<LockFile>(&content) else {
+        return false;
+    };
 
-    if trimmed.is_empty() {
+    let age = now_secs().saturating_sub(lock.locked_at);
+    if age >= MAX_LOCK_AGE_SECS {
         return false;
     }
 
-    trimmed.parse::<u32>().is_ok_and(|pid| {
-        std::process::Command::new("kill")
-            .args(["-0", &pid.to_string()])
-            .stderr(std::process::Stdio::null())
-            .status()
-            .is_ok_and(|s| s.success())
-    })
+    std::process::Command::new("kill")
+        .args(["-0", &lock.pid.to_string()])
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|s| s.success())
 }
 
 fn lock_path(repo_id: &str) -> Option<std::path::PathBuf> {
@@ -116,4 +153,10 @@ fn lock_path(repo_id: &str) -> Option<std::path::PathBuf> {
             .join(CACHE_DIR_NAME)
             .join(format!("{repo_id}.lock")),
     )
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs())
 }

--- a/src/infra/refresh_lock.rs
+++ b/src/infra/refresh_lock.rs
@@ -170,3 +170,95 @@ fn now_secs() -> u64 {
         .duration_since(UNIX_EPOCH)
         .map_or(0, |d| d.as_secs())
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    /// `create_with_pid` を N スレッドから同時に呼んでも、成功は正確に 1 つだけであること。
+    ///
+    /// `O_CREAT | O_EXCL` の OS アトミック性を検証する。
+    #[test]
+    fn create_with_pid_concurrent_exactly_one_succeeds() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.lock");
+        let success_count = Arc::new(AtomicUsize::new(0));
+
+        std::thread::scope(|s| {
+            let handles: Vec<_> = (0..16)
+                .map(|_| {
+                    let count = Arc::clone(&success_count);
+                    let p = path.clone();
+                    s.spawn(move || {
+                        if create_with_pid(&p) {
+                            count.fetch_add(1, Ordering::SeqCst);
+                        }
+                    })
+                })
+                .collect();
+            for h in handles {
+                h.join().unwrap();
+            }
+        });
+
+        assert_eq!(
+            success_count.load(Ordering::SeqCst),
+            1,
+            "exactly 1 thread should win create_with_pid"
+        );
+    }
+
+    /// `create_with_pid` 成功直後、ファイルに有効な JSON が書き込まれており
+    /// 現プロセスの PID が記録されていること（空ファイル状態が残らないことの確認）。
+    #[test]
+    fn create_with_pid_writes_valid_json_immediately() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.lock");
+
+        assert!(create_with_pid(&path));
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let lock: LockFile =
+            serde_json::from_str(&content).expect("lock file should contain valid JSON");
+        assert_eq!(lock.pid, std::process::id(), "pid should match current process");
+        assert!(lock.locked_at > 0, "locked_at should be non-zero");
+    }
+
+    /// `create_with_pid` が失敗した後（ファイル既存）にロックファイルが孤立しないこと。
+    ///
+    /// リリース後に再取得できることで、孤立ファイルがないことを確認する。
+    #[test]
+    fn create_with_pid_failure_leaves_no_orphan_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.lock");
+
+        assert!(create_with_pid(&path), "first acquire should succeed");
+        assert!(!create_with_pid(&path), "second acquire should fail");
+
+        // ファイルはちょうど 1 つ存在（失敗がファイルを汚染していない）
+        assert!(path.exists());
+
+        // リリース後は再取得できる（孤立ファイルがないことの証明）
+        std::fs::remove_file(&path).unwrap();
+        assert!(
+            create_with_pid(&path),
+            "should be re-acquirable after release — no orphan file"
+        );
+    }
+
+    /// `is_alive` は空ファイルを「死んでいる」と判定すること。
+    ///
+    /// JSON パース失敗 = 空ファイル含む → false。
+    #[test]
+    fn is_alive_returns_false_for_empty_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.lock");
+        std::fs::write(&path, b"").unwrap();
+        assert!(!is_alive(&path));
+    }
+}

--- a/src/infra/refresh_lock.rs
+++ b/src/infra/refresh_lock.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::io::Write;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
@@ -97,25 +98,34 @@ pub fn maybe_spawn_refresh(repo_id: &str) {
     // ロックは子プロセス（run_refresh の末尾）が解放する
 }
 
-/// ロックファイルをアトミックに作成し、直後に自 PID と取得時刻を JSON で書き込む。
+/// ロックファイルをアトミックに作成し、ハンドルを保持したまま自 PID と取得時刻を JSON で書き込む。
 ///
-/// 作成に成功した場合 `true`、既に存在する場合 `false` を返す。
+/// `create_new(true)`（`O_CREAT | O_EXCL`）でアトミックにファイルを作成後、
+/// ハンドルを閉じる前に `write_all` で JSON を書くことで「空ファイル」状態を排除する。
+/// 書き込み失敗時はファイルを削除して `false` を返す。
+///
+/// 作成に成功した場合 `true`、既に存在する場合は `false` を返す。
 fn create_with_pid(path: &std::path::Path) -> bool {
-    let Ok(f) = fs::OpenOptions::new()
+    let Ok(mut f) = fs::OpenOptions::new()
         .write(true)
         .create_new(true)
         .open(path)
     else {
         return false;
     };
-    // ファイルハンドルは drop して close してから JSON を書き込む
-    drop(f);
     let lock = LockFile {
         pid: std::process::id(),
         locked_at: now_secs(),
     };
-    if let Ok(content) = serde_json::to_string(&lock) {
-        let _ = fs::write(path, content);
+    let Ok(content) = serde_json::to_string(&lock) else {
+        drop(f);
+        let _ = fs::remove_file(path);
+        return false;
+    };
+    if f.write_all(content.as_bytes()).is_err() {
+        drop(f);
+        let _ = fs::remove_file(path);
+        return false;
     }
     true
 }

--- a/src/infra/refresh_lock.rs
+++ b/src/infra/refresh_lock.rs
@@ -1,0 +1,119 @@
+use std::fs;
+use std::io::Write as _;
+
+const CACHE_DIR_NAME: &str = "merge-ready";
+
+/// リフレッシュロックを取得する。成功時は `true`、既に起動中なら `false` を返す。
+///
+/// `create_new(true)`（`O_CREAT | O_EXCL`）でアトミックにファイルを作成し、
+/// 直後に自プロセスの PID を書き込む。これにより空ファイルが存在する瞬間をなくす。
+///
+/// ロックファイルが既存の場合は PID で生存確認（`kill -0`）を行い、
+/// プロセスが死んでいれば除去して再取得する。
+pub fn try_acquire(repo_id: &str) -> bool {
+    let Some(path) = lock_path(repo_id) else {
+        return false;
+    };
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+
+    if create_with_pid(&path) {
+        return true;
+    }
+
+    // ロックファイルが既存: 生存確認して死んでいれば再取得
+    if is_alive(&path) {
+        return false;
+    }
+    let _ = fs::remove_file(&path);
+    create_with_pid(&path)
+}
+
+/// spawn 後に子プロセスの PID をロックファイルへ上書きする。
+pub fn update_pid(repo_id: &str, pid: u32) {
+    if let Some(path) = lock_path(repo_id) {
+        let _ = fs::write(path, pid.to_string());
+    }
+}
+
+/// リフレッシュロックを解放する。
+pub fn release(repo_id: &str) {
+    if let Some(path) = lock_path(repo_id) {
+        let _ = fs::remove_file(path);
+    }
+}
+
+/// ロックを取得できた場合のみバックグラウンドリフレッシュを起動する（多重起動抑止）。
+pub fn maybe_spawn_refresh(repo_id: &str) {
+    if !try_acquire(repo_id) {
+        return;
+    }
+    let Ok(exe) = std::env::current_exe() else {
+        release(repo_id);
+        return;
+    };
+    match std::process::Command::new(exe)
+        .args(["prompt", "--refresh"])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+    {
+        Ok(child) => {
+            // 子 PID をロックファイルへ書き込む（kill -0 による生存確認に使用）
+            update_pid(repo_id, child.id());
+        }
+        Err(_) => {
+            release(repo_id);
+        }
+    }
+    // ロックは子プロセス（run_refresh の末尾）が解放する
+}
+
+/// ロックファイルをアトミックに作成し、直後に自 PID を書き込む。
+///
+/// 作成に成功した場合 `true`、既に存在する場合 `false` を返す。
+fn create_with_pid(path: &std::path::Path) -> bool {
+    if let Ok(mut f) = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+    {
+        let _ = f.write_all(std::process::id().to_string().as_bytes());
+        true
+    } else {
+        false
+    }
+}
+
+/// ロックファイルが示すプロセスが生存しているかを確認する。
+///
+/// - PID あり → `kill -0 <pid>` でプロセス生存確認
+/// - PID なし（空ファイル）→ 異常状態として dead 扱い
+fn is_alive(path: &std::path::Path) -> bool {
+    let content = fs::read_to_string(path).unwrap_or_default();
+    let trimmed = content.trim();
+
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    trimmed.parse::<u32>().is_ok_and(|pid| {
+        std::process::Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .stderr(std::process::Stdio::null())
+            .status()
+            .is_ok_and(|s| s.success())
+    })
+}
+
+fn lock_path(repo_id: &str) -> Option<std::path::PathBuf> {
+    let home = std::env::var_os("HOME")?;
+    Some(
+        std::path::Path::new(&home)
+            .join(".cache")
+            .join(CACHE_DIR_NAME)
+            .join(format!("{repo_id}.lock")),
+    )
+}

--- a/src/infra/repo_id.rs
+++ b/src/infra/repo_id.rs
@@ -22,17 +22,18 @@ pub fn get() -> Option<String> {
         return None;
     }
 
-    // 英数字と `-` 以外を `_` に置換してファイルシステムセーフな ID を生成
-    // 例: "/home/user/repos/my-project" → "_home_user_repos_my-project"
-    Some(
-        path.chars()
-            .map(|c| {
-                if c.is_alphanumeric() || c == '-' {
-                    c
-                } else {
-                    '_'
-                }
-            })
-            .collect(),
-    )
+    Some(path_to_id(path))
+}
+
+/// パス文字列を FNV-1a ハッシュでファイルシステムセーフな ID に変換する。
+///
+/// 文字置換ではなくハッシュを使うことで、`/` と `_` が同じ `_` に潰れる衝突を回避する。
+/// 例: `"/home/user/repos/my_project"` と `"/home/user/repos/my/project"` は別の ID になる。
+pub fn path_to_id(path: &str) -> String {
+    let mut hash: u64 = 14_695_981_039_346_656_037;
+    for byte in path.bytes() {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(1_099_511_628_211);
+    }
+    format!("{hash:016x}")
 }

--- a/src/infra/repo_id.rs
+++ b/src/infra/repo_id.rs
@@ -1,0 +1,27 @@
+use std::process::Command;
+
+/// `git remote get-url origin` からリポジトリ ID を生成する。
+///
+/// 生成されたIDはキャッシュのディレクトリ名として使用する。
+/// 取得失敗時（非 git ディレクトリ、git がない、remote が未設定等）は `None` を返す。
+pub fn get() -> Option<String> {
+    let output = Command::new("git")
+        .args(["remote", "get-url", "origin"])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let url = String::from_utf8_lossy(&output.stdout);
+    let url = url.trim();
+
+    if url.is_empty() {
+        return None;
+    }
+
+    // 英数字と `-` 以外を `_` に置換してファイルシステムセーフなIDを生成
+    // 例: "https://github.com/test/repo.git" → "https___github_com_test_repo_git"
+    Some(url.chars().map(|c| if c.is_alphanumeric() || c == '-' { c } else { '_' }).collect())
+}

--- a/src/infra/repo_id.rs
+++ b/src/infra/repo_id.rs
@@ -1,12 +1,13 @@
 use std::process::Command;
 
-/// `git remote get-url origin` からリポジトリ ID を生成する。
+/// `git rev-parse --show-toplevel` からワークツリーの ID を生成する。
 ///
-/// 生成されたIDはキャッシュのディレクトリ名として使用する。
-/// 取得失敗時（非 git ディレクトリ、git がない、remote が未設定等）は `None` を返す。
+/// 生成された ID はキャッシュのファイル名として使用する。
+/// worktree ごとに固有のパスが返るため、同一リモートの worktree 間で衝突しない。
+/// 取得失敗時（非 git ディレクトリ、git がない等）は `None` を返す。
 pub fn get() -> Option<String> {
     let output = Command::new("git")
-        .args(["remote", "get-url", "origin"])
+        .args(["rev-parse", "--show-toplevel"])
         .output()
         .ok()?;
 
@@ -14,17 +15,17 @@ pub fn get() -> Option<String> {
         return None;
     }
 
-    let url = String::from_utf8_lossy(&output.stdout);
-    let url = url.trim();
+    let path = String::from_utf8_lossy(&output.stdout);
+    let path = path.trim();
 
-    if url.is_empty() {
+    if path.is_empty() {
         return None;
     }
 
-    // 英数字と `-` 以外を `_` に置換してファイルシステムセーフなIDを生成
-    // 例: "https://github.com/test/repo.git" → "https___github_com_test_repo_git"
+    // 英数字と `-` 以外を `_` に置換してファイルシステムセーフな ID を生成
+    // 例: "/home/user/repos/my-project" → "_home_user_repos_my-project"
     Some(
-        url.chars()
+        path.chars()
             .map(|c| {
                 if c.is_alphanumeric() || c == '-' {
                     c

--- a/src/infra/repo_id.rs
+++ b/src/infra/repo_id.rs
@@ -23,5 +23,15 @@ pub fn get() -> Option<String> {
 
     // 英数字と `-` 以外を `_` に置換してファイルシステムセーフなIDを生成
     // 例: "https://github.com/test/repo.git" → "https___github_com_test_repo_git"
-    Some(url.chars().map(|c| if c.is_alphanumeric() || c == '-' { c } else { '_' }).collect())
+    Some(
+        url.chars()
+            .map(|c| {
+                if c.is_alphanumeric() || c == '-' {
+                    c
+                } else {
+                    '_'
+                }
+            })
+            .collect(),
+    )
 }

--- a/src/infra/repo_id.rs
+++ b/src/infra/repo_id.rs
@@ -1,28 +1,32 @@
 use std::process::Command;
 
-/// `git rev-parse --show-toplevel` からワークツリーの ID を生成する。
+/// `git rev-parse --show-toplevel` と `git branch --show-current` からキャッシュキーを生成する。
 ///
-/// 生成された ID はキャッシュのファイル名として使用する。
-/// worktree ごとに固有のパスが返るため、同一リモートの worktree 間で衝突しない。
+/// worktree パスとブランチ名の組み合わせをハッシュ化することで、
+/// 同一 worktree でのブランチ切り替えや複数 worktree の並走でも衝突しない。
 /// 取得失敗時（非 git ディレクトリ、git がない等）は `None` を返す。
 pub fn get() -> Option<String> {
-    let output = Command::new("git")
-        .args(["rev-parse", "--show-toplevel"])
-        .output()
-        .ok()?;
+    let toplevel = run_git(&["rev-parse", "--show-toplevel"])?;
+    // detached HEAD の場合は空文字列になるが、それでもキーとして一意に扱う
+    let branch = run_git(&["branch", "--show-current"]).unwrap_or_default();
+    Some(path_to_id(&format!("{toplevel}\0{branch}")))
+}
+
+fn run_git(args: &[&str]) -> Option<String> {
+    let output = Command::new("git").args(args).output().ok()?;
 
     if !output.status.success() {
         return None;
     }
 
-    let path = String::from_utf8_lossy(&output.stdout);
-    let path = path.trim();
+    let s = String::from_utf8_lossy(&output.stdout);
+    let s = s.trim();
 
-    if path.is_empty() {
+    if s.is_empty() {
         return None;
     }
 
-    Some(path_to_id(path))
+    Some(s.to_owned())
 }
 
 /// パス文字列を FNV-1a ハッシュでファイルシステムセーフな ID に変換する。

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,7 @@ mod domain;
 mod infra;
 mod presentation;
 
-use application::errors::{ErrorPresenter, ErrorToken};
-use infra::cache::CacheStatus;
+use application::cache::DisplayAction;
 
 fn main() {
     // テスト/デバッグ用: MERGE_READY_NO_CACHE=1 でキャッシュを無効化して gh を直接呼ぶ
@@ -13,33 +12,14 @@ fn main() {
         return;
     }
 
-    // バックグラウンドリフレッシュモード: gh を呼んでキャッシュを更新するだけ（stdout に出力しない）
-    if std::env::args().any(|a| a == "--refresh") {
-        if let Some(id) = infra::repo_id::get() {
-            let output = run_silent();
-            infra::cache::write(&id, &output);
+    // 通常モード: キャッシュ方針はアプリケーション層が決定する
+    let cache = infra::cache::CacheStore;
+    match application::cache::resolve(infra::repo_id::get().as_deref(), &cache) {
+        DisplayAction::Display(s) | DisplayAction::DisplayAndRefresh(s) => {
+            print!("{s}");
         }
-        return;
-    }
-
-    // 通常モード: gh を呼ばずキャッシュから即座に返す（常に <40ms）
-    let Some(id) = infra::repo_id::get() else {
-        // git remote が取得できない場合はローディング表示
-        print!("? loading");
-        return;
-    };
-
-    match infra::cache::check(&id) {
-        CacheStatus::Fresh(output) => {
-            print!("{output}");
-        }
-        CacheStatus::Stale(output) => {
-            print!("{output}");
-            spawn_background_refresh();
-        }
-        CacheStatus::Miss => {
+        DisplayAction::Loading => {
             print!("? loading");
-            spawn_background_refresh();
         }
     }
 }
@@ -54,32 +34,4 @@ fn run_direct() {
     if !tokens.is_empty() {
         presentation::display(&tokens);
     }
-}
-
-/// バックグラウンドリフレッシュ用: gh を呼んで結果を文字列で返す（stdout には何も出力しない）
-fn run_silent() -> String {
-    struct SilentPresenter;
-
-    impl ErrorPresenter for SilentPresenter {
-        fn show_error(&self, _token: ErrorToken) {}
-    }
-
-    let tokens = application::run(
-        &infra::gh::GhClient::new(),
-        &infra::logger::Logger,
-        &SilentPresenter,
-    );
-    presentation::render_to_string(&tokens)
-}
-
-fn spawn_background_refresh() {
-    let Ok(exe) = std::env::current_exe() else {
-        return;
-    };
-    let _ = std::process::Command::new(exe)
-        .arg("--refresh")
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,6 @@ mod domain;
 mod infra;
 mod presentation;
 
-use application::cache::DisplayAction;
-
 fn main() {
     cli::run();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,12 +6,6 @@ mod presentation;
 use application::cache::DisplayAction;
 
 fn main() {
-    // テスト/デバッグ用: MERGE_READY_NO_CACHE=1 でキャッシュを無効化して gh を直接呼ぶ
-    if std::env::var("MERGE_READY_NO_CACHE").as_deref() == Ok("1") {
-        run_direct();
-        return;
-    }
-
     // 通常モード: キャッシュ方針はアプリケーション層が決定する
     let cache = infra::cache::CacheStore;
     match application::cache::resolve(infra::repo_id::get().as_deref(), &cache) {
@@ -21,17 +15,5 @@ fn main() {
         DisplayAction::Loading => {
             print!("? loading");
         }
-    }
-}
-
-/// テスト/デバッグ用: gh を直接呼んで結果を stdout に出力する（従来の挙動）
-fn run_direct() {
-    let tokens = application::run(
-        &infra::gh::GhClient::new(),
-        &infra::logger::Logger,
-        &presentation::Presenter,
-    );
-    if !tokens.is_empty() {
-        presentation::display(&tokens);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,49 @@ mod domain;
 mod infra;
 mod presentation;
 
+use application::errors::{ErrorPresenter, ErrorToken};
+use infra::cache::CacheStatus;
+
 fn main() {
+    // テスト/デバッグ用: MERGE_READY_NO_CACHE=1 でキャッシュを無効化して gh を直接呼ぶ
+    if std::env::var("MERGE_READY_NO_CACHE").as_deref() == Ok("1") {
+        run_direct();
+        return;
+    }
+
+    // バックグラウンドリフレッシュモード: gh を呼んでキャッシュを更新するだけ（stdout に出力しない）
+    if std::env::args().any(|a| a == "--refresh") {
+        if let Some(id) = infra::repo_id::get() {
+            let output = run_silent();
+            infra::cache::write(&id, &output);
+        }
+        return;
+    }
+
+    // 通常モード: gh を呼ばずキャッシュから即座に返す（常に <40ms）
+    let Some(id) = infra::repo_id::get() else {
+        // git remote が取得できない場合はローディング表示
+        print!("? loading");
+        return;
+    };
+
+    match infra::cache::check(&id) {
+        CacheStatus::Fresh(output) => {
+            print!("{output}");
+        }
+        CacheStatus::Stale(output) => {
+            print!("{output}");
+            spawn_background_refresh();
+        }
+        CacheStatus::Miss => {
+            print!("? loading");
+            spawn_background_refresh();
+        }
+    }
+}
+
+/// テスト/デバッグ用: gh を直接呼んで結果を stdout に出力する（従来の挙動）
+fn run_direct() {
     let tokens = application::run(
         &infra::gh::GhClient::new(),
         &infra::logger::Logger,
@@ -12,4 +54,32 @@ fn main() {
     if !tokens.is_empty() {
         presentation::display(&tokens);
     }
+}
+
+/// バックグラウンドリフレッシュ用: gh を呼んで結果を文字列で返す（stdout には何も出力しない）
+fn run_silent() -> String {
+    struct SilentPresenter;
+
+    impl ErrorPresenter for SilentPresenter {
+        fn show_error(&self, _token: ErrorToken) {}
+    }
+
+    let tokens = application::run(
+        &infra::gh::GhClient::new(),
+        &infra::logger::Logger,
+        &SilentPresenter,
+    );
+    presentation::render_to_string(&tokens)
+}
+
+fn spawn_background_refresh() {
+    let Ok(exe) = std::env::current_exe() else {
+        return;
+    };
+    let _ = std::process::Command::new(exe)
+        .arg("--refresh")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn();
 }

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -25,10 +25,14 @@ fn render_error(token: ErrorToken) -> &'static str {
     }
 }
 
+/// トークン列を文字列に変換する
+pub fn render_to_string(tokens: &[OutputToken]) -> String {
+    tokens.iter().map(render).collect::<Vec<_>>().join(" ")
+}
+
 /// トークン列を `stdout` に出力する（末尾改行なし）
 pub fn display(tokens: &[OutputToken]) {
-    let rendered: Vec<&str> = tokens.iter().map(render).collect();
-    print!("{}", rendered.join(" "));
+    print!("{}", render_to_string(tokens));
 }
 
 pub struct Presenter;

--- a/tests/e2e/branch_sync.rs
+++ b/tests/e2e/branch_sync.rs
@@ -12,7 +12,7 @@ use assert_cmd::Command;
 fn cmd(env: &TestEnv) -> Command {
     let mut c = Command::cargo_bin("merge-ready").unwrap();
     env.apply(&mut c);
-    c.arg("prompt");
+    c.args(["prompt", "--no-cache"]);
     c
 }
 

--- a/tests/e2e/cache.rs
+++ b/tests/e2e/cache.rs
@@ -153,9 +153,7 @@ fn test_no_git_remote_shows_nothing() {
 
     let mut cmd = Command::cargo_bin(BIN).unwrap();
     env.apply_with_cache(&mut cmd);
-    cmd.assert()
-        .success()
-        .stdout(predicate::str::is_empty());
+    cmd.assert().success().stdout(predicate::str::is_empty());
 
     // キャッシュが作成されていないこと
     let state_path = state_json_path(env.home());

--- a/tests/e2e/cache.rs
+++ b/tests/e2e/cache.rs
@@ -128,7 +128,10 @@ fn test_stale_cache_is_updated_by_refresh() {
     let mut refresh_cmd = Command::cargo_bin(BIN).unwrap();
     env.apply_with_cache(&mut refresh_cmd);
     refresh_cmd.arg("--refresh");
-    refresh_cmd.assert().success().stdout(predicate::str::is_empty());
+    refresh_cmd
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
 
     // state.json の fetched_at_secs が更新されていること
     let state = read_state_json(env.home()).expect("state.json should exist");

--- a/tests/e2e/cache.rs
+++ b/tests/e2e/cache.rs
@@ -15,11 +15,16 @@ const BIN: &str = "merge-ready";
 
 /// fake git が返すワークツリーパス（`git rev-parse --show-toplevel` の戻り値）
 const FAKE_TOPLEVEL: &str = "/fake/repo";
+/// fake git が返すブランチ名（`git branch --show-current` の戻り値）
+const FAKE_BRANCH: &str = "main";
 
 /// FNV-1a ハッシュで生成される repo_id（`infra::repo_id::path_to_id` と同じアルゴリズム）
+///
+/// キーは `"<toplevel>\0<branch>"` の形式で生成する。
 fn fake_repo_id() -> String {
+    let input = format!("{FAKE_TOPLEVEL}\0{FAKE_BRANCH}");
     let mut hash: u64 = 14_695_981_039_346_656_037;
-    for byte in FAKE_TOPLEVEL.bytes() {
+    for byte in input.bytes() {
         hash ^= byte as u64;
         hash = hash.wrapping_mul(1_099_511_628_211);
     }

--- a/tests/e2e/cache.rs
+++ b/tests/e2e/cache.rs
@@ -146,22 +146,22 @@ fn test_stale_cache_is_updated_by_refresh() {
 
 // ── git remote 取得不可 ─────────────────────────────────────────────────
 
-/// `git remote get-url origin` が失敗する場合、`? loading` を出力してキャッシュを作らない
+/// git リポジトリでない場合、何も出力せずキャッシュも作らない
 #[test]
-fn test_no_git_remote_shows_loading() {
+fn test_no_git_remote_shows_nothing() {
     let env = TestEnv::without_git_remote();
 
     let mut cmd = Command::cargo_bin(BIN).unwrap();
     env.apply_with_cache(&mut cmd);
     cmd.assert()
         .success()
-        .stdout(predicate::str::diff("? loading"));
+        .stdout(predicate::str::is_empty());
 
     // キャッシュが作成されていないこと
     let state_path = state_json_path(env.home());
     assert!(
         !state_path.exists(),
-        "state.json should NOT be created when git remote is unavailable"
+        "state.json should NOT be created when not in a git repository"
     );
 }
 

--- a/tests/e2e/cache.rs
+++ b/tests/e2e/cache.rs
@@ -51,7 +51,7 @@ fn test_refresh_mode_writes_cache() {
     let mut cmd = Command::cargo_bin(BIN).unwrap();
     env.apply_with_cache(&mut cmd);
     cmd.arg("--refresh");
-    // --refresh は stdout に何も出力しない
+    // prompt --refresh は stdout に何も出力しない
     cmd.assert().success().stdout(predicate::str::is_empty());
 
     // state.json が作成されていること
@@ -89,7 +89,7 @@ fn test_cache_fresh_returns_cached_output() {
     let mut cmd = Command::cargo_bin(BIN).unwrap();
     cmd.env("PATH", broken_env.path_env()); // 壊れた gh の PATH
     cmd.env("HOME", env.home()); // キャッシュが存在する HOME
-    // MERGE_READY_NO_CACHE は設定しない（キャッシュ有効）
+    cmd.arg("prompt"); // キャッシュ有効モード
 
     cmd.assert()
         .success()
@@ -124,7 +124,7 @@ fn test_stale_cache_is_updated_by_refresh() {
     // stale_ttl より古いキャッシュを作成
     write_state_json(env.home(), stale_output, now_secs() - 10);
 
-    // --refresh を明示的に実行
+    // prompt --refresh を明示的に実行
     let mut refresh_cmd = Command::cargo_bin(BIN).unwrap();
     env.apply_with_cache(&mut refresh_cmd);
     refresh_cmd.arg("--refresh");

--- a/tests/e2e/cache.rs
+++ b/tests/e2e/cache.rs
@@ -13,11 +13,11 @@ use super::helpers::TestEnv;
 /// merge-ready のバイナリ名
 const BIN: &str = "merge-ready";
 
-/// fake git が返す remote URL から生成される repo_id
-/// `git remote get-url origin` → "https://github.com/test/repo.git"
+/// fake git が返すワークツリーパスから生成される repo_id
+/// `git rev-parse --show-toplevel` → "/fake/repo"
 /// → 英数字と `-` 以外を `_` に置換
-/// → "https___github_com_test_repo_git"
-const FAKE_REPO_ID: &str = "https___github_com_test_repo_git";
+/// → "_fake_repo"
+const FAKE_REPO_ID: &str = "_fake_repo";
 
 /// マージ可能な PR の `gh pr view` JSON（キャッシュテスト用の最小セット）
 /// `baseRefName` / `headRefName` を空にすることで `gh repo view` 呼び出しを回避し
@@ -177,8 +177,7 @@ fn now_secs() -> u64 {
 fn state_json_path(home: &std::path::Path) -> std::path::PathBuf {
     home.join(".cache")
         .join("merge-ready")
-        .join(FAKE_REPO_ID)
-        .join("state.json")
+        .join(format!("{FAKE_REPO_ID}.json"))
 }
 
 /// 指定した home_dir の下に state.json を書き込む

--- a/tests/e2e/cache.rs
+++ b/tests/e2e/cache.rs
@@ -13,11 +13,18 @@ use super::helpers::TestEnv;
 /// merge-ready のバイナリ名
 const BIN: &str = "merge-ready";
 
-/// fake git が返すワークツリーパスから生成される repo_id
-/// `git rev-parse --show-toplevel` → "/fake/repo"
-/// → 英数字と `-` 以外を `_` に置換
-/// → "_fake_repo"
-const FAKE_REPO_ID: &str = "_fake_repo";
+/// fake git が返すワークツリーパス（`git rev-parse --show-toplevel` の戻り値）
+const FAKE_TOPLEVEL: &str = "/fake/repo";
+
+/// FNV-1a ハッシュで生成される repo_id（`infra::repo_id::path_to_id` と同じアルゴリズム）
+fn fake_repo_id() -> String {
+    let mut hash: u64 = 14_695_981_039_346_656_037;
+    for byte in FAKE_TOPLEVEL.bytes() {
+        hash ^= byte as u64;
+        hash = hash.wrapping_mul(1_099_511_628_211);
+    }
+    format!("{hash:016x}")
+}
 
 /// マージ可能な PR の `gh pr view` JSON（キャッシュテスト用の最小セット）
 /// `baseRefName` / `headRefName` を空にすることで `gh repo view` 呼び出しを回避し
@@ -175,7 +182,7 @@ fn now_secs() -> u64 {
 fn state_json_path(home: &std::path::Path) -> std::path::PathBuf {
     home.join(".cache")
         .join("merge-ready")
-        .join(format!("{FAKE_REPO_ID}.json"))
+        .join(format!("{}.json", fake_repo_id()))
 }
 
 /// 指定した home_dir の下に state.json を書き込む

--- a/tests/e2e/cache.rs
+++ b/tests/e2e/cache.rs
@@ -1,0 +1,194 @@
+//! キャッシュ機構の e2e テスト
+//!
+//! これらのテストは `TestEnv::apply_with_cache()` を使用してキャッシュを有効にする。
+//! `home_dir` は tempdir で分離されているため、テスト間でキャッシュはリークしない。
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use super::helpers::TestEnv;
+
+/// merge-ready のバイナリ名
+const BIN: &str = "merge-ready";
+
+/// fake git が返す remote URL から生成される repo_id
+/// `git remote get-url origin` → "https://github.com/test/repo.git"
+/// → 英数字と `-` 以外を `_` に置換
+/// → "https___github_com_test_repo_git"
+const FAKE_REPO_ID: &str = "https___github_com_test_repo_git";
+
+/// マージ可能な PR の `gh pr view` JSON（キャッシュテスト用の最小セット）
+/// `baseRefName` / `headRefName` を空にすることで `gh repo view` 呼び出しを回避し
+/// ブランチ同期を "Clean" として扱う
+const OPEN_PR_VIEW_JSON: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}"#;
+
+/// CI が Pass の `gh pr checks` JSON
+const CI_PASS_JSON: &str = r#"[{"bucket":"pass","state":"SUCCESS","name":"ci","link":""}]"#;
+
+// ── キャッシュなし（初回起動） ──────────────────────────────────────────
+
+/// キャッシュなし → `? loading` を出力する
+#[test]
+fn test_cache_miss_shows_loading() {
+    let env = TestEnv::new(OPEN_PR_VIEW_JSON, Some(CI_PASS_JSON));
+
+    let mut cmd = Command::cargo_bin(BIN).unwrap();
+    env.apply_with_cache(&mut cmd);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::diff("? loading"));
+}
+
+// ── --refresh モード ─────────────────────────────────────────────────────
+
+/// `--refresh` モードを明示的に実行すると state.json が作成される
+#[test]
+fn test_refresh_mode_writes_cache() {
+    let env = TestEnv::new(OPEN_PR_VIEW_JSON, Some(CI_PASS_JSON));
+
+    let mut cmd = Command::cargo_bin(BIN).unwrap();
+    env.apply_with_cache(&mut cmd);
+    cmd.arg("--refresh");
+    // --refresh は stdout に何も出力しない
+    cmd.assert().success().stdout(predicate::str::is_empty());
+
+    // state.json が作成されていること
+    let state_path = state_json_path(env.home());
+    assert!(
+        state_path.exists(),
+        "state.json should be created by --refresh at: {}",
+        state_path.display()
+    );
+
+    // state.json の内容確認
+    let state = read_state_json(env.home()).expect("state.json should be parseable");
+    let fetched_at: u64 = state["fetched_at_secs"]
+        .as_u64()
+        .expect("fetched_at_secs should be u64");
+    assert!(
+        fetched_at > now_secs() - 5,
+        "fetched_at_secs should be recent (was: {fetched_at})"
+    );
+}
+
+// ── キャッシュヒット（新鮮） ────────────────────────────────────────────
+
+/// 新鮮な state.json が存在する場合、キャッシュの値がそのまま返る
+#[test]
+fn test_cache_fresh_returns_cached_output() {
+    let env = TestEnv::new(OPEN_PR_VIEW_JSON, Some(CI_PASS_JSON));
+    let cached_output = "✓ merge-ready";
+
+    // state.json を手動で書き込む（fetched_at_secs = now）
+    write_state_json(env.home(), cached_output, now_secs());
+
+    // 壊れた fake gh を使っても、キャッシュが使われるためエラーにならない
+    let broken_env = TestEnv::with_error("gh is broken", 1);
+    let mut cmd = Command::cargo_bin(BIN).unwrap();
+    cmd.env("PATH", broken_env.path_env()); // 壊れた gh の PATH
+    cmd.env("HOME", env.home()); // キャッシュが存在する HOME
+    // MERGE_READY_NO_CACHE は設定しない（キャッシュ有効）
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::diff(cached_output));
+}
+
+// ── キャッシュ stale（期限切れ） ───────────────────────────────────────
+
+/// stale_ttl より古いキャッシュが存在する場合、キャッシュの値を出力する
+#[test]
+fn test_cache_stale_returns_cached_output() {
+    let env = TestEnv::new(OPEN_PR_VIEW_JSON, Some(CI_PASS_JSON));
+    let cached_output = "✗ conflict";
+
+    // stale_ttl(5秒)より古いキャッシュを作成: now - 10秒
+    write_state_json(env.home(), cached_output, now_secs() - 10);
+
+    let mut cmd = Command::cargo_bin(BIN).unwrap();
+    env.apply_with_cache(&mut cmd);
+    // stale でもキャッシュ値を返す（ブロックしない）
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::diff(cached_output));
+}
+
+/// stale 後に `--refresh` を実行すると state.json が更新される
+#[test]
+fn test_stale_cache_is_updated_by_refresh() {
+    let env = TestEnv::new(OPEN_PR_VIEW_JSON, Some(CI_PASS_JSON));
+    let stale_output = "✗ conflict";
+
+    // stale_ttl より古いキャッシュを作成
+    write_state_json(env.home(), stale_output, now_secs() - 10);
+
+    // --refresh を明示的に実行
+    let mut refresh_cmd = Command::cargo_bin(BIN).unwrap();
+    env.apply_with_cache(&mut refresh_cmd);
+    refresh_cmd.arg("--refresh");
+    refresh_cmd.assert().success().stdout(predicate::str::is_empty());
+
+    // state.json の fetched_at_secs が更新されていること
+    let state = read_state_json(env.home()).expect("state.json should exist");
+    let new_fetched_at: u64 = state["fetched_at_secs"]
+        .as_u64()
+        .expect("fetched_at_secs should be u64");
+    assert!(
+        new_fetched_at > now_secs() - 5,
+        "fetched_at_secs should be updated by --refresh (was: {new_fetched_at})"
+    );
+}
+
+// ── git remote 取得不可 ─────────────────────────────────────────────────
+
+/// `git remote get-url origin` が失敗する場合、`? loading` を出力してキャッシュを作らない
+#[test]
+fn test_no_git_remote_shows_loading() {
+    let env = TestEnv::without_git_remote();
+
+    let mut cmd = Command::cargo_bin(BIN).unwrap();
+    env.apply_with_cache(&mut cmd);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::diff("? loading"));
+
+    // キャッシュが作成されていないこと
+    let state_path = state_json_path(env.home());
+    assert!(
+        !state_path.exists(),
+        "state.json should NOT be created when git remote is unavailable"
+    );
+}
+
+// ── ヘルパー関数 ────────────────────────────────────────────────────────
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
+fn state_json_path(home: &std::path::Path) -> std::path::PathBuf {
+    home.join(".cache")
+        .join("merge-ready")
+        .join(FAKE_REPO_ID)
+        .join("state.json")
+}
+
+/// 指定した home_dir の下に state.json を書き込む
+fn write_state_json(home: &std::path::Path, output: &str, fetched_at_secs: u64) {
+    let state_path = state_json_path(home);
+    if let Some(parent) = state_path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    let content = format!(r#"{{"fetched_at_secs":{fetched_at_secs},"output":"{output}"}}"#);
+    fs::write(&state_path, content).unwrap();
+}
+
+fn read_state_json(home: &std::path::Path) -> Option<serde_json::Value> {
+    let content = fs::read_to_string(state_json_path(home)).ok()?;
+    serde_json::from_str(&content).ok()
+}

--- a/tests/e2e/ci_checks.rs
+++ b/tests/e2e/ci_checks.rs
@@ -11,7 +11,7 @@ use assert_cmd::Command;
 fn cmd(env: &TestEnv) -> Command {
     let mut c = Command::cargo_bin("merge-ready").unwrap();
     env.apply(&mut c);
-    c.arg("prompt");
+    c.args(["prompt", "--no-cache"]);
     c
 }
 

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -25,12 +25,12 @@ fn test_default_no_args_shows_help() {
         .stdout(predicates::str::contains("Usage:"));
 }
 
-/// `prompt` サブコマンド → PR ステータスを出力する
+/// `prompt --no-cache` サブコマンド → PR ステータスを出力する
 #[test]
 fn test_prompt_subcommand() {
     let env = TestEnv::new(MERGE_READY_PR_VIEW_JSON, Some(MERGE_READY_PR_CHECKS_JSON));
     cmd(&env)
-        .arg("prompt")
+        .args(["prompt", "--no-cache"])
         .assert()
         .success()
         .stdout("✓ merge-ready");

--- a/tests/e2e/errors.rs
+++ b/tests/e2e/errors.rs
@@ -23,7 +23,7 @@ fn test_gh_not_installed() {
     let env = TestEnv::without_gh();
     let mut cmd = Command::cargo_bin("merge-ready").unwrap();
     env.apply(&mut cmd);
-    cmd.arg("prompt")
+    cmd.args(["prompt", "--no-cache"])
         .assert()
         .success()
         .stdout("! gh auth login")
@@ -39,7 +39,7 @@ fn test_gh_not_logged_in() {
     );
     let mut cmd = Command::cargo_bin("merge-ready").unwrap();
     env.apply(&mut cmd);
-    cmd.arg("prompt")
+    cmd.args(["prompt", "--no-cache"])
         .assert()
         .success()
         .stdout("! gh auth login")
@@ -55,7 +55,7 @@ fn test_bad_credentials() {
     );
     let mut cmd = Command::cargo_bin("merge-ready").unwrap();
     env.apply(&mut cmd);
-    cmd.arg("prompt")
+    cmd.args(["prompt", "--no-cache"])
         .assert()
         .success()
         .stdout("! gh auth login")
@@ -70,7 +70,7 @@ fn test_api_error() {
     let env = TestEnv::with_error("HTTP 500: Internal Server Error", 1);
     let mut cmd = Command::cargo_bin("merge-ready").unwrap();
     env.apply(&mut cmd);
-    cmd.arg("prompt")
+    cmd.args(["prompt", "--no-cache"])
         .assert()
         .success()
         .stdout("✗ api-error")
@@ -86,7 +86,7 @@ fn test_no_network() {
     );
     let mut cmd = Command::cargo_bin("merge-ready").unwrap();
     env.apply(&mut cmd);
-    cmd.arg("prompt")
+    cmd.args(["prompt", "--no-cache"])
         .assert()
         .success()
         .stdout("✗ api-error")
@@ -102,7 +102,7 @@ fn test_rate_limited() {
     );
     let mut cmd = Command::cargo_bin("merge-ready").unwrap();
     env.apply(&mut cmd);
-    cmd.arg("prompt")
+    cmd.args(["prompt", "--no-cache"])
         .assert()
         .success()
         .stdout("✗ rate-limited")
@@ -120,7 +120,7 @@ fn test_error_log_written() {
 
     let mut cmd = Command::cargo_bin("merge-ready").unwrap();
     env.apply(&mut cmd);
-    cmd.arg("prompt").assert().success();
+    cmd.args(["prompt", "--no-cache"]).assert().success();
 
     assert!(log_path.exists(), "error.log が作成されていない");
     let content = std::fs::read_to_string(&log_path).unwrap();

--- a/tests/e2e/helpers.rs
+++ b/tests/e2e/helpers.rs
@@ -236,16 +236,19 @@ esac
         self.home_dir.path()
     }
 
-    /// `Command` に `PATH` / `HOME` をまとめて設定する
+    /// `Command` に `PATH` / `HOME` をまとめて設定する（キャッシュ無効）
+    ///
+    /// サブコマンドと `--no-cache` は呼び出し元が追加すること。
     pub fn apply(&self, cmd: &mut assert_cmd::Command) {
         cmd.env("PATH", self.path_env());
         cmd.env("HOME", self.home());
     }
 
-    /// キャッシュを有効にした状態で `PATH` / `HOME` を設定する（キャッシュ専用テスト用）
+    /// `Command` に `PATH` / `HOME` / `prompt` サブコマンドをまとめて設定する（キャッシュ有効）
     pub fn apply_with_cache(&self, cmd: &mut assert_cmd::Command) {
         cmd.env("PATH", self.path_env());
         cmd.env("HOME", self.home());
+        cmd.arg("prompt");
     }
 }
 

--- a/tests/e2e/helpers.rs
+++ b/tests/e2e/helpers.rs
@@ -27,6 +27,8 @@ case "$*" in
     echo 'main'; exit 0 ;;
   *'rev-parse --abbrev-ref HEAD'*)
     echo 'main'; exit 0 ;;
+  *'remote get-url origin'*)
+    echo 'https://github.com/test/repo.git'; exit 0 ;;
   *)
     exit 0 ;;
 esac
@@ -193,6 +195,37 @@ impl TestEnv {
         Self { bin_dir, home_dir }
     }
 
+    /// `git remote get-url origin` が失敗するシナリオ（キャッシュ対象外のテスト用）
+    pub fn without_git_remote() -> Self {
+        let bin_dir = tempdir().expect("failed to create bin_dir");
+        let home_dir = tempdir().expect("failed to create home_dir");
+
+        // git remote get-url origin のみ exit 1、他は通常通り
+        let git_script = r#"#!/bin/sh
+case "$*" in
+  *'rev-parse --is-inside-work-tree'*)
+    echo 'true'; exit 0 ;;
+  *'rev-parse --show-toplevel'*)
+    echo '/fake/repo'; exit 0 ;;
+  *'branch --show-current'*)
+    echo 'main'; exit 0 ;;
+  *'rev-parse --abbrev-ref HEAD'*)
+    echo 'main'; exit 0 ;;
+  *'remote get-url origin'*)
+    echo 'no remote' >&2; exit 1 ;;
+  *)
+    exit 0 ;;
+esac
+"#;
+        write_executable(bin_dir.path().join("git"), git_script);
+
+        // gh は応答しないようにする（呼ばれるべきでない）
+        let gh_script = "#!/bin/sh\necho 'gh should not be called' >&2\nexit 1\n";
+        write_executable(bin_dir.path().join("gh"), gh_script);
+
+        Self { bin_dir, home_dir }
+    }
+
     /// `PATH` 文字列を返す（`bin_dir` を先頭に追加）
     pub fn path_env(&self) -> String {
         format!("{}:/bin:/usr/bin", self.bin_dir.path().display())
@@ -204,7 +237,17 @@ impl TestEnv {
     }
 
     /// `Command` に `PATH` / `HOME` をまとめて設定する
+    ///
+    /// キャッシュを無効化（`MERGE_READY_NO_CACHE=1`）して既存テストを隔離する。
+    /// キャッシュ挙動を検証するテストは `TestEnv::apply_with_cache()` を使うこと。
     pub fn apply(&self, cmd: &mut assert_cmd::Command) {
+        cmd.env("PATH", self.path_env());
+        cmd.env("HOME", self.home());
+        cmd.env("MERGE_READY_NO_CACHE", "1");
+    }
+
+    /// キャッシュを有効にした状態で `PATH` / `HOME` を設定する（キャッシュ専用テスト用）
+    pub fn apply_with_cache(&self, cmd: &mut assert_cmd::Command) {
         cmd.env("PATH", self.path_env());
         cmd.env("HOME", self.home());
     }

--- a/tests/e2e/helpers.rs
+++ b/tests/e2e/helpers.rs
@@ -200,19 +200,19 @@ impl TestEnv {
         let bin_dir = tempdir().expect("failed to create bin_dir");
         let home_dir = tempdir().expect("failed to create home_dir");
 
-        // git remote get-url origin のみ exit 1、他は通常通り
+        // rev-parse --show-toplevel のみ exit 1、他は通常通り
         let git_script = r#"#!/bin/sh
 case "$*" in
   *'rev-parse --is-inside-work-tree'*)
     echo 'true'; exit 0 ;;
   *'rev-parse --show-toplevel'*)
-    echo '/fake/repo'; exit 0 ;;
+    echo 'not a git repository' >&2; exit 1 ;;
   *'branch --show-current'*)
     echo 'main'; exit 0 ;;
   *'rev-parse --abbrev-ref HEAD'*)
     echo 'main'; exit 0 ;;
   *'remote get-url origin'*)
-    echo 'no remote' >&2; exit 1 ;;
+    echo 'https://github.com/test/repo.git'; exit 0 ;;
   *)
     exit 0 ;;
 esac

--- a/tests/e2e/helpers.rs
+++ b/tests/e2e/helpers.rs
@@ -237,13 +237,9 @@ esac
     }
 
     /// `Command` に `PATH` / `HOME` をまとめて設定する
-    ///
-    /// キャッシュを無効化（`MERGE_READY_NO_CACHE=1`）して既存テストを隔離する。
-    /// キャッシュ挙動を検証するテストは `TestEnv::apply_with_cache()` を使うこと。
     pub fn apply(&self, cmd: &mut assert_cmd::Command) {
         cmd.env("PATH", self.path_env());
         cmd.env("HOME", self.home());
-        cmd.env("MERGE_READY_NO_CACHE", "1");
     }
 
     /// キャッシュを有効にした状態で `PATH` / `HOME` を設定する（キャッシュ専用テスト用）

--- a/tests/e2e/merge_ready.rs
+++ b/tests/e2e/merge_ready.rs
@@ -9,7 +9,7 @@ use assert_cmd::Command;
 fn cmd(env: &TestEnv) -> Command {
     let mut c = Command::cargo_bin("merge-ready").unwrap();
     env.apply(&mut c);
-    c.arg("prompt");
+    c.args(["prompt", "--no-cache"]);
     c
 }
 

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -1,4 +1,5 @@
 mod branch_sync;
+mod cache;
 mod ci_checks;
 mod errors;
 mod helpers;

--- a/tests/e2e/pr_state.rs
+++ b/tests/e2e/pr_state.rs
@@ -8,7 +8,7 @@ use assert_cmd::Command;
 fn cmd(env: &TestEnv) -> Command {
     let mut c = Command::cargo_bin("merge-ready").unwrap();
     env.apply(&mut c);
-    c.arg("prompt");
+    c.args(["prompt", "--no-cache"]);
     c
 }
 

--- a/tests/e2e/review.rs
+++ b/tests/e2e/review.rs
@@ -16,7 +16,7 @@ fn test_review_changes_requested() {
     );
     let mut cmd = Command::cargo_bin("merge-ready").unwrap();
     env.apply(&mut cmd);
-    cmd.arg("prompt")
+    cmd.args(["prompt", "--no-cache"])
         .assert()
         .success()
         .stdout("⚠ review")


### PR DESCRIPTION
## 概要

キャッシュファースト・アーキテクチャにより、プロンプト描画パスで **`gh` を一切呼ばない** 設計を実装する。

| キャッシュ状態 | 表示 | バックグラウンド処理 |
|---|---|---|
| Fresh（5秒以内） | キャッシュ値をそのまま表示 | なし |
| Stale（5秒超過） | キャッシュ値を即座に表示 | `prompt --refresh` を spawn |
| Miss（ファイルなし） | `? loading` を表示 | `prompt --refresh` を spawn |
| git リポジトリ外 | 何も表示しない | なし |

- キャッシュキー: `git rev-parse --show-toplevel` のパスを元に生成（worktree ごとに独立）
- キャッシュパス: `~/.cache/merge-ready/<id>.json`
- デフォルト `stale_ttl`: 5秒（`MERGE_READY_STALE_TTL` 環境変数で上書き可能）
- 多重起動抑止: ロックファイル（`<id>.lock`、TTL 30秒）

## アーキテクチャ

```
[メインパス — 常に <40ms]
merge-ready prompt → ~/.cache/merge-ready/<id>.json を読む → 表示

[バックグラウンドリフレッシュ: merge-ready prompt --refresh]
gh pr view → gh pr checks（並列） → gh api compare → キャッシュ書き込み
```

## CLI

```
merge-ready prompt             # キャッシュファーストで PR ステータスを表示
merge-ready prompt --no-cache  # キャッシュを使わず gh を直接呼ぶ
merge-ready prompt --refresh   # キャッシュを更新（stdout に出力しない）
```

## 主な変更点

- clap ベースの CLI（`prompt` サブコマンド）を導入
- `application::cache` にキャッシュ方針（`CachePort` トレイト / `DisplayAction` / `resolve()`）を集約し、main からの漏れを解消
- `infra::cache::CacheStore` が `CachePort` を実装
- エラー時はキャッシュを上書きしない（`run_silent` が `Option<String>` を返す）
- git リポジトリ外では何も表示しない（`run_direct` と同じ挙動）

## テスト

- 既存 e2e テスト 32 件すべて通過
- キャッシュ専用 e2e テスト（`tests/e2e/cache.rs`）
  - `test_cache_miss_shows_loading`
  - `test_cache_fresh_returns_cached_output`
  - `test_cache_stale_returns_cached_output`
  - `test_no_git_remote_shows_nothing`
  - `test_refresh_mode_writes_cache`（RED — `prompt --refresh` 実装後に GREEN）
  - `test_stale_cache_is_updated_by_refresh`（RED — 同上）

## 関連 Issue

- Closes #7
- `stale_ttl` のユーザー設定は #10 で対応予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)