### PR TITLE
fix: Changelog 重複エントリの解消と Main ブランチへのマージ戦略の統一

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -28,13 +28,9 @@ split_commits = false
 commit_preprocessors = [
   # 1. Issue 番号をリンクに変換
   { pattern = '#([0-9]+)', replace = "[#${1}](https://github.com/toshiki670/merge-ready/issues/${1})" },
-  # 2. スカッシュマージ: "feat: 説明 ([#N](link))" → "merge_TYPE: 説明 ([PR #N](pull-link))"
-  #    GitHub デフォルトのスカッシュマージ形式 "feat: 説明 (#N)" が対象
-  #    ステップ1 で #N がリンク化された後にマッチさせる
-  { pattern = '^(feat|fix|perf)(?:\([^)]+\))?: ([^\n]+) \(\[#([0-9]+)\]\([^)]+\)\)', replace = "merge_${1}: ${2} ([PR #${3}](https://github.com/toshiki670/merge-ready/pull/${3}))" },
-  # 3. マージコミットの feat/fix/perf PR を "merge_TYPE: 説明 (PR リンク)" に変換
+  # 2. マージコミットの feat/fix/perf PR を "merge_TYPE: 説明 (PR リンク)" に変換
   { pattern = '(?s)Merge pull request \[#([0-9]+)\]\([^)]+\) from [^\n]+\n\n(feat|fix|perf)(?:\([^)]+\))?: ([^\n]+).*', replace = "merge_${2}: ${3} ([PR #${1}](https://github.com/toshiki670/merge-ready/pull/${1}))" },
-  # 4. その他の PR を skip マーカーに変換
+  # 3. その他の PR を skip マーカーに変換
   { pattern = '(?s)Merge pull request \[#([0-9]+)\]\([^)]+\) from [^\n]+.*', replace = "merge_other:" },
 ]
 commit_parsers = [


### PR DESCRIPTION
## Summary

- `cliff.toml` の squash-merge 専用 `commit_preprocessors` Step 2 を削除し、`git-cliff --unreleased` での重複エントリを解消
- GitHub Ruleset "Main protect" を更新し、`main` ブランチへのマージ方式を merge commit のみに制限
- Epic/Feature ブランチへの squash-merge 許可設定を調査し、追加設定不要と確認

## 詳細

### cliff.toml の変更

旧 Step 2 はスカッシュマージ形式 `"feat: 説明 (#N)"` を `merge_TYPE:` に変換するルールだったが、このリポジトリは merge commit を採用しているため不要。削除により `cd86f2a` のような `(#36)` 付きコミットが誤ってスカッシュマージと認識される問題が修正される。

### GitHub Ruleset の変更

"Main protect" Ruleset の `allowed_merge_methods` を `["merge", "squash"]` → `["merge"]` に変更。

### Epic/Feature ブランチのマージ設定

リポジトリレベルでは squash / merge / rebase がすべて許可されており、`main` の Ruleset のみが merge に制限している。`epic/*` や `feat/*` ブランチには Ruleset がないため、デフォルトで squash-merge が使用可能。追加の Ruleset 設定は不要。

## Test plan

- [x] `git cliff --unreleased` で重複エントリが出ないことを確認済み
- [x] GitHub Ruleset で `main` の `allowed_merge_methods` が `["merge"]` のみになっていることを確認済み
- [x] Epic/Feature ブランチへの squash-merge はリポジトリレベル設定で許可されていることを確認済み

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)