### PR TITLE
fix: release-plz で feat が minor バンプ・CHANGELOG に反映されない問題を修正

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -14,7 +14,7 @@ body = """
 {% for group, commits in commits | group_by(attribute="group") %}\
 ### {{ group | upper_first }}
 {% for commit in commits %}\
-- {% if commit.breaking %}[**BREAKING**] {% endif %}{{ commit.message | replace(from="merge_feat: ", to="") | replace(from="merge_fix: ", to="") | replace(from="merge_perf: ", to="") | upper_first }}
+- {% if commit.breaking %}[**BREAKING**] {% endif %}{{ commit.message | upper_first }}
 {% endfor %}
 {% endfor %}\
 """
@@ -26,19 +26,13 @@ conventional_commits = true
 filter_unconventional = false
 split_commits = false
 commit_preprocessors = [
-  # 1. Issue 番号をリンクに変換
   { pattern = '#([0-9]+)', replace = "[#${1}](https://github.com/toshiki670/merge-ready/issues/${1})" },
-  # 2. マージコミットの feat/fix/perf PR を "merge_TYPE: 説明 (PR リンク)" に変換
-  { pattern = '(?s)Merge pull request \[#([0-9]+)\]\([^)]+\) from [^\n]+\n\n(feat|fix|perf)(?:\([^)]+\))?: ([^\n]+).*', replace = "merge_${2}: ${3} ([PR #${1}](https://github.com/toshiki670/merge-ready/pull/${1}))" },
-  # 3. その他の PR を skip マーカーに変換
-  { pattern = '(?s)Merge pull request \[#([0-9]+)\]\([^)]+\) from [^\n]+.*', replace = "merge_other:" },
 ]
 commit_parsers = [
-  { message = "^merge_feat", group = "Features" },
-  { message = "^merge_fix",  group = "Bug Fixes" },
-  { message = "^merge_perf", group = "Performance" },
-  { message = "^merge_",     skip = true },
-  { message = ".*",          skip = true },
+  { message = "^feat",  group = "Features" },
+  { message = "^fix",   group = "Bug Fixes" },
+  { message = "^perf",  group = "Performance" },
+  { message = ".*",     skip = true },
 ]
 protect_breaking_commits = true
 filter_commits = true

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -4,3 +4,27 @@ changelog_config = "cliff.toml"
 git_release_enable = true
 git_release_draft = false
 pr_branch_prefix = "release-"
+
+[[package]]
+name = "configuration-domain"
+changelog_update = false
+
+[[package]]
+name = "configuration-infrastructure"
+changelog_update = false
+
+[[package]]
+name = "merge-readiness-domain"
+changelog_update = false
+
+[[package]]
+name = "merge-readiness-application"
+changelog_update = false
+
+[[package]]
+name = "merge-readiness-infrastructure"
+changelog_update = false
+
+[[package]]
+name = "merge-readiness-interface"
+changelog_update = false


### PR DESCRIPTION
## Summary

- `cliff.toml` のパーサーを `merge_feat:` 等の変換済み形式から `^feat`/`^fix`/`^perf` の通常 conventional commits 形式に変更
- `release-plz.toml` で contexts/ crate 6つに `changelog_update = false` を追加し、ルート以外への CHANGELOG.md 生成を抑制

## 根本原因

release-plz はマージコミットの **body（本文）** を git-cliff に渡さず、個別コミット (`feat: ...`, `fix: ...`) のみを渡す。旧 `cliff.toml` は merge commit 変換後の `merge_feat:` 等しか認識しなかったため、全コミットが skip され:

- CHANGELOG.md が空になる
- グループなし → デフォルトのパッチバンプ → v0.1.1（期待値: v0.2.0）

## Test plan

- [ ] この PR を main にマージ後、release-plz ワークフローを再実行する
- [ ] 生成される PR のタイトルが `chore: release v0.2.0` であることを確認
- [ ] CHANGELOG.md に Features / Bug Fixes / Performance セクションが生成されることを確認
- [ ] contexts/ crate に CHANGELOG.md が生成されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)