### PR TITLE
fix: CHANGELOG の二重リンク (#36 → [[#36](url)](url)) を修正

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -25,9 +25,7 @@ trim = true
 conventional_commits = true
 filter_unconventional = false
 split_commits = false
-commit_preprocessors = [
-  { pattern = '#([0-9]+)', replace = "[#${1}](https://github.com/toshiki670/merge-ready/issues/${1})" },
-]
+commit_preprocessors = []
 commit_parsers = [
   { message = "^feat",  group = "Features" },
   { message = "^fix",   group = "Bug Fixes" },


### PR DESCRIPTION
## Summary

- `cliff.toml` の `#([0-9]+)` → リンク変換 preprocessor を削除

## 根本原因

release-plz はコミットメッセージの `#N` を `[#N](url)` 形式に**事前変換**してから git-cliff に渡す。そこへ cliff.toml の preprocessor が再度 `#N` → `[#N](url)` を適用するため、`[#36](url)` の中の `#36` がさらに変換されて二重リンクになっていた。

```
release-plz 変換: (#36) → ([#36](url))
cliff preprocessor:  [#36](url) の #36 をさらに変換 → ([[#36](url)](url))  ← バグ
```

ローカルの `git cliff --unreleased` では release-plz の前変換がないため問題が出なかった。

## Test plan

- [ ] この PR を main にマージ
- [ ] PR #48 を Close して release-plz ワークフローを再実行
- [ ] 生成された CHANGELOG.md に二重リンクが含まれないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)