### PR TITLE
fix: pre-1.0 で feat が patch バンプになる問題を修正

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -4,6 +4,7 @@ changelog_config = "cliff.toml"
 git_release_enable = true
 git_release_draft = false
 pr_branch_prefix = "release-"
+features_always_increment_minor = true
 
 [[package]]
 name = "configuration-domain"


### PR DESCRIPTION
## Summary

- `release-plz.toml` の `[workspace]` に `features_always_increment_minor = true` を追加

## 根本原因

release-plz は **version 0.x.y のパッケージに対してデフォルトで `feat:` を patch バンプ** として扱う（Cargo の SemVer 慣例に準拠した挙動）。そのため `feat:` コミットがあっても v0.1.0 → v0.1.1 になっていた。

`features_always_increment_minor = true` を設定することで、pre-1.0 でも `feat:` → minor バンプ（v0.1.0 → v0.2.0）になる。

## Test plan

- [ ] この PR を main にマージ後、PR #48 を Close して release-plz ワークフローを再実行
- [ ] 生成される PR のタイトルが `chore: release v0.2.0` であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)