### PR TITLE
fix: align release-publish trigger with actual branch prefix

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -14,7 +14,7 @@ jobs:
     name: release-publish
     if: |
       github.event.pull_request.merged == true &&
-      startsWith(github.event.pull_request.head.ref, 'release-v')
+      startsWith(github.event.pull_request.head.ref, 'release-')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## 概要

`release-publish` ワークフローが release-plz の作成する PR をトリガーとして認識しない問題を修正。

## 原因

`release-plz.toml` の `pr_branch_prefix = "release-"` により、release-plz が生成するブランチ名は `release-2026-04-15T00-42-04Z` のようなタイムスタンプ形式になる。
一方、`release-publish.yml` の条件は `startsWith(..., 'release-v')` となっており、不一致のためワークフローがスキップされていた。

## 変更内容

```diff
- startsWith(github.event.pull_request.head.ref, 'release-v')
+ startsWith(github.event.pull_request.head.ref, 'release-')
```

## Test plan

- [ ] マージ後に `release-prepare` を実行して release PR を作成
- [ ] その release PR をマージし、`release-publish` ワークフローが起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)