### PR TITLE
fix: use GitHub App token in release-prepare to allow PR creation

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -12,6 +12,11 @@ jobs:
     name: release-prepare
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
@@ -22,5 +27,5 @@ jobs:
         with:
           command: release-pr
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## 概要

`release-prepare` ワークフローが HTTP 403 で失敗していた問題を修正。
`GITHUB_TOKEN` の代わりに GitHub App トークンを使用するよう変更した。

## 変更内容

- `actions/create-github-app-token` を追加し、GitHub App トークンを生成
- `GITHUB_TOKEN` を `${{ secrets.GITHUB_TOKEN }}` から `${{ steps.app-token.outputs.token }}` に差し替え

## 必要な事前設定

このPRをマージする前に以下の Secrets が登録されている必要がある：

| Secret 名 | 内容 |
|---|---|
| `APP_ID` | GitHub App の数値 ID |
| `APP_PRIVATE_KEY` | GitHub App の Private Key（.pem の中身） |

詳細は関連 Issue を参照。

## Test plan

- [ ] Secrets (`APP_ID`, `APP_PRIVATE_KEY`) をリポジトリに登録済みであることを確認
- [ ] マージ後に `release-prepare` ワークフローを手動実行し、PR が正常に作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)