### PR TITLE
feat: 内部クレートの changelog_update を有効化

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -4,27 +4,3 @@ changelog_config = "cliff.toml"
 git_release_enable = true
 git_release_draft = false
 pr_branch_prefix = "release-"
-
-[[package]]
-name = "configuration-domain"
-changelog_update = false
-
-[[package]]
-name = "configuration-infrastructure"
-changelog_update = false
-
-[[package]]
-name = "merge-readiness-domain"
-changelog_update = false
-
-[[package]]
-name = "merge-readiness-application"
-changelog_update = false
-
-[[package]]
-name = "merge-readiness-infrastructure"
-changelog_update = false
-
-[[package]]
-name = "merge-readiness-interface"
-changelog_update = false


### PR DESCRIPTION
Closes #56

## Summary
- `release-plz.toml` から全 `[[package]]` エントリを削除
- 各内部クレートでクレート単位の CHANGELOG.md が生成されるようになる
- release-plz はそのクレートのファイルを変更したコミットのみを対象にするため、履歴が適切に分離される

🤖 Generated with [Claude Code](https://claude.com/claude-code)