### PR TITLE
feat: ~/.config/merge-ready.toml によるシンボル・フォーマットのカスタマイズ

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "configuration-domain"
+version = "0.1.0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "configuration-infrastructure"
+version = "0.1.0"
+dependencies = [
+ "configuration-domain",
+ "serde",
+ "toml",
+]
+
+[[package]]
 name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,6 +518,8 @@ version = "0.1.0"
 dependencies = [
  "assert_cmd",
  "clap",
+ "configuration-domain",
+ "configuration-infrastructure",
  "criterion",
  "merge-readiness-application",
  "merge-readiness-infrastructure",
@@ -773,6 +791,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -823,6 +850,47 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "unicode-ident"
@@ -1012,6 +1080,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,8 @@
 [workspace]
 members = [
     ".",
+    "contexts/configuration/domain",
+    "contexts/configuration/infrastructure",
     "contexts/merge_readiness/domain",
     "contexts/merge_readiness/application",
     "contexts/merge_readiness/infrastructure",
@@ -19,6 +21,7 @@ homepage = "https://github.com/toshiki670/merge-ready"
 clap = { version = "4", features = ["derive", "cargo"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml = "0.8"
 tempfile = "3"
 
 [workspace.lints.rust]
@@ -44,6 +47,8 @@ workspace = true
 
 [dependencies]
 clap.workspace = true
+configuration-domain = { path = "contexts/configuration/domain" }
+configuration-infrastructure = { path = "contexts/configuration/infrastructure" }
 merge-readiness-application = { path = "contexts/merge_readiness/application" }
 merge-readiness-infrastructure = { path = "contexts/merge_readiness/infrastructure" }
 merge-readiness-interface = { path = "contexts/merge_readiness/interface" }

--- a/contexts/configuration/domain/Cargo.toml
+++ b/contexts/configuration/domain/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "configuration-domain"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+serde.workspace = true

--- a/contexts/configuration/domain/src/config.rs
+++ b/contexts/configuration/domain/src/config.rs
@@ -1,0 +1,38 @@
+use serde::Deserialize;
+
+const DEFAULT_FORMAT: &str = "$symbol $label";
+
+#[derive(Deserialize, Default)]
+pub struct Config {
+    pub merge_ready: Option<TokenConfig>,
+    pub conflict: Option<TokenConfig>,
+    pub update_branch: Option<TokenConfig>,
+    pub sync_unknown: Option<TokenConfig>,
+    pub ci_fail: Option<TokenConfig>,
+    pub ci_action: Option<TokenConfig>,
+    pub review: Option<TokenConfig>,
+    pub error: Option<ErrorConfig>,
+}
+
+#[derive(Deserialize, Default)]
+pub struct TokenConfig {
+    pub symbol: Option<String>,
+    pub label: Option<String>,
+    pub format: Option<String>,
+}
+
+impl TokenConfig {
+    pub fn render(&self, default_symbol: &str, default_label: &str) -> String {
+        let symbol = self.symbol.as_deref().unwrap_or(default_symbol);
+        let label = self.label.as_deref().unwrap_or(default_label);
+        let fmt = self.format.as_deref().unwrap_or(DEFAULT_FORMAT);
+        fmt.replace("$symbol", symbol).replace("$label", label)
+    }
+}
+
+#[derive(Deserialize, Default)]
+pub struct ErrorConfig {
+    pub auth_required: Option<TokenConfig>,
+    pub rate_limited: Option<TokenConfig>,
+    pub api_error: Option<TokenConfig>,
+}

--- a/contexts/configuration/domain/src/config.rs
+++ b/contexts/configuration/domain/src/config.rs
@@ -22,6 +22,7 @@ pub struct TokenConfig {
 }
 
 impl TokenConfig {
+    #[must_use]
     pub fn render(&self, default_symbol: &str, default_label: &str) -> String {
         let symbol = self.symbol.as_deref().unwrap_or(default_symbol);
         let label = self.label.as_deref().unwrap_or(default_label);

--- a/contexts/configuration/domain/src/lib.rs
+++ b/contexts/configuration/domain/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod config;
+pub mod repository;

--- a/contexts/configuration/domain/src/repository.rs
+++ b/contexts/configuration/domain/src/repository.rs
@@ -1,0 +1,5 @@
+use crate::config::Config;
+
+pub trait ConfigRepository {
+    fn load(&self) -> Config;
+}

--- a/contexts/configuration/infrastructure/Cargo.toml
+++ b/contexts/configuration/infrastructure/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "configuration-infrastructure"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+configuration-domain = { path = "../domain" }
+serde.workspace = true
+toml.workspace = true

--- a/contexts/configuration/infrastructure/src/lib.rs
+++ b/contexts/configuration/infrastructure/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod toml_loader;

--- a/contexts/configuration/infrastructure/src/toml_loader.rs
+++ b/contexts/configuration/infrastructure/src/toml_loader.rs
@@ -1,18 +1,25 @@
 use configuration_domain::{config::Config, repository::ConfigRepository};
+use std::path::PathBuf;
 
 pub struct TomlConfigRepository;
 
 impl ConfigRepository for TomlConfigRepository {
     fn load(&self) -> Config {
-        let Some(home) = std::env::var_os("HOME") else {
+        let Some(path) = config_path() else {
             return Config::default();
         };
-        let path = std::path::PathBuf::from(home)
-            .join(".config")
-            .join("merge-ready.toml");
         let Ok(content) = std::fs::read_to_string(path) else {
             return Config::default();
         };
         toml::from_str(&content).unwrap_or_default()
     }
+}
+
+// XDG_CONFIG_HOME が設定されていればそちらを優先し、なければ $HOME/.config にフォールバックする。
+fn config_path() -> Option<PathBuf> {
+    if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
+        return Some(PathBuf::from(xdg).join("merge-ready.toml"));
+    }
+    let home = std::env::var_os("HOME")?;
+    Some(PathBuf::from(home).join(".config").join("merge-ready.toml"))
 }

--- a/contexts/configuration/infrastructure/src/toml_loader.rs
+++ b/contexts/configuration/infrastructure/src/toml_loader.rs
@@ -1,0 +1,18 @@
+use configuration_domain::{config::Config, repository::ConfigRepository};
+
+pub struct TomlConfigRepository;
+
+impl ConfigRepository for TomlConfigRepository {
+    fn load(&self) -> Config {
+        let Some(home) = std::env::var_os("HOME") else {
+            return Config::default();
+        };
+        let path = std::path::PathBuf::from(home)
+            .join(".config")
+            .join("merge-ready.toml");
+        let Ok(content) = std::fs::read_to_string(path) else {
+            return Config::default();
+        };
+        toml::from_str(&content).unwrap_or_default()
+    }
+}

--- a/contexts/merge_readiness/interface/src/cli/prompt/direct.rs
+++ b/contexts/merge_readiness/interface/src/cli/prompt/direct.rs
@@ -3,10 +3,9 @@ use merge_readiness_application::{
     ReviewRepository, errors::ErrorLogger,
 };
 
-use crate::presentation;
+use crate::presentation::{Presenter, PresentationConfigPort};
 
-/// gh を直接呼んで結果を stdout に出力する（キャッシュを使わない）。
-pub fn run<C, L>(client: &C, logger: &L)
+pub fn run<C, L, P>(client: &C, logger: &L, config_port: P)
 where
     C: PrStateRepository
         + BranchSyncRepository
@@ -15,10 +14,11 @@ where
         + MergeReadinessRepository
         + Sync,
     L: ErrorLogger + Sync,
+    P: PresentationConfigPort + Sync,
 {
-    let presenter = presentation::Presenter;
+    let presenter = Presenter::new(config_port);
     let tokens = merge_readiness_application::run(client, logger, &presenter);
     if !tokens.is_empty() {
-        presentation::display(&tokens);
+        presenter.display(&tokens);
     }
 }

--- a/contexts/merge_readiness/interface/src/cli/prompt/direct.rs
+++ b/contexts/merge_readiness/interface/src/cli/prompt/direct.rs
@@ -3,7 +3,7 @@ use merge_readiness_application::{
     ReviewRepository, errors::ErrorLogger,
 };
 
-use crate::presentation::{Presenter, PresentationConfigPort};
+use crate::presentation::{PresentationConfigPort, Presenter};
 
 pub fn run<C, L, P>(client: &C, logger: &L, config_port: P)
 where

--- a/contexts/merge_readiness/interface/src/presentation.rs
+++ b/contexts/merge_readiness/interface/src/presentation.rs
@@ -3,42 +3,35 @@ use merge_readiness_application::{
     errors::{ErrorPresenter, ErrorToken},
 };
 
-/// `OutputToken` を表示文字列に変換する
-fn render(token: &OutputToken) -> &'static str {
-    match token {
-        OutputToken::Conflict => "✗ conflict",
-        OutputToken::UpdateBranch => "✗ update-branch",
-        OutputToken::SyncUnknown => "? sync-unknown",
-        OutputToken::CiFail => "✗ ci-fail",
-        OutputToken::CiAction => "⚠ ci-action",
-        OutputToken::ReviewRequested => "⚠ review",
-        OutputToken::MergeReady => "✓ merge-ready",
+pub trait PresentationConfigPort {
+    fn render_token(&self, token: &OutputToken) -> String;
+    fn render_error_token(&self, token: ErrorToken) -> String;
+}
+
+pub struct Presenter<C: PresentationConfigPort> {
+    config_port: C,
+}
+
+impl<C: PresentationConfigPort> Presenter<C> {
+    pub fn new(config_port: C) -> Self {
+        Self { config_port }
+    }
+
+    pub fn render_to_string(&self, tokens: &[OutputToken]) -> String {
+        tokens
+            .iter()
+            .map(|t| self.config_port.render_token(t))
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    pub fn display(&self, tokens: &[OutputToken]) {
+        print!("{}", self.render_to_string(tokens));
     }
 }
 
-/// `ErrorToken` を表示文字列に変換する
-fn render_error(token: ErrorToken) -> &'static str {
-    match token {
-        ErrorToken::AuthRequired => "! gh auth login",
-        ErrorToken::RateLimited => "✗ rate-limited",
-        ErrorToken::ApiError => "✗ api-error",
-    }
-}
-
-/// トークン列を文字列に変換する
-pub fn render_to_string(tokens: &[OutputToken]) -> String {
-    tokens.iter().map(render).collect::<Vec<_>>().join(" ")
-}
-
-/// トークン列を `stdout` に出力する（末尾改行なし）
-pub fn display(tokens: &[OutputToken]) {
-    print!("{}", render_to_string(tokens));
-}
-
-pub struct Presenter;
-
-impl ErrorPresenter for Presenter {
+impl<C: PresentationConfigPort> ErrorPresenter for Presenter<C> {
     fn show_error(&self, token: ErrorToken) {
-        print!("{}", render_error(token));
+        print!("{}", self.config_port.render_error_token(token));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,60 +52,68 @@ impl ConfigAdapter {
 
 impl PresentationConfigPort for ConfigAdapter {
     fn render_token(&self, token: &OutputToken) -> String {
-        let e = TokenConfig::default();
+        let default = TokenConfig::default();
         match token {
             OutputToken::MergeReady => self
                 .0
                 .merge_ready
                 .as_ref()
-                .unwrap_or(&e)
+                .unwrap_or(&default)
                 .render("✓", "merge-ready"),
             OutputToken::Conflict => self
                 .0
                 .conflict
                 .as_ref()
-                .unwrap_or(&e)
+                .unwrap_or(&default)
                 .render("✗", "conflict"),
             OutputToken::UpdateBranch => self
                 .0
                 .update_branch
                 .as_ref()
-                .unwrap_or(&e)
+                .unwrap_or(&default)
                 .render("✗", "update-branch"),
             OutputToken::SyncUnknown => self
                 .0
                 .sync_unknown
                 .as_ref()
-                .unwrap_or(&e)
+                .unwrap_or(&default)
                 .render("?", "sync-unknown"),
-            OutputToken::CiFail => self.0.ci_fail.as_ref().unwrap_or(&e).render("✗", "ci-fail"),
+            OutputToken::CiFail => self
+                .0
+                .ci_fail
+                .as_ref()
+                .unwrap_or(&default)
+                .render("✗", "ci-fail"),
             OutputToken::CiAction => self
                 .0
                 .ci_action
                 .as_ref()
-                .unwrap_or(&e)
+                .unwrap_or(&default)
                 .render("⚠", "ci-action"),
-            OutputToken::ReviewRequested => {
-                self.0.review.as_ref().unwrap_or(&e).render("⚠", "review")
-            }
+            OutputToken::ReviewRequested => self
+                .0
+                .review
+                .as_ref()
+                .unwrap_or(&default)
+                .render("⚠", "review"),
         }
     }
 
     fn render_error_token(&self, token: ErrorToken) -> String {
-        let e = TokenConfig::default();
+        let default = TokenConfig::default();
         let err = self.0.error.as_ref();
         match token {
             ErrorToken::AuthRequired => err
-                .and_then(|e| e.auth_required.as_ref())
-                .unwrap_or(&e)
+                .and_then(|ec| ec.auth_required.as_ref())
+                .unwrap_or(&default)
                 .render("!", "gh auth login"),
             ErrorToken::RateLimited => err
-                .and_then(|e| e.rate_limited.as_ref())
-                .unwrap_or(&e)
+                .and_then(|ec| ec.rate_limited.as_ref())
+                .unwrap_or(&default)
                 .render("✗", "rate-limited"),
             ErrorToken::ApiError => err
-                .and_then(|e| e.api_error.as_ref())
-                .unwrap_or(&e)
+                .and_then(|ec| ec.api_error.as_ref())
+                .unwrap_or(&default)
                 .render("✗", "api-error"),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,19 @@ mod cached;
 mod refresh;
 
 use clap::{CommandFactory, Parser, Subcommand};
-use merge_readiness_application::prompt::{ExecutionMode, RepoIdPort};
+use configuration_domain::config::TokenConfig;
+use configuration_domain::repository::ConfigRepository as _;
+use configuration_infrastructure::toml_loader::TomlConfigRepository;
+use merge_readiness_application::{
+    OutputToken,
+    errors::ErrorToken,
+    prompt::{ExecutionMode, RepoIdPort},
+};
 use merge_readiness_infrastructure::{gh::GhClient, logger::Logger};
-use merge_readiness_interface::cli::prompt::{self, AFTER_HELP, PromptArgs};
+use merge_readiness_interface::{
+    cli::prompt::{self, AFTER_HELP, PromptArgs},
+    presentation::PresentationConfigPort,
+};
 
 #[derive(Parser)]
 #[command(
@@ -32,6 +42,39 @@ impl RepoIdPort for InfraRepoIdPort {
     }
 }
 
+pub(crate) struct ConfigAdapter(configuration_domain::config::Config);
+
+impl ConfigAdapter {
+    pub(crate) fn load() -> Self {
+        Self(TomlConfigRepository.load())
+    }
+}
+
+impl PresentationConfigPort for ConfigAdapter {
+    fn render_token(&self, token: &OutputToken) -> String {
+        let e = TokenConfig::default();
+        match token {
+            OutputToken::MergeReady => self.0.merge_ready.as_ref().unwrap_or(&e).render("✓", "merge-ready"),
+            OutputToken::Conflict => self.0.conflict.as_ref().unwrap_or(&e).render("✗", "conflict"),
+            OutputToken::UpdateBranch => self.0.update_branch.as_ref().unwrap_or(&e).render("✗", "update-branch"),
+            OutputToken::SyncUnknown => self.0.sync_unknown.as_ref().unwrap_or(&e).render("?", "sync-unknown"),
+            OutputToken::CiFail => self.0.ci_fail.as_ref().unwrap_or(&e).render("✗", "ci-fail"),
+            OutputToken::CiAction => self.0.ci_action.as_ref().unwrap_or(&e).render("⚠", "ci-action"),
+            OutputToken::ReviewRequested => self.0.review.as_ref().unwrap_or(&e).render("⚠", "review"),
+        }
+    }
+
+    fn render_error_token(&self, token: ErrorToken) -> String {
+        let e = TokenConfig::default();
+        let err = self.0.error.as_ref();
+        match token {
+            ErrorToken::AuthRequired => err.and_then(|e| e.auth_required.as_ref()).unwrap_or(&e).render("!", "gh auth login"),
+            ErrorToken::RateLimited => err.and_then(|e| e.rate_limited.as_ref()).unwrap_or(&e).render("✗", "rate-limited"),
+            ErrorToken::ApiError => err.and_then(|e| e.api_error.as_ref()).unwrap_or(&e).render("✗", "api-error"),
+        }
+    }
+}
+
 fn main() {
     let repo_id_port = InfraRepoIdPort;
     let Some(mode) = (match Cli::parse().command {
@@ -46,7 +89,11 @@ fn main() {
 
     match mode {
         ExecutionMode::Direct => {
-            merge_readiness_interface::cli::prompt::direct::run(&GhClient::new(), &Logger);
+            merge_readiness_interface::cli::prompt::direct::run(
+                &GhClient::new(),
+                &Logger,
+                ConfigAdapter::load(),
+            );
         }
         ExecutionMode::Cached => cached::run(),
         ExecutionMode::BackgroundRefresh { repo_id } => refresh::run(&repo_id),

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,13 +54,40 @@ impl PresentationConfigPort for ConfigAdapter {
     fn render_token(&self, token: &OutputToken) -> String {
         let e = TokenConfig::default();
         match token {
-            OutputToken::MergeReady => self.0.merge_ready.as_ref().unwrap_or(&e).render("✓", "merge-ready"),
-            OutputToken::Conflict => self.0.conflict.as_ref().unwrap_or(&e).render("✗", "conflict"),
-            OutputToken::UpdateBranch => self.0.update_branch.as_ref().unwrap_or(&e).render("✗", "update-branch"),
-            OutputToken::SyncUnknown => self.0.sync_unknown.as_ref().unwrap_or(&e).render("?", "sync-unknown"),
+            OutputToken::MergeReady => self
+                .0
+                .merge_ready
+                .as_ref()
+                .unwrap_or(&e)
+                .render("✓", "merge-ready"),
+            OutputToken::Conflict => self
+                .0
+                .conflict
+                .as_ref()
+                .unwrap_or(&e)
+                .render("✗", "conflict"),
+            OutputToken::UpdateBranch => self
+                .0
+                .update_branch
+                .as_ref()
+                .unwrap_or(&e)
+                .render("✗", "update-branch"),
+            OutputToken::SyncUnknown => self
+                .0
+                .sync_unknown
+                .as_ref()
+                .unwrap_or(&e)
+                .render("?", "sync-unknown"),
             OutputToken::CiFail => self.0.ci_fail.as_ref().unwrap_or(&e).render("✗", "ci-fail"),
-            OutputToken::CiAction => self.0.ci_action.as_ref().unwrap_or(&e).render("⚠", "ci-action"),
-            OutputToken::ReviewRequested => self.0.review.as_ref().unwrap_or(&e).render("⚠", "review"),
+            OutputToken::CiAction => self
+                .0
+                .ci_action
+                .as_ref()
+                .unwrap_or(&e)
+                .render("⚠", "ci-action"),
+            OutputToken::ReviewRequested => {
+                self.0.review.as_ref().unwrap_or(&e).render("⚠", "review")
+            }
         }
     }
 
@@ -68,9 +95,18 @@ impl PresentationConfigPort for ConfigAdapter {
         let e = TokenConfig::default();
         let err = self.0.error.as_ref();
         match token {
-            ErrorToken::AuthRequired => err.and_then(|e| e.auth_required.as_ref()).unwrap_or(&e).render("!", "gh auth login"),
-            ErrorToken::RateLimited => err.and_then(|e| e.rate_limited.as_ref()).unwrap_or(&e).render("✗", "rate-limited"),
-            ErrorToken::ApiError => err.and_then(|e| e.api_error.as_ref()).unwrap_or(&e).render("✗", "api-error"),
+            ErrorToken::AuthRequired => err
+                .and_then(|e| e.auth_required.as_ref())
+                .unwrap_or(&e)
+                .render("!", "gh auth login"),
+            ErrorToken::RateLimited => err
+                .and_then(|e| e.rate_limited.as_ref())
+                .unwrap_or(&e)
+                .render("✗", "rate-limited"),
+            ErrorToken::ApiError => err
+                .and_then(|e| e.api_error.as_ref())
+                .unwrap_or(&e)
+                .render("✗", "api-error"),
         }
     }
 }

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -1,14 +1,12 @@
 use merge_readiness_infrastructure::{cache, gh::GhClient, logger::Logger, refresh_lock};
-use merge_readiness_interface::presentation;
+use merge_readiness_interface::presentation::Presenter;
 
-/// gh を直接呼んでキャッシュを更新する（stdout に出力しない）。
-///
-/// `repo_id` は親プロセスから `--repo-id` 引数で受け取る。
-/// git から再取得しないため、ブランチ切替・git 一時失敗時でもロック解放が保証される。
+use crate::ConfigAdapter;
+
 pub fn run(repo_id: &str) {
     let tokens = merge_readiness_application::prompt::fetch_output(&GhClient::new(), &Logger);
     if let Some(tokens) = tokens {
-        let output = presentation::render_to_string(&tokens);
+        let output = Presenter::new(ConfigAdapter::load()).render_to_string(&tokens);
         cache::write(repo_id, &output);
     }
     refresh_lock::release(repo_id);

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -3,6 +3,10 @@ use merge_readiness_interface::presentation::Presenter;
 
 use crate::ConfigAdapter;
 
+/// gh を直接呼んでキャッシュを更新する（stdout に出力しない）。
+///
+/// `repo_id` は親プロセスから `--repo-id` 引数で受け取る。
+/// git から再取得しないため、ブランチ切替・git 一時失敗時でもロック解放が保証される。
 pub fn run(repo_id: &str) {
     let tokens = merge_readiness_application::prompt::fetch_output(&GhClient::new(), &Logger);
     if let Some(tokens) = tokens {

--- a/tests/e2e/config.rs
+++ b/tests/e2e/config.rs
@@ -1,0 +1,106 @@
+//! 設定ファイル（`~/.config/merge-ready.toml`）の E2E テスト
+//!
+//! symbol / label / format のカスタマイズ、部分設定のフォールバック、
+//! 設定ファイルなし・不正 TOML でのデフォルト出力を検証する。
+
+use super::helpers::TestEnv;
+use assert_cmd::Command;
+
+const MERGE_READY_JSON: &str =
+    r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED"}"#;
+const CHECKS_PASS_JSON: &str = r#"[{"bucket":"pass","state":"SUCCESS"}]"#;
+const CONFLICT_JSON: &str =
+    r#"{"state":"OPEN","isDraft":false,"mergeable":"CONFLICTING","mergeStateStatus":"DIRTY","reviewDecision":"APPROVED"}"#;
+
+fn cmd(env: &TestEnv) -> Command {
+    let mut c = Command::cargo_bin("merge-ready").unwrap();
+    env.apply(&mut c);
+    c.args(["prompt", "--no-cache"]);
+    c
+}
+
+/// 設定ファイルなし → デフォルトのシンボル・ラベルで出力
+#[test]
+fn test_no_config_uses_defaults() {
+    let env = TestEnv::new(MERGE_READY_JSON, Some(CHECKS_PASS_JSON));
+    cmd(&env)
+        .assert()
+        .success()
+        .stdout("✓ merge-ready")
+        .stderr("");
+}
+
+/// `symbol` のみカスタマイズ → カスタムシンボル + デフォルトラベル
+#[test]
+fn test_custom_symbol() {
+    let env = TestEnv::new(MERGE_READY_JSON, Some(CHECKS_PASS_JSON));
+    env.write_config("[merge_ready]\nsymbol = \"★\"");
+    cmd(&env)
+        .assert()
+        .success()
+        .stdout("★ merge-ready")
+        .stderr("");
+}
+
+/// `label` のみカスタマイズ → デフォルトシンボル + カスタムラベル
+#[test]
+fn test_custom_label() {
+    let env = TestEnv::new(MERGE_READY_JSON, Some(CHECKS_PASS_JSON));
+    env.write_config("[merge_ready]\nlabel = \"OK!\"");
+    cmd(&env)
+        .assert()
+        .success()
+        .stdout("✓ OK!")
+        .stderr("");
+}
+
+/// `format` をカスタマイズ → 順序・区切りが変わる
+#[test]
+fn test_custom_format() {
+    let env = TestEnv::new(MERGE_READY_JSON, Some(CHECKS_PASS_JSON));
+    env.write_config("[merge_ready]\nformat = \"[$symbol] $label\"");
+    cmd(&env)
+        .assert()
+        .success()
+        .stdout("[✓] merge-ready")
+        .stderr("");
+}
+
+/// `symbol` / `label` / `format` を全部カスタマイズ
+#[test]
+fn test_all_fields_custom() {
+    let env = TestEnv::new(MERGE_READY_JSON, Some(CHECKS_PASS_JSON));
+    env.write_config(
+        "[merge_ready]\nsymbol = \"✅\"\nlabel = \"lgtm\"\nformat = \"$label $symbol\"",
+    );
+    cmd(&env)
+        .assert()
+        .success()
+        .stdout("lgtm ✅")
+        .stderr("");
+}
+
+/// 一部セクションのみ設定 → 未設定セクションはデフォルト値にフォールバック
+#[test]
+fn test_partial_config_other_tokens_use_defaults() {
+    let env = TestEnv::new(CONFLICT_JSON, Some(CHECKS_PASS_JSON));
+    // conflict のみカスタマイズ、他はデフォルト
+    env.write_config("[conflict]\nsymbol = \"✘\"");
+    cmd(&env)
+        .assert()
+        .success()
+        .stdout("✘ conflict")
+        .stderr("");
+}
+
+/// 不正な TOML → デフォルト出力にフォールバック（パニックしない）
+#[test]
+fn test_invalid_toml_falls_back_to_defaults() {
+    let env = TestEnv::new(MERGE_READY_JSON, Some(CHECKS_PASS_JSON));
+    env.write_config("this is not valid toml ][[[");
+    cmd(&env)
+        .assert()
+        .success()
+        .stdout("✓ merge-ready")
+        .stderr("");
+}

--- a/tests/e2e/config.rs
+++ b/tests/e2e/config.rs
@@ -90,3 +90,48 @@ fn test_invalid_toml_falls_back_to_defaults() {
         .stdout("✓ merge-ready")
         .stderr("");
 }
+
+/// XDG_CONFIG_HOME が設定されている場合、そちらから設定を読む
+#[test]
+fn test_xdg_config_home_is_used() {
+    use std::fs;
+    use tempfile::tempdir;
+
+    let env = TestEnv::new(MERGE_READY_JSON, Some(CHECKS_PASS_JSON));
+    let xdg_dir = tempdir().expect("tempdir");
+    fs::write(
+        xdg_dir.path().join("merge-ready.toml"),
+        "[merge_ready]\nsymbol = \"★\"",
+    )
+    .expect("write config");
+
+    let mut c = Command::cargo_bin("merge-ready").unwrap();
+    env.apply(&mut c);
+    c.env("XDG_CONFIG_HOME", xdg_dir.path());
+    c.args(["prompt", "--no-cache"]);
+    c.assert().success().stdout("★ merge-ready").stderr("");
+}
+
+/// XDG_CONFIG_HOME と HOME が両方ある場合、XDG_CONFIG_HOME が優先される
+#[test]
+fn test_xdg_config_home_takes_precedence_over_home() {
+    use std::fs;
+    use tempfile::tempdir;
+
+    let env = TestEnv::new(MERGE_READY_JSON, Some(CHECKS_PASS_JSON));
+    // HOME 側にも設定を置くが XDG 側が優先されるはず
+    env.write_config("[merge_ready]\nsymbol = \"✓\"");
+
+    let xdg_dir = tempdir().expect("tempdir");
+    fs::write(
+        xdg_dir.path().join("merge-ready.toml"),
+        "[merge_ready]\nsymbol = \"★\"",
+    )
+    .expect("write xdg config");
+
+    let mut c = Command::cargo_bin("merge-ready").unwrap();
+    env.apply(&mut c);
+    c.env("XDG_CONFIG_HOME", xdg_dir.path());
+    c.args(["prompt", "--no-cache"]);
+    c.assert().success().stdout("★ merge-ready").stderr("");
+}

--- a/tests/e2e/config.rs
+++ b/tests/e2e/config.rs
@@ -6,11 +6,9 @@
 use super::helpers::TestEnv;
 use assert_cmd::Command;
 
-const MERGE_READY_JSON: &str =
-    r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED"}"#;
+const MERGE_READY_JSON: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED"}"#;
 const CHECKS_PASS_JSON: &str = r#"[{"bucket":"pass","state":"SUCCESS"}]"#;
-const CONFLICT_JSON: &str =
-    r#"{"state":"OPEN","isDraft":false,"mergeable":"CONFLICTING","mergeStateStatus":"DIRTY","reviewDecision":"APPROVED"}"#;
+const CONFLICT_JSON: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"CONFLICTING","mergeStateStatus":"DIRTY","reviewDecision":"APPROVED"}"#;
 
 fn cmd(env: &TestEnv) -> Command {
     let mut c = Command::cargo_bin("merge-ready").unwrap();
@@ -47,11 +45,7 @@ fn test_custom_symbol() {
 fn test_custom_label() {
     let env = TestEnv::new(MERGE_READY_JSON, Some(CHECKS_PASS_JSON));
     env.write_config("[merge_ready]\nlabel = \"OK!\"");
-    cmd(&env)
-        .assert()
-        .success()
-        .stdout("✓ OK!")
-        .stderr("");
+    cmd(&env).assert().success().stdout("✓ OK!").stderr("");
 }
 
 /// `format` をカスタマイズ → 順序・区切りが変わる
@@ -73,11 +67,7 @@ fn test_all_fields_custom() {
     env.write_config(
         "[merge_ready]\nsymbol = \"✅\"\nlabel = \"lgtm\"\nformat = \"$label $symbol\"",
     );
-    cmd(&env)
-        .assert()
-        .success()
-        .stdout("lgtm ✅")
-        .stderr("");
+    cmd(&env).assert().success().stdout("lgtm ✅").stderr("");
 }
 
 /// 一部セクションのみ設定 → 未設定セクションはデフォルト値にフォールバック
@@ -86,11 +76,7 @@ fn test_partial_config_other_tokens_use_defaults() {
     let env = TestEnv::new(CONFLICT_JSON, Some(CHECKS_PASS_JSON));
     // conflict のみカスタマイズ、他はデフォルト
     env.write_config("[conflict]\nsymbol = \"✘\"");
-    cmd(&env)
-        .assert()
-        .success()
-        .stdout("✘ conflict")
-        .stderr("");
+    cmd(&env).assert().success().stdout("✘ conflict").stderr("");
 }
 
 /// 不正な TOML → デフォルト出力にフォールバック（パニックしない）

--- a/tests/e2e/helpers.rs
+++ b/tests/e2e/helpers.rs
@@ -301,6 +301,14 @@ impl TestEnv {
         cmd.current_dir(self.repo_dir.path());
         cmd.arg("prompt");
     }
+
+    /// `~/.config/merge-ready.toml` に TOML 設定を書き込む。
+    pub fn write_config(&self, toml_content: &str) {
+        let config_dir = self.home_dir.path().join(".config");
+        fs::create_dir_all(&config_dir).expect("create .config");
+        fs::write(config_dir.join("merge-ready.toml"), toml_content)
+            .expect("write merge-ready.toml");
+    }
 }
 
 fn write_executable(path: impl AsRef<Path>, content: &str) {

--- a/tests/e2e/helpers.rs
+++ b/tests/e2e/helpers.rs
@@ -290,6 +290,7 @@ impl TestEnv {
         cmd.env("PATH", self.path_env());
         cmd.env("HOME", self.home());
         cmd.env("TMPDIR", self.home());
+        cmd.env_remove("XDG_CONFIG_HOME");
         cmd.current_dir(self.repo_dir.path());
     }
 

--- a/tests/e2e/helpers.rs
+++ b/tests/e2e/helpers.rs
@@ -290,7 +290,7 @@ impl TestEnv {
         cmd.env("PATH", self.path_env());
         cmd.env("HOME", self.home());
         cmd.env("TMPDIR", self.home());
-        cmd.env_remove("XDG_CONFIG_HOME");
+        cmd.env("XDG_CONFIG_HOME", self.home().join(".config"));
         cmd.current_dir(self.repo_dir.path());
     }
 

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -1,4 +1,5 @@
 mod branch_sync;
+mod config;
 mod cache;
 mod ci_checks;
 mod cli;

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -1,8 +1,8 @@
 mod branch_sync;
-mod config;
 mod cache;
 mod ci_checks;
 mod cli;
+mod config;
 mod errors;
 mod helpers;
 mod merge_ready;


### PR DESCRIPTION
## Summary

- `~/.config/merge-ready.toml` で各トークンの `symbol` / `label` / `format` をカスタマイズできるようにした（Starship 風 TOML 形式）
- Configuration を独立した Bounded Context（DDD）として `contexts/configuration/` に実装
- コンテキスト間通信は `InfraRepoIdPort` パターンに準拠し、bin の `ConfigAdapter` が唯一の結合点

## TOML 形式

```toml
[merge_ready]
symbol = "✓"
label  = "merge-ready"
format = "$symbol $label"  # 省略時デフォルト

[conflict]
symbol = "✗"

[error.auth_required]
symbol = "!"
label  = "gh auth login"
```

すべてのフィールドは省略可能。未設定はハードコードのデフォルト値にフォールバック。

## アーキテクチャ

- `contexts/configuration/domain/` — `Config` / `TokenConfig` / `ErrorConfig` 型定義、`ConfigRepository` trait
- `contexts/configuration/infrastructure/` — `TomlConfigRepository` がファイルシステムから読み込み
- `merge-readiness-interface` — `PresentationConfigPort` trait を定義（configuration に依存しない）
- `src/main.rs` — `ConfigAdapter` が `PresentationConfigPort` を実装してコンテキスト境界を越える

## Test plan

- [x] `rtk cargo build --workspace` が通る
- [x] `rtk cargo test --workspace` 全 62 テスト通過
- [x] E2E テスト 7 件追加（`tests/e2e/config.rs`）
  - 設定ファイルなし → デフォルト出力
  - symbol / label / format 各カスタマイズ
  - 一部セクションのみ設定 → 残りはデフォルトフォールバック
  - 不正 TOML → フォールバックしてパニックしない

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)