### PR TITLE
fix: 内部クレートに publish = false を追加

### DIFF
--- a/contexts/configuration/domain/Cargo.toml
+++ b/contexts/configuration/domain/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "configuration-domain"
 version.workspace = true
+publish = false
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/contexts/configuration/infrastructure/Cargo.toml
+++ b/contexts/configuration/infrastructure/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "configuration-infrastructure"
 version.workspace = true
+publish = false
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/contexts/merge_readiness/application/Cargo.toml
+++ b/contexts/merge_readiness/application/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "merge-readiness-application"
 version.workspace = true
+publish = false
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/contexts/merge_readiness/domain/Cargo.toml
+++ b/contexts/merge_readiness/domain/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "merge-readiness-domain"
 version.workspace = true
+publish = false
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/contexts/merge_readiness/infrastructure/Cargo.toml
+++ b/contexts/merge_readiness/infrastructure/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "merge-readiness-infrastructure"
 version.workspace = true
+publish = false
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/contexts/merge_readiness/interface/Cargo.toml
+++ b/contexts/merge_readiness/interface/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "merge-readiness-interface"
 version.workspace = true
+publish = false
 edition.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## Summary
- 内部クレート 6 つ（configuration-domain/infrastructure、merge-readiness-domain/application/infrastructure/interface）に `publish = false` を追加
- crates.io へ誤 publish しようとして 403 で release が失敗していた問題を修正

## Root Cause
release-plz がワークスペース内の全クレートを publish 対象とするが、内部クレートには `publish = false` が設定されていなかった。

🤖 Generated with [Claude Code](https://claude.com/claude-code)