### PR TITLE
fix: add toolchain input to dtolnay/rust-toolchain in CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,6 +41,8 @@ jobs:
       - name: Setup Rust toolchain
         if: matrix.language == 'rust'
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4


### PR DESCRIPTION
## Summary

- `codeql.yml` の `dtolnay/rust-toolchain` アクションに `with: toolchain: stable` が抜けていた
- `# stable` はコメントのみでアクションへの入力としては機能しないため、`'toolchain' is a required input` エラーで `Analyze (rust)` ジョブが失敗していた

Fixes: https://github.com/toshiki670/merge-ready/actions/runs/24456169008/job/71457376880

## Test plan

- [ ] CodeQL の `Analyze (rust)` ジョブが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)