### PR TITLE
refactor: CHANGELOG をコミット SHA リンク + Issue リンク方式に変更

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -14,21 +14,12 @@ body = """
 {% for group, commits in commits | group_by(attribute="group") %}\
 ### {{ group | upper_first }}
 {% for commit in commits %}\
-{% if commit.remote.pr_number %}\
-- {% if commit.breaking %}[**BREAKING**] {% endif %}{{ commit.remote.pr_title | trim_start_matches(pat="feat!: ") | trim_start_matches(pat="fix!: ") | trim_start_matches(pat="perf!: ") | trim_start_matches(pat="feat: ") | trim_start_matches(pat="fix: ") | trim_start_matches(pat="perf: ") | upper_first }} ([#{{ commit.remote.pr_number }}](https://github.com/toshiki670/merge-ready/pull/{{ commit.remote.pr_number }}))
-{% else %}\
-- {% if commit.breaking %}[**BREAKING**] {% endif %}{{ commit.message | upper_first }}
-{% endif %}\
+- {% if commit.breaking %}[**BREAKING**] {% endif %}{{ commit.message | upper_first }} ([`{{ commit.id | truncate(length=7, end="") }}`](https://github.com/toshiki670/merge-ready/commit/{{ commit.id }}))
 {% endfor %}\
 {% endfor %}\
 """
 footer = ""
 trim = true
-
-[remote.github]
-owner = "toshiki670"
-repo = "merge-ready"
-token = "$GITHUB_TOKEN"
 
 [git]
 conventional_commits = true
@@ -36,13 +27,6 @@ filter_unconventional = false
 split_commits = false
 commit_preprocessors = []
 commit_parsers = [
-  # GitHub integration: PR タイトルでグループ分け（token 設定時）
-  { field = "github.pr_title", pattern = "^feat",  group = "Features" },
-  { field = "github.pr_title", pattern = "^fix",   group = "Bug Fixes" },
-  { field = "github.pr_title", pattern = "^perf",  group = "Performance" },
-  # PR タイトルが feat/fix/perf 以外（arch/chore/refactor/docs/style/ci）はスキップ
-  { field = "github.pr_title", pattern = ".*",     skip = true },
-  # Fallback: GitHub token 未設定時はコミットメッセージでグループ分け
   { message = "^feat",  group = "Features" },
   { message = "^fix",   group = "Bug Fixes" },
   { message = "^perf",  group = "Performance" },

--- a/cliff.toml
+++ b/cliff.toml
@@ -14,21 +14,35 @@ body = """
 {% for group, commits in commits | group_by(attribute="group") %}\
 ### {{ group | upper_first }}
 {% for commit in commits %}\
+{% if commit.remote.pr_number %}\
+- {% if commit.breaking %}[**BREAKING**] {% endif %}{{ commit.remote.pr_title | trim_start_matches(pat="feat!: ") | trim_start_matches(pat="fix!: ") | trim_start_matches(pat="perf!: ") | trim_start_matches(pat="feat: ") | trim_start_matches(pat="fix: ") | trim_start_matches(pat="perf: ") | upper_first }} ([#{{ commit.remote.pr_number }}](https://github.com/toshiki670/merge-ready/pull/{{ commit.remote.pr_number }}))
+{% else %}\
 - {% if commit.breaking %}[**BREAKING**] {% endif %}{{ commit.message | upper_first }}
-{% endfor %}
+{% endif %}\
+{% endfor %}\
 {% endfor %}\
 """
 footer = ""
 trim = true
 
+[remote.github]
+owner = "toshiki670"
+repo = "merge-ready"
+token = "$GITHUB_TOKEN"
+
 [git]
 conventional_commits = true
 filter_unconventional = false
 split_commits = false
-commit_preprocessors = [
-  { pattern = '#([0-9]+)', replace = "[#${1}](https://github.com/toshiki670/merge-ready/issues/${1})" },
-]
+commit_preprocessors = []
 commit_parsers = [
+  # GitHub integration: PR タイトルでグループ分け（token 設定時）
+  { field = "github.pr_title", pattern = "^feat",  group = "Features" },
+  { field = "github.pr_title", pattern = "^fix",   group = "Bug Fixes" },
+  { field = "github.pr_title", pattern = "^perf",  group = "Performance" },
+  # PR タイトルが feat/fix/perf 以外（arch/chore/refactor/docs/style/ci）はスキップ
+  { field = "github.pr_title", pattern = ".*",     skip = true },
+  # Fallback: GitHub token 未設定時はコミットメッセージでグループ分け
   { message = "^feat",  group = "Features" },
   { message = "^fix",   group = "Bug Fixes" },
   { message = "^perf",  group = "Performance" },

--- a/cliff.toml
+++ b/cliff.toml
@@ -14,7 +14,7 @@ body = """
 {% for group, commits in commits | group_by(attribute="group") %}\
 ### {{ group | upper_first }}
 {% for commit in commits %}\
-- {% if commit.breaking %}[**BREAKING**] {% endif %}{{ commit.message | upper_first }} ([`{{ commit.id | truncate(length=7, end="") }}`](https://github.com/toshiki670/merge-ready/commit/{{ commit.id }}))
+- {% if commit.breaking %}[**BREAKING**] {% endif %}{{ commit.message | upper_first }}{% for link in commit.links %} ([{{ link.text }}]({{ link.href }})){% endfor %} ([`{{ commit.id | truncate(length=7, end="") }}`](https://github.com/toshiki670/merge-ready/commit/{{ commit.id }}))
 {% endfor %}\
 {% endfor %}\
 """
@@ -23,9 +23,12 @@ trim = true
 
 [git]
 conventional_commits = true
-filter_unconventional = false
+filter_unconventional = true
 split_commits = false
 commit_preprocessors = []
+link_parsers = [
+  { pattern = "#(\\d+)", href = "https://github.com/toshiki670/merge-ready/issues/$1", text = "#$1" },
+]
 commit_parsers = [
   { message = "^feat",  group = "Features" },
   { message = "^fix",   group = "Bug Fixes" },


### PR DESCRIPTION
## Summary
- GitHub remote integration（API トークン必須）を廃止
- コミット SHA リンク（`commit/<sha>`）でコミット単位のエントリを生成
- `link_parsers` でコミットメッセージ中の `#N` を Issues リンクに変換

## 方針
PR リンクは GitHub API に依存しプロプライエタリ。コミット SHA はリポジトリ本体（Git 管理）であり GitHub はビュー層のみ。Issue 参照リンクは差し替え可能な外部参照として許容。

## Test plan
- [ ] `git cliff --unreleased` でトークンなし・コミット SHA リンク付きエントリが出力される
- [ ] コミットメッセージ中の `#N` が Issues リンクに変換される
- [ ] release-plz ワークフロー実行後に CHANGELOG.md が正しく更新される

🤖 Generated with [Claude Code](https://claude.com/claude-code)