### PR TITLE
fix: change CodeQL Rust build-mode from manual to none

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,27 +32,17 @@ jobs:
           - language: actions
             build-mode: none
           - language: rust
-            build-mode: manual
+            build-mode: none
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Setup Rust toolchain
-        if: matrix.language == 'rust'
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
-        with:
-          toolchain: stable
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
-
-      - name: Build
-        if: matrix.build-mode == 'manual'
-        run: cargo build --release
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## Summary

- CodeQL 2.25.2 でRustの `build-mode: manual` サポートが廃止された
- `build-mode: none` に変更
- 不要になった `Setup Rust toolchain` ステップと `Build` ステップも削除

## Root Cause

CI ログのエラー:
```
A fatal error occurred: Rust does not support the manual build mode. Please try using one of the following build modes instead: none.
```

## Test plan

- [ ] PRマージ後、`main` push で CodeQL が正常完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)