### PR TITLE
perf: キャッシュパスを tmpfs（/tmp）に変更

### DIFF
--- a/benches/hot_path.rs
+++ b/benches/hot_path.rs
@@ -21,7 +21,7 @@ use tempfile::TempDir;
 
 struct BenchEnv {
     bin_dir: TempDir,
-    home_dir: TempDir,
+    tmp_dir: TempDir,
 }
 
 const FAKE_TOPLEVEL: &str = "/fake/bench/repo";
@@ -67,7 +67,8 @@ fn setup_bench_env() -> BenchEnv {
         + "' ;;\n  *'api'*'compare'*) printf '{\"behind_by\":0}' ;;\n  *) exit 0 ;;\nesac\n";
     write_executable(&bin_dir.path().join("gh"), &gh_script);
 
-    BenchEnv { bin_dir, home_dir }
+    let tmp_dir = TempDir::new().expect("tmp_dir");
+    BenchEnv { bin_dir, tmp_dir }
 }
 
 fn write_executable(path: &PathBuf, content: &str) {
@@ -77,6 +78,21 @@ fn write_executable(path: &PathBuf, content: &str) {
 
 fn path_env(env: &BenchEnv) -> String {
     format!("{}:/bin:/usr/bin", env.bin_dir.path().display())
+}
+
+/// `std::env::temp_dir()` と同じロジックでキャッシュディレクトリのサブディレクトリ名を返す。
+///
+/// バイナリ側の `infra::tmp_cache_dir::dir_name()` と同一のロジックを複製している。
+/// macOS: "merge-ready"、Linux: "merge-ready-{uid}"
+fn bench_cache_dir_name() -> String {
+    #[cfg(target_os = "linux")]
+    {
+        use std::os::unix::fs::MetadataExt;
+        if let Ok(meta) = std::fs::metadata("/proc/self") {
+            return format!("merge-ready-{}", meta.uid());
+        }
+    }
+    "merge-ready".to_owned()
 }
 
 fn binary_path() -> PathBuf {
@@ -110,10 +126,9 @@ fn bench_cache_hit(c: &mut Criterion) {
     let env = setup_bench_env();
     let repo_id = bench_repo_id();
     let cache_path = env
-        .home_dir
+        .tmp_dir
         .path()
-        .join(".cache")
-        .join("merge-ready")
+        .join(bench_cache_dir_name())
         .join(format!("{repo_id}.json"));
 
     fs::create_dir_all(cache_path.parent().unwrap()).expect("create cache dir");
@@ -125,13 +140,13 @@ fn bench_cache_hit(c: &mut Criterion) {
 
     let bin = binary_path();
     let path = path_env(&env);
-    let home = env.home_dir.path().to_owned();
+    let tmpdir = env.tmp_dir.path().to_owned();
 
     c.bench_function("cache_hit", |b| {
         b.iter(|| {
             Command::new(&bin)
                 .env("PATH", &path)
-                .env("HOME", &home)
+                .env("TMPDIR", &tmpdir)
                 .arg("prompt")
                 .output()
                 .expect("merge-ready failed")
@@ -147,13 +162,13 @@ fn bench_no_cache_direct(c: &mut Criterion) {
     let env = setup_bench_env();
     let bin = binary_path();
     let path = path_env(&env);
-    let home = env.home_dir.path().to_owned();
+    let tmpdir = env.tmp_dir.path().to_owned();
 
     c.bench_function("no_cache_direct", |b| {
         b.iter(|| {
             Command::new(&bin)
                 .env("PATH", &path)
-                .env("HOME", &home)
+                .env("TMPDIR", &tmpdir)
                 .args(["prompt", "--no-cache"])
                 .output()
                 .expect("merge-ready failed")

--- a/src/infra.rs
+++ b/src/infra.rs
@@ -3,3 +3,4 @@ pub mod gh;
 pub mod logger;
 pub mod refresh_lock;
 pub mod repo_id;
+pub(crate) mod tmp_cache_dir;

--- a/src/infra/cache.rs
+++ b/src/infra/cache.rs
@@ -4,9 +4,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use serde::{Deserialize, Serialize};
 
 use crate::application::cache::{CachePort, CacheState};
+use crate::infra::tmp_cache_dir;
 
 const DEFAULT_STALE_TTL_SECS: u64 = 5;
-const CACHE_DIR_NAME: &str = "merge-ready";
 
 #[derive(Serialize, Deserialize)]
 struct StateJson {
@@ -38,9 +38,7 @@ enum RawCacheStatus {
 ///
 /// キャッシュファイルが存在しない、または読み込めない場合は [`RawCacheStatus::Miss`] を返す。
 fn check_raw(repo_id: &str) -> RawCacheStatus {
-    let Some(state_path) = cache_path(repo_id) else {
-        return RawCacheStatus::Miss;
-    };
+    let state_path = cache_path(repo_id);
 
     let Ok(content) = fs::read_to_string(&state_path) else {
         return RawCacheStatus::Miss;
@@ -65,9 +63,7 @@ fn check_raw(repo_id: &str) -> RawCacheStatus {
 /// ディレクトリが存在しない場合は自動的に作成する。
 /// 書き込み失敗は静かに握り潰す。
 pub fn write(repo_id: &str, output: &str) {
-    let Some(state_path) = cache_path(repo_id) else {
-        return;
-    };
+    let state_path = cache_path(repo_id);
 
     if let Some(parent) = state_path.parent() {
         let _ = fs::create_dir_all(parent);
@@ -92,14 +88,8 @@ pub fn write(repo_id: &str, output: &str) {
     }
 }
 
-fn cache_path(repo_id: &str) -> Option<std::path::PathBuf> {
-    let home = std::env::var_os("HOME")?;
-    Some(
-        std::path::Path::new(&home)
-            .join(".cache")
-            .join(CACHE_DIR_NAME)
-            .join(format!("{repo_id}.json")),
-    )
+fn cache_path(repo_id: &str) -> std::path::PathBuf {
+    tmp_cache_dir::cache_dir().join(format!("{repo_id}.json"))
 }
 
 fn now_secs() -> u64 {

--- a/src/infra/refresh_lock.rs
+++ b/src/infra/refresh_lock.rs
@@ -4,7 +4,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
-const CACHE_DIR_NAME: &str = "merge-ready";
+use crate::infra::tmp_cache_dir;
 
 /// PID 再利用安全弁としてのロック最大有効期間。
 ///
@@ -30,9 +30,7 @@ struct LockFile {
 /// ロックファイルが既存の場合は PID と age で生存確認を行い、
 /// プロセスが死んでいれば除去して再取得する。
 pub fn try_acquire(repo_id: &str) -> bool {
-    let Some(path) = lock_path(repo_id) else {
-        return false;
-    };
+    let path = lock_path(repo_id);
     if let Some(parent) = path.parent() {
         let _ = fs::create_dir_all(parent);
     }
@@ -53,22 +51,19 @@ pub fn try_acquire(repo_id: &str) -> bool {
 ///
 /// `locked_at` をリセットして子プロセスの開始時刻を反映する。
 pub fn update_pid(repo_id: &str, pid: u32) {
-    if let Some(path) = lock_path(repo_id) {
-        let lock = LockFile {
-            pid,
-            locked_at: now_secs(),
-        };
-        if let Ok(content) = serde_json::to_string(&lock) {
-            let _ = fs::write(path, content);
-        }
+    let path = lock_path(repo_id);
+    let lock = LockFile {
+        pid,
+        locked_at: now_secs(),
+    };
+    if let Ok(content) = serde_json::to_string(&lock) {
+        let _ = fs::write(path, content);
     }
 }
 
 /// リフレッシュロックを解放する。
 pub fn release(repo_id: &str) {
-    if let Some(path) = lock_path(repo_id) {
-        let _ = fs::remove_file(path);
-    }
+    let _ = fs::remove_file(lock_path(repo_id));
 }
 
 /// ロックファイルをアトミックに作成し、ハンドルを保持したまま自 PID と取得時刻を JSON で書き込む。
@@ -128,14 +123,8 @@ fn is_alive(path: &std::path::Path) -> bool {
         .is_ok_and(|s| s.success())
 }
 
-fn lock_path(repo_id: &str) -> Option<std::path::PathBuf> {
-    let home = std::env::var_os("HOME")?;
-    Some(
-        std::path::Path::new(&home)
-            .join(".cache")
-            .join(CACHE_DIR_NAME)
-            .join(format!("{repo_id}.lock")),
-    )
+fn lock_path(repo_id: &str) -> std::path::PathBuf {
+    tmp_cache_dir::cache_dir().join(format!("{repo_id}.lock"))
 }
 
 fn now_secs() -> u64 {

--- a/src/infra/tmp_cache_dir.rs
+++ b/src/infra/tmp_cache_dir.rs
@@ -1,0 +1,26 @@
+/// キャッシュ・ロックファイルを格納する一時ディレクトリのパスを返す。
+///
+/// - macOS: `$TMPDIR/merge-ready/`
+///   `$TMPDIR` は OS が各ユーザーに割り当てる専用ディレクトリ（例: `/var/folders/.../T/`）。
+///   [`std::env::temp_dir()`] が `$TMPDIR` を返すため、別途 UID を付加しなくてもユーザー間で衝突しない。
+///
+/// - Linux: `/tmp/merge-ready-{uid}/`
+///   `/tmp` はすべてのユーザーが共有するため、`/proc/self` のメタデータから取得した UID を
+///   ディレクトリ名に付加してユーザー間衝突を防ぐ。
+///   `$TMPDIR` が設定されている場合は [`std::env::temp_dir()`] がその値を使用する。
+pub(crate) fn cache_dir() -> std::path::PathBuf {
+    std::env::temp_dir().join(dir_name())
+}
+
+const DIR_NAME: &str = "merge-ready";
+
+fn dir_name() -> String {
+    #[cfg(target_os = "linux")]
+    {
+        use std::os::unix::fs::MetadataExt;
+        if let Ok(meta) = std::fs::metadata("/proc/self") {
+            return format!("{DIR_NAME}-{}", meta.uid());
+        }
+    }
+    DIR_NAME.to_owned()
+}

--- a/tests/e2e/cache.rs
+++ b/tests/e2e/cache.rs
@@ -100,7 +100,8 @@ fn test_cache_fresh_returns_cached_output() {
     let broken_env = TestEnv::with_error("gh is broken", 1);
     let mut cmd = Command::cargo_bin(BIN).unwrap();
     cmd.env("PATH", broken_env.path_env()); // 壊れた gh の PATH
-    cmd.env("HOME", env.home()); // キャッシュが存在する HOME
+    cmd.env("HOME", env.home()); // HOME は env.home() で隔離
+    cmd.env("TMPDIR", env.home()); // キャッシュが存在する TMPDIR
     cmd.arg("prompt"); // キャッシュ有効モード
 
     cmd.assert()
@@ -184,15 +185,30 @@ fn now_secs() -> u64 {
         .as_secs()
 }
 
-fn state_json_path(home: &std::path::Path) -> std::path::PathBuf {
-    home.join(".cache")
-        .join("merge-ready")
+/// `std::env::temp_dir()` と同じロジックでキャッシュディレクトリのサブディレクトリ名を返す。
+///
+/// `infra::tmp_cache_dir::dir_name()` と同一のロジックを複製している。
+/// macOS: "merge-ready"、Linux: "merge-ready-{uid}"
+fn cache_dir_name() -> String {
+    #[cfg(target_os = "linux")]
+    {
+        use std::os::unix::fs::MetadataExt;
+        if let Ok(meta) = std::fs::metadata("/proc/self") {
+            return format!("merge-ready-{}", meta.uid());
+        }
+    }
+    "merge-ready".to_owned()
+}
+
+fn state_json_path(tmpdir: &std::path::Path) -> std::path::PathBuf {
+    tmpdir
+        .join(cache_dir_name())
         .join(format!("{}.json", fake_repo_id()))
 }
 
-/// 指定した home_dir の下に state.json を書き込む
-fn write_state_json(home: &std::path::Path, output: &str, fetched_at_secs: u64) {
-    let state_path = state_json_path(home);
+/// 指定した tmpdir の下に state.json を書き込む
+fn write_state_json(tmpdir: &std::path::Path, output: &str, fetched_at_secs: u64) {
+    let state_path = state_json_path(tmpdir);
     if let Some(parent) = state_path.parent() {
         fs::create_dir_all(parent).unwrap();
     }
@@ -200,7 +216,7 @@ fn write_state_json(home: &std::path::Path, output: &str, fetched_at_secs: u64) 
     fs::write(&state_path, content).unwrap();
 }
 
-fn read_state_json(home: &std::path::Path) -> Option<serde_json::Value> {
-    let content = fs::read_to_string(state_json_path(home)).ok()?;
+fn read_state_json(tmpdir: &std::path::Path) -> Option<serde_json::Value> {
+    let content = fs::read_to_string(state_json_path(tmpdir)).ok()?;
     serde_json::from_str(&content).ok()
 }

--- a/tests/e2e/helpers.rs
+++ b/tests/e2e/helpers.rs
@@ -12,7 +12,7 @@ use tempfile::{TempDir, tempdir};
 pub struct TestEnv {
     /// `fake gh` / `fake git` を配置する一時ディレクトリ
     pub bin_dir: TempDir,
-    /// 隔離された `HOME`（`~/.cache/ci-status/error.log` の書き込み先）
+    /// 隔離された `HOME` 兼 `TMPDIR`（キャッシュ・ロックファイルの書き込み先）
     pub home_dir: TempDir,
 }
 
@@ -236,18 +236,20 @@ esac
         self.home_dir.path()
     }
 
-    /// `Command` に `PATH` / `HOME` をまとめて設定する（キャッシュ無効）
+    /// `Command` に `PATH` / `HOME` / `TMPDIR` をまとめて設定する（キャッシュ無効）
     ///
     /// サブコマンドと `--no-cache` は呼び出し元が追加すること。
     pub fn apply(&self, cmd: &mut assert_cmd::Command) {
         cmd.env("PATH", self.path_env());
         cmd.env("HOME", self.home());
+        cmd.env("TMPDIR", self.home());
     }
 
-    /// `Command` に `PATH` / `HOME` / `prompt` サブコマンドをまとめて設定する（キャッシュ有効）
+    /// `Command` に `PATH` / `HOME` / `TMPDIR` / `prompt` サブコマンドをまとめて設定する（キャッシュ有効）
     pub fn apply_with_cache(&self, cmd: &mut assert_cmd::Command) {
         cmd.env("PATH", self.path_env());
         cmd.env("HOME", self.home());
+        cmd.env("TMPDIR", self.home());
         cmd.arg("prompt");
     }
 }


### PR DESCRIPTION
## Summary

- `~/.cache/merge-ready/`（HOME 依存）から `std::env::temp_dir()` ベースのパスに変更
  - macOS: `$TMPDIR/merge-ready/`（OS がユーザーごとに割り当てる専用ディレクトリ）
  - Linux: `/tmp/merge-ready-{uid}/`（`/proc/self` の `uid()` で複数ユーザー衝突を防止）
- `src/infra/tmp_cache_dir.rs` に共通の `cache_dir()` を実装、`cache.rs` と `refresh_lock.rs` で参照
- `HOME` 非依存となったため `cache_path()` / `lock_path()` の戻り値を `Option<PathBuf>` → `PathBuf` に簡略化
- E2E テストと benches は `TMPDIR` 環境変数でキャッシュパスを制御するよう更新

## Test plan

- [x] `cargo build` 通過
- [x] `cargo clippy -- -D warnings` 通過
- [x] `cargo test` 全 48 テスト通過（E2E 含む）

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)