### PR TITLE
perf: git 子プロセスを廃止し .git ディレクトリ直接読み取りで repo_id を生成

### DIFF
--- a/benches/hot_path.rs
+++ b/benches/hot_path.rs
@@ -10,7 +10,7 @@
 
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -22,9 +22,10 @@ use tempfile::TempDir;
 struct BenchEnv {
     bin_dir: TempDir,
     tmp_dir: TempDir,
+    /// 最小限の `.git` 構造を持つ偽リポジトリルート
+    repo_dir: TempDir,
 }
 
-const FAKE_TOPLEVEL: &str = "/fake/bench/repo";
 const FAKE_BRANCH: &str = "main";
 const OPEN_MERGE_READY_JSON: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}"#;
 const CI_PASS_JSON: &str = r#"[{"bucket":"pass","state":"SUCCESS","name":"ci","link":""}]"#;
@@ -32,8 +33,8 @@ const CI_PASS_JSON: &str = r#"[{"bucket":"pass","state":"SUCCESS","name":"ci","l
 /// FNV-1a ハッシュで repo_id を生成する（`infra::repo_id::path_to_id` と同じアルゴリズム）
 ///
 /// キーは `"<toplevel>\0<branch>"` の形式で生成する。
-fn bench_repo_id() -> String {
-    let input = format!("{FAKE_TOPLEVEL}\0{FAKE_BRANCH}");
+fn compute_repo_id(toplevel: &Path, branch: &str) -> String {
+    let input = format!("{}\0{}", toplevel.display(), branch);
     let mut hash: u64 = 14_695_981_039_346_656_037;
     for byte in input.bytes() {
         hash ^= byte as u64;
@@ -42,21 +43,9 @@ fn bench_repo_id() -> String {
     format!("{hash:016x}")
 }
 
-/// フェイクの gh/git バイナリを含むベンチマーク環境を構築する
+/// フェイクの gh バイナリと最小限の git リポジトリ構造を含むベンチマーク環境を構築する
 fn setup_bench_env() -> BenchEnv {
     let bin_dir = TempDir::new().expect("bin_dir");
-    let home_dir = TempDir::new().expect("home_dir");
-
-    // fake git: rev-parse --show-toplevel と branch --show-current が必要
-    let git_script = format!(
-        "#!/bin/sh\n\
-         case \"$*\" in\n\
-           *'rev-parse --show-toplevel'*) echo '{FAKE_TOPLEVEL}'; exit 0 ;;\n\
-           *'branch --show-current'*) echo '{FAKE_BRANCH}'; exit 0 ;;\n\
-           *) exit 0 ;;\n\
-         esac\n"
-    );
-    write_executable(&bin_dir.path().join("git"), &git_script);
 
     // fake gh（即時応答）
     // JSON に `{}` が含まれているため format! ではなく文字列連結を使用
@@ -68,7 +57,22 @@ fn setup_bench_env() -> BenchEnv {
     write_executable(&bin_dir.path().join("gh"), &gh_script);
 
     let tmp_dir = TempDir::new().expect("tmp_dir");
-    BenchEnv { bin_dir, tmp_dir }
+
+    // 最小限の git リポジトリ構造（.git/HEAD のみ）
+    let repo_dir = TempDir::new().expect("repo_dir");
+    let git_dir = repo_dir.path().join(".git");
+    fs::create_dir_all(&git_dir).expect("create .git");
+    fs::write(
+        git_dir.join("HEAD"),
+        format!("ref: refs/heads/{FAKE_BRANCH}\n"),
+    )
+    .expect("write HEAD");
+
+    BenchEnv {
+        bin_dir,
+        tmp_dir,
+        repo_dir,
+    }
 }
 
 fn write_executable(path: &PathBuf, content: &str) {
@@ -124,7 +128,7 @@ fn now_secs() -> u64 {
 /// `prompt` サブコマンドでキャッシュファイルを読み込んで返すパスのみを計測する。
 fn bench_cache_hit(c: &mut Criterion) {
     let env = setup_bench_env();
-    let repo_id = bench_repo_id();
+    let repo_id = compute_repo_id(env.repo_dir.path(), FAKE_BRANCH);
     let cache_path = env
         .tmp_dir
         .path()
@@ -141,12 +145,14 @@ fn bench_cache_hit(c: &mut Criterion) {
     let bin = binary_path();
     let path = path_env(&env);
     let tmpdir = env.tmp_dir.path().to_owned();
+    let repo_dir = env.repo_dir.path().to_owned();
 
     c.bench_function("cache_hit", |b| {
         b.iter(|| {
             Command::new(&bin)
                 .env("PATH", &path)
                 .env("TMPDIR", &tmpdir)
+                .current_dir(&repo_dir)
                 .arg("prompt")
                 .output()
                 .expect("merge-ready failed")
@@ -163,12 +169,14 @@ fn bench_no_cache_direct(c: &mut Criterion) {
     let bin = binary_path();
     let path = path_env(&env);
     let tmpdir = env.tmp_dir.path().to_owned();
+    let repo_dir = env.repo_dir.path().to_owned();
 
     c.bench_function("no_cache_direct", |b| {
         b.iter(|| {
             Command::new(&bin)
                 .env("PATH", &path)
                 .env("TMPDIR", &tmpdir)
+                .current_dir(&repo_dir)
                 .args(["prompt", "--no-cache"])
                 .output()
                 .expect("merge-ready failed")

--- a/src/infra/repo_id.rs
+++ b/src/infra/repo_id.rs
@@ -74,7 +74,11 @@ mod tests {
         let main_repo = TempDir::new().unwrap();
         let worktree_meta = main_repo.path().join(".git/worktrees/feat");
         fs::create_dir_all(&worktree_meta).unwrap();
-        fs::write(worktree_meta.join("HEAD"), format!("ref: refs/heads/{branch}\n")).unwrap();
+        fs::write(
+            worktree_meta.join("HEAD"),
+            format!("ref: refs/heads/{branch}\n"),
+        )
+        .unwrap();
 
         let worktree = TempDir::new().unwrap();
         fs::write(

--- a/src/infra/repo_id.rs
+++ b/src/infra/repo_id.rs
@@ -1,32 +1,46 @@
-use std::process::Command;
+use std::fs;
+use std::path::{Path, PathBuf};
 
-/// `git rev-parse --show-toplevel` と `git branch --show-current` からキャッシュキーを生成する。
+/// `.git` ディレクトリを直接読み取ってキャッシュキーを生成する。
 ///
 /// worktree パスとブランチ名の組み合わせをハッシュ化することで、
 /// 同一 worktree でのブランチ切り替えや複数 worktree の並走でも衝突しない。
-/// 取得失敗時（非 git ディレクトリ、git がない等）は `None` を返す。
+/// 取得失敗時（非 git ディレクトリ等）は `None` を返す。
 pub fn get() -> Option<String> {
-    let toplevel = run_git(&["rev-parse", "--show-toplevel"])?;
-    // detached HEAD の場合は空文字列になるが、それでもキーとして一意に扱う
-    let branch = run_git(&["branch", "--show-current"]).unwrap_or_default();
-    Some(path_to_id(&format!("{toplevel}\0{branch}")))
+    let cwd = std::env::current_dir().ok()?;
+    let (toplevel, git_dir) = find_git_dir(&cwd)?;
+    let branch = read_head(&git_dir).unwrap_or_default();
+    Some(path_to_id(&format!("{}\0{}", toplevel.display(), branch)))
 }
 
-fn run_git(args: &[&str]) -> Option<String> {
-    let output = Command::new("git").args(args).output().ok()?;
-
-    if !output.status.success() {
-        return None;
+/// カレントディレクトリから上に向かって `.git` を探す。
+///
+/// worktree またはサブモジュールの場合 `.git` はファイル（`"gitdir: <path>"` 形式）。
+fn find_git_dir(start: &Path) -> Option<(PathBuf, PathBuf)> {
+    let mut dir = start.to_path_buf();
+    loop {
+        let dot_git = dir.join(".git");
+        if dot_git.is_dir() {
+            return Some((dir, dot_git));
+        }
+        if dot_git.is_file() {
+            // worktree / サブモジュール: "gitdir: /path/to/.git/worktrees/xxx"
+            let content = fs::read_to_string(&dot_git).ok()?;
+            let real = content.strip_prefix("gitdir: ")?.trim();
+            return Some((dir, PathBuf::from(real)));
+        }
+        if !dir.pop() {
+            return None; // git リポジトリ外
+        }
     }
+}
 
-    let s = String::from_utf8_lossy(&output.stdout);
-    let s = s.trim();
-
-    if s.is_empty() {
-        return None;
-    }
-
-    Some(s.to_owned())
+/// `.git/HEAD` から `"ref: refs/heads/main"` → `"main"` を取り出す。
+///
+/// detached HEAD は `None` を返す（`unwrap_or_default()` で `""` になる）。
+fn read_head(git_dir: &Path) -> Option<String> {
+    let content = fs::read_to_string(git_dir.join("HEAD")).ok()?;
+    Some(content.strip_prefix("ref: refs/heads/")?.trim().to_owned())
 }
 
 /// パス文字列を FNV-1a ハッシュでファイルシステムセーフな ID に変換する。
@@ -40,4 +54,109 @@ pub fn path_to_id(path: &str) -> String {
         hash = hash.wrapping_mul(1_099_511_628_211);
     }
     format!("{hash:016x}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn make_normal_repo(branch: &str) -> TempDir {
+        let dir = TempDir::new().unwrap();
+        let git_dir = dir.path().join(".git");
+        fs::create_dir(&git_dir).unwrap();
+        fs::write(git_dir.join("HEAD"), format!("ref: refs/heads/{branch}\n")).unwrap();
+        dir
+    }
+
+    // worktree: main_repo/.git/worktrees/feat/HEAD + worktree/.git (file)
+    fn make_worktree(branch: &str) -> (TempDir, TempDir) {
+        let main_repo = TempDir::new().unwrap();
+        let worktree_meta = main_repo.path().join(".git/worktrees/feat");
+        fs::create_dir_all(&worktree_meta).unwrap();
+        fs::write(worktree_meta.join("HEAD"), format!("ref: refs/heads/{branch}\n")).unwrap();
+
+        let worktree = TempDir::new().unwrap();
+        fs::write(
+            worktree.path().join(".git"),
+            format!("gitdir: {}\n", worktree_meta.display()),
+        )
+        .unwrap();
+        (main_repo, worktree)
+    }
+
+    // ── find_git_dir ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn normal_repo_finds_toplevel_and_git_dir() {
+        let repo = make_normal_repo("main");
+        let (toplevel, git_dir) = find_git_dir(repo.path()).unwrap();
+        assert_eq!(toplevel, repo.path());
+        assert_eq!(git_dir, repo.path().join(".git"));
+    }
+
+    #[test]
+    fn subdirectory_finds_repo_root() {
+        let repo = make_normal_repo("main");
+        let subdir = repo.path().join("a/b/c");
+        fs::create_dir_all(&subdir).unwrap();
+        let (toplevel, _) = find_git_dir(&subdir).unwrap();
+        assert_eq!(toplevel, repo.path());
+    }
+
+    #[test]
+    fn worktree_finds_toplevel_and_real_git_dir() {
+        let (main_repo, worktree) = make_worktree("feat");
+        let (toplevel, git_dir) = find_git_dir(worktree.path()).unwrap();
+        assert_eq!(toplevel, worktree.path());
+        assert_eq!(git_dir, main_repo.path().join(".git/worktrees/feat"));
+    }
+
+    #[test]
+    fn outside_repo_returns_none() {
+        let dir = TempDir::new().unwrap(); // .git のない空ディレクトリ
+        assert!(find_git_dir(dir.path()).is_none());
+    }
+
+    // ── read_head ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn read_head_returns_branch_name() {
+        let repo = make_normal_repo("main");
+        let branch = read_head(&repo.path().join(".git")).unwrap();
+        assert_eq!(branch, "main");
+    }
+
+    #[test]
+    fn detached_head_returns_none() {
+        let dir = TempDir::new().unwrap();
+        let git_dir = dir.path().join(".git");
+        fs::create_dir(&git_dir).unwrap();
+        fs::write(git_dir.join("HEAD"), "abc123deadbeef\n").unwrap();
+        assert!(read_head(&git_dir).is_none());
+    }
+
+    #[test]
+    fn worktree_head_returns_branch_name() {
+        let (main_repo, _worktree) = make_worktree("feat");
+        let git_dir = main_repo.path().join(".git/worktrees/feat");
+        let branch = read_head(&git_dir).unwrap();
+        assert_eq!(branch, "feat");
+    }
+
+    // ── path_to_id ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn different_paths_produce_different_ids() {
+        let a = path_to_id("/home/user/repos/my_project\0main");
+        let b = path_to_id("/home/user/repos/my/project\0main");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn same_input_produces_same_id() {
+        let a = path_to_id("/repo\0main");
+        let b = path_to_id("/repo\0main");
+        assert_eq!(a, b);
+    }
 }

--- a/tests/e2e/cache.rs
+++ b/tests/e2e/cache.rs
@@ -13,24 +13,6 @@ use super::helpers::TestEnv;
 /// merge-ready のバイナリ名
 const BIN: &str = "merge-ready";
 
-/// fake git が返すワークツリーパス（`git rev-parse --show-toplevel` の戻り値）
-const FAKE_TOPLEVEL: &str = "/fake/repo";
-/// fake git が返すブランチ名（`git branch --show-current` の戻り値）
-const FAKE_BRANCH: &str = "main";
-
-/// FNV-1a ハッシュで生成される repo_id（`infra::repo_id::path_to_id` と同じアルゴリズム）
-///
-/// キーは `"<toplevel>\0<branch>"` の形式で生成する。
-fn fake_repo_id() -> String {
-    let input = format!("{FAKE_TOPLEVEL}\0{FAKE_BRANCH}");
-    let mut hash: u64 = 14_695_981_039_346_656_037;
-    for byte in input.bytes() {
-        hash ^= byte as u64;
-        hash = hash.wrapping_mul(1_099_511_628_211);
-    }
-    format!("{hash:016x}")
-}
-
 /// マージ可能な PR の `gh pr view` JSON（キャッシュテスト用の最小セット）
 /// `baseRefName` / `headRefName` を空にすることで `gh repo view` 呼び出しを回避し
 /// ブランチ同期を "Clean" として扱う
@@ -67,7 +49,7 @@ fn test_refresh_mode_writes_cache() {
     cmd.assert().success().stdout(predicate::str::is_empty());
 
     // state.json が作成されていること
-    let state_path = state_json_path(env.home());
+    let state_path = state_json_path(&env);
     assert!(
         state_path.exists(),
         "state.json should be created by --refresh at: {}",
@@ -75,7 +57,7 @@ fn test_refresh_mode_writes_cache() {
     );
 
     // state.json の内容確認
-    let state = read_state_json(env.home()).expect("state.json should be parseable");
+    let state = read_state_json(&env).expect("state.json should be parseable");
     let fetched_at: u64 = state["fetched_at_secs"]
         .as_u64()
         .expect("fetched_at_secs should be u64");
@@ -94,7 +76,7 @@ fn test_cache_fresh_returns_cached_output() {
     let cached_output = "✓ merge-ready";
 
     // state.json を手動で書き込む（fetched_at_secs = now）
-    write_state_json(env.home(), cached_output, now_secs());
+    write_state_json(&env, cached_output, now_secs());
 
     // 壊れた fake gh を使っても、キャッシュが使われるためエラーにならない
     let broken_env = TestEnv::with_error("gh is broken", 1);
@@ -102,6 +84,7 @@ fn test_cache_fresh_returns_cached_output() {
     cmd.env("PATH", broken_env.path_env()); // 壊れた gh の PATH
     cmd.env("HOME", env.home()); // HOME は env.home() で隔離
     cmd.env("TMPDIR", env.home()); // キャッシュが存在する TMPDIR
+    cmd.current_dir(env.repo_dir.path()); // repo_id を一致させる
     cmd.arg("prompt"); // キャッシュ有効モード
 
     cmd.assert()
@@ -118,7 +101,7 @@ fn test_cache_stale_returns_cached_output() {
     let cached_output = "✗ conflict";
 
     // stale_ttl(5秒)より古いキャッシュを作成: now - 10秒
-    write_state_json(env.home(), cached_output, now_secs() - 10);
+    write_state_json(&env, cached_output, now_secs() - 10);
 
     let mut cmd = Command::cargo_bin(BIN).unwrap();
     env.apply_with_cache(&mut cmd);
@@ -135,7 +118,7 @@ fn test_stale_cache_is_updated_by_refresh() {
     let stale_output = "✗ conflict";
 
     // stale_ttl より古いキャッシュを作成
-    write_state_json(env.home(), stale_output, now_secs() - 10);
+    write_state_json(&env, stale_output, now_secs() - 10);
 
     // prompt --refresh を明示的に実行
     let mut refresh_cmd = Command::cargo_bin(BIN).unwrap();
@@ -147,7 +130,7 @@ fn test_stale_cache_is_updated_by_refresh() {
         .stdout(predicate::str::is_empty());
 
     // state.json の fetched_at_secs が更新されていること
-    let state = read_state_json(env.home()).expect("state.json should exist");
+    let state = read_state_json(&env).expect("state.json should exist");
     let new_fetched_at: u64 = state["fetched_at_secs"]
         .as_u64()
         .expect("fetched_at_secs should be u64");
@@ -157,7 +140,7 @@ fn test_stale_cache_is_updated_by_refresh() {
     );
 }
 
-// ── git remote 取得不可 ─────────────────────────────────────────────────
+// ── git リポジトリ外 ────────────────────────────────────────────────────
 
 /// git リポジトリでない場合、何も出力せずキャッシュも作らない
 #[test]
@@ -169,7 +152,7 @@ fn test_no_git_remote_shows_nothing() {
     cmd.assert().success().stdout(predicate::str::is_empty());
 
     // キャッシュが作成されていないこと
-    let state_path = state_json_path(env.home());
+    let state_path = state_json_path(&env);
     assert!(
         !state_path.exists(),
         "state.json should NOT be created when not in a git repository"
@@ -200,15 +183,15 @@ fn cache_dir_name() -> String {
     "merge-ready".to_owned()
 }
 
-fn state_json_path(tmpdir: &std::path::Path) -> std::path::PathBuf {
-    tmpdir
+fn state_json_path(env: &TestEnv) -> std::path::PathBuf {
+    env.home()
         .join(cache_dir_name())
-        .join(format!("{}.json", fake_repo_id()))
+        .join(format!("{}.json", env.repo_id()))
 }
 
-/// 指定した tmpdir の下に state.json を書き込む
-fn write_state_json(tmpdir: &std::path::Path, output: &str, fetched_at_secs: u64) {
-    let state_path = state_json_path(tmpdir);
+/// 指定した env の state.json を書き込む
+fn write_state_json(env: &TestEnv, output: &str, fetched_at_secs: u64) {
+    let state_path = state_json_path(env);
     if let Some(parent) = state_path.parent() {
         fs::create_dir_all(parent).unwrap();
     }
@@ -216,7 +199,7 @@ fn write_state_json(tmpdir: &std::path::Path, output: &str, fetched_at_secs: u64
     fs::write(&state_path, content).unwrap();
 }
 
-fn read_state_json(tmpdir: &std::path::Path) -> Option<serde_json::Value> {
-    let content = fs::read_to_string(state_json_path(tmpdir)).ok()?;
+fn read_state_json(env: &TestEnv) -> Option<serde_json::Value> {
+    let content = fs::read_to_string(state_json_path(env)).ok()?;
     serde_json::from_str(&content).ok()
 }

--- a/tests/e2e/helpers.rs
+++ b/tests/e2e/helpers.rs
@@ -1,7 +1,10 @@
 //! テスト環境ヘルパー
 //!
-//! 各テストが独立した `bin_dir`（`fake gh` / `fake git`）と `home_dir` を持つ。
+//! 各テストが独立した `bin_dir`（`fake gh`）と `home_dir` / `repo_dir` を持つ。
 //! テストを並列実行してもキャッシュやエラーログが競合しない。
+//!
+//! `repo_id` は `.git` ディレクトリを直接読み取って生成されるため、
+//! バイナリの実行ディレクトリを `repo_dir` に設定することで再現性を確保する。
 
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
@@ -10,44 +13,73 @@ use tempfile::{TempDir, tempdir};
 
 /// テスト実行環境を完全に隔離するヘルパー。
 pub struct TestEnv {
-    /// `fake gh` / `fake git` を配置する一時ディレクトリ
+    /// `fake gh` を配置する一時ディレクトリ
     pub bin_dir: TempDir,
     /// 隔離された `HOME` 兼 `TMPDIR`（キャッシュ・ロックファイルの書き込み先）
     pub home_dir: TempDir,
+    /// バイナリを実行するワーキングディレクトリ（`.git/HEAD` を持つ偽リポジトリ）
+    /// `None` = `.git` のない空ディレクトリ（git リポジトリ外シナリオ）
+    pub repo_dir: TempDir,
+    /// `repo_dir/.git/HEAD` に書き込んだブランチ名
+    pub branch: String,
 }
 
-/// `git` の引数別に固定値を返すフェイクスクリプト
-const FAKE_GIT_SCRIPT: &str = r#"#!/bin/sh
-case "$*" in
-  *'rev-parse --is-inside-work-tree'*)
-    echo 'true'; exit 0 ;;
-  *'rev-parse --show-toplevel'*)
-    echo '/fake/repo'; exit 0 ;;
-  *'branch --show-current'*)
-    echo 'main'; exit 0 ;;
-  *'rev-parse --abbrev-ref HEAD'*)
-    echo 'main'; exit 0 ;;
-  *'remote get-url origin'*)
-    echo 'https://github.com/test/repo.git'; exit 0 ;;
-  *)
-    exit 0 ;;
-esac
-"#;
+/// テスト用の固定ブランチ名
+const DEFAULT_BRANCH: &str = "main";
 
 impl TestEnv {
-    /// `bin_dir` に `fake git` を配置し、`home_dir` を生成する共通初期化処理
-    fn setup() -> (TempDir, TempDir) {
+    /// `bin_dir` / `home_dir` と最小限の `.git` 構造を持つ `repo_dir` を生成する共通初期化処理。
+    fn setup_with_git() -> (TempDir, TempDir, TempDir) {
         let bin_dir = tempdir().expect("failed to create bin_dir");
         let home_dir = tempdir().expect("failed to create home_dir");
-        write_executable(bin_dir.path().join("git"), FAKE_GIT_SCRIPT);
-        (bin_dir, home_dir)
+        let repo_dir = tempdir().expect("failed to create repo_dir");
+
+        // 最小限の .git 構造（HEAD のみ）
+        let git_dir = repo_dir.path().join(".git");
+        fs::create_dir_all(&git_dir).expect("create .git");
+        fs::write(
+            git_dir.join("HEAD"),
+            format!("ref: refs/heads/{DEFAULT_BRANCH}\n"),
+        )
+        .expect("write HEAD");
+
+        (bin_dir, home_dir, repo_dir)
+    }
+
+    /// `.git` のない空のワーキングディレクトリを生成する（git リポジトリ外シナリオ用）。
+    fn setup_without_git() -> (TempDir, TempDir, TempDir) {
+        let bin_dir = tempdir().expect("failed to create bin_dir");
+        let home_dir = tempdir().expect("failed to create home_dir");
+        let repo_dir = tempdir().expect("failed to create repo_dir");
+        // repo_dir に .git を作らない
+        (bin_dir, home_dir, repo_dir)
+    }
+
+    /// FNV-1a ハッシュで `repo_id` を計算する（`infra::repo_id::path_to_id` と同じアルゴリズム）。
+    ///
+    /// キーは `"<toplevel>\0<branch>"` の形式。
+    /// macOS では `/var/folders/...` が `/private/var/folders/...` のシンボリックリンクのため、
+    /// `std::env::current_dir()` が返す正規化パスと一致させるために `canonicalize()` を使用する。
+    pub fn repo_id(&self) -> String {
+        let canonical = self
+            .repo_dir
+            .path()
+            .canonicalize()
+            .unwrap_or_else(|_| self.repo_dir.path().to_path_buf());
+        let input = format!("{}\0{}", canonical.display(), self.branch);
+        let mut hash: u64 = 14_695_981_039_346_656_037;
+        for byte in input.bytes() {
+            hash ^= byte as u64;
+            hash = hash.wrapping_mul(1_099_511_628_211);
+        }
+        format!("{hash:016x}")
     }
 
     /// 正常系: `pr view` / `pr checks` それぞれの JSON を返す `fake gh` を配置する。
     ///
     /// `pr_checks_json` が `None` の場合、`gh pr checks` が呼ばれると `exit 1` を返す。
     pub fn new(pr_view_json: &str, pr_checks_json: Option<&str>) -> Self {
-        let (bin_dir, home_dir) = Self::setup();
+        let (bin_dir, home_dir, repo_dir) = Self::setup_with_git();
 
         let checks_block = match pr_checks_json {
             Some(j) => format!("printf '%s' '{j}'\n"),
@@ -74,7 +106,12 @@ impl TestEnv {
         );
 
         write_executable(bin_dir.path().join("gh"), &script);
-        Self { bin_dir, home_dir }
+        Self {
+            bin_dir,
+            home_dir,
+            repo_dir,
+            branch: DEFAULT_BRANCH.to_owned(),
+        }
     }
 
     /// compare API が `behind_by` を返すシナリオ用の `fake gh` を配置する。
@@ -85,7 +122,7 @@ impl TestEnv {
         pr_checks_json: Option<&str>,
         behind_by: u64,
     ) -> Self {
-        let (bin_dir, home_dir) = Self::setup();
+        let (bin_dir, home_dir, repo_dir) = Self::setup_with_git();
 
         let checks_block = match pr_checks_json {
             Some(j) => format!("printf '%s' '{j}'\n"),
@@ -115,7 +152,12 @@ impl TestEnv {
         );
 
         write_executable(bin_dir.path().join("gh"), &script);
-        Self { bin_dir, home_dir }
+        Self {
+            bin_dir,
+            home_dir,
+            repo_dir,
+            branch: DEFAULT_BRANCH.to_owned(),
+        }
     }
 
     /// Compare API がエラーを返すシナリオ用の `fake gh` を配置する。
@@ -123,7 +165,7 @@ impl TestEnv {
     /// `pr view` JSON には `baseRefName` / `headRefName` を含めること（API を呼ぶため）。
     /// `repo view` は正常に応答し、`api compare` のみ `exit 1` で失敗する。
     pub fn with_compare_error(pr_view_json: &str, pr_checks_json: Option<&str>) -> Self {
-        let (bin_dir, home_dir) = Self::setup();
+        let (bin_dir, home_dir, repo_dir) = Self::setup_with_git();
 
         let checks_block = match pr_checks_json {
             Some(j) => format!("printf '%s' '{j}'\n"),
@@ -154,21 +196,31 @@ impl TestEnv {
         );
 
         write_executable(bin_dir.path().join("gh"), &script);
-        Self { bin_dir, home_dir }
+        Self {
+            bin_dir,
+            home_dir,
+            repo_dir,
+            branch: DEFAULT_BRANCH.to_owned(),
+        }
     }
 
     /// エラー系: 指定した `exit_code` と `stderr` メッセージを返す `fake gh` を配置する。
     pub fn with_error(stderr_msg: &str, exit_code: u8) -> Self {
-        let (bin_dir, home_dir) = Self::setup();
+        let (bin_dir, home_dir, repo_dir) = Self::setup_with_git();
         let script = format!("#!/bin/sh\nprintf '%s' '{stderr_msg}' >&2\nexit {exit_code}\n");
         write_executable(bin_dir.path().join("gh"), &script);
-        Self { bin_dir, home_dir }
+        Self {
+            bin_dir,
+            home_dir,
+            repo_dir,
+            branch: DEFAULT_BRANCH.to_owned(),
+        }
     }
 
     /// CI 未設定シナリオ: `gh pr view` は成功するが `gh pr checks` が
     /// `"no checks reported"` で `exit 1` を返す。
     pub fn with_no_ci_checks(pr_view_json: &str) -> Self {
-        let (bin_dir, home_dir) = Self::setup();
+        let (bin_dir, home_dir, repo_dir) = Self::setup_with_git();
         let script = format!(
             "#!/bin/sh\n\
              case \"$*\" in\n\
@@ -186,44 +238,39 @@ impl TestEnv {
              esac\n"
         );
         write_executable(bin_dir.path().join("gh"), &script);
-        Self { bin_dir, home_dir }
+        Self {
+            bin_dir,
+            home_dir,
+            repo_dir,
+            branch: DEFAULT_BRANCH.to_owned(),
+        }
     }
 
-    /// `gh` バイナリが `PATH` に存在しないシナリオ（`fake git` と `home_dir` は用意する）
+    /// `gh` バイナリが `PATH` に存在しないシナリオ（`home_dir` / `repo_dir` は用意する）
     pub fn without_gh() -> Self {
-        let (bin_dir, home_dir) = Self::setup();
-        Self { bin_dir, home_dir }
+        let (bin_dir, home_dir, repo_dir) = Self::setup_with_git();
+        Self {
+            bin_dir,
+            home_dir,
+            repo_dir,
+            branch: DEFAULT_BRANCH.to_owned(),
+        }
     }
 
-    /// `git remote get-url origin` が失敗するシナリオ（キャッシュ対象外のテスト用）
+    /// git リポジトリ外シナリオ（`.git` のない空ディレクトリで実行）
     pub fn without_git_remote() -> Self {
-        let bin_dir = tempdir().expect("failed to create bin_dir");
-        let home_dir = tempdir().expect("failed to create home_dir");
+        let (bin_dir, home_dir, repo_dir) = Self::setup_without_git();
 
-        // rev-parse --show-toplevel のみ exit 1、他は通常通り
-        let git_script = r#"#!/bin/sh
-case "$*" in
-  *'rev-parse --is-inside-work-tree'*)
-    echo 'true'; exit 0 ;;
-  *'rev-parse --show-toplevel'*)
-    echo 'not a git repository' >&2; exit 1 ;;
-  *'branch --show-current'*)
-    echo 'main'; exit 0 ;;
-  *'rev-parse --abbrev-ref HEAD'*)
-    echo 'main'; exit 0 ;;
-  *'remote get-url origin'*)
-    echo 'https://github.com/test/repo.git'; exit 0 ;;
-  *)
-    exit 0 ;;
-esac
-"#;
-        write_executable(bin_dir.path().join("git"), git_script);
-
-        // gh は応答しないようにする（呼ばれるべきでない）
+        // gh は呼ばれるべきでない
         let gh_script = "#!/bin/sh\necho 'gh should not be called' >&2\nexit 1\n";
         write_executable(bin_dir.path().join("gh"), gh_script);
 
-        Self { bin_dir, home_dir }
+        Self {
+            bin_dir,
+            home_dir,
+            repo_dir,
+            branch: DEFAULT_BRANCH.to_owned(),
+        }
     }
 
     /// `PATH` 文字列を返す（`bin_dir` を先頭に追加）
@@ -236,20 +283,22 @@ esac
         self.home_dir.path()
     }
 
-    /// `Command` に `PATH` / `HOME` / `TMPDIR` をまとめて設定する（キャッシュ無効）
+    /// `Command` に `PATH` / `HOME` / `TMPDIR` / `current_dir` をまとめて設定する（キャッシュ無効）
     ///
     /// サブコマンドと `--no-cache` は呼び出し元が追加すること。
     pub fn apply(&self, cmd: &mut assert_cmd::Command) {
         cmd.env("PATH", self.path_env());
         cmd.env("HOME", self.home());
         cmd.env("TMPDIR", self.home());
+        cmd.current_dir(self.repo_dir.path());
     }
 
-    /// `Command` に `PATH` / `HOME` / `TMPDIR` / `prompt` サブコマンドをまとめて設定する（キャッシュ有効）
+    /// `Command` に `PATH` / `HOME` / `TMPDIR` / `current_dir` / `prompt` サブコマンドをまとめて設定する（キャッシュ有効）
     pub fn apply_with_cache(&self, cmd: &mut assert_cmd::Command) {
         cmd.env("PATH", self.path_env());
         cmd.env("HOME", self.home());
         cmd.env("TMPDIR", self.home());
+        cmd.current_dir(self.repo_dir.path());
         cmd.arg("prompt");
     }
 }


### PR DESCRIPTION
## Summary

- `src/infra/repo_id.rs` を `std::process::Command` なし実装に書き換え。`.git/HEAD` を直接読み取ることで `git rev-parse` / `git branch` の子プロセス 2 回（計 ~10–20ms）を削除
- 通常リポジトリ・worktree・detached HEAD・リポジトリ外のすべてのケースに対応
- 単体テスト 8 件、既存 E2E テスト全 57 件パス

## Changes

| ファイル | 変更内容 |
|---|---|
| `src/infra/repo_id.rs` | `find_git_dir()` / `read_head()` を新規実装、単体テスト追加 |
| `tests/e2e/helpers.rs` | fake git スクリプトを廃止 → `repo_dir: TempDir` + `.git/HEAD` 構造に変更 |
| `tests/e2e/cache.rs` | `fake_repo_id()` を `env.repo_id()` に置き換え |
| `benches/hot_path.rs` | fake git を削除し `current_dir` ベースの偽リポジトリに変更 |

## Performance

| | 変更前 | 変更後 |
|---|---|---|
| `git rev-parse` | 子プロセス ~5–10ms | なし |
| `git branch` | 子プロセス ~5–10ms | なし |
| `.git` 読み取り | — | ディレクトリ走査 + ファイル read ~数μs |
| 外部依存 | `git` コマンド必須 | 標準ライブラリのみ |

## Test plan

- [x] `cargo test` — 57 passed (0 failed)
- [x] 通常リポジトリ: `.git/` がディレクトリ → `toplevel` はその親
- [x] worktree: `.git` がファイル（`gitdir: <path>`）→ `<path>/HEAD` を読む
- [x] detached HEAD: `HEAD` が `ref: refs/heads/` で始まらない → 空文字列
- [x] git リポジトリ外: `.git` が見つからない → `None`
- [x] サブディレクトリから上向き探索

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)