### PR TITLE
refactor: ワークスペース共有バージョンを廃止し各クレートで独立管理

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/toshiki670/merge-ready"
@@ -32,7 +31,7 @@ pedantic = "warn"
 
 [package]
 name = "merge-ready"
-version.workspace = true
+version = "0.1.1"
 edition.workspace = true
 description = "Show pull request merge blockers as concise prompt tokens"
 license.workspace = true

--- a/contexts/configuration/domain/Cargo.toml
+++ b/contexts/configuration/domain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "configuration-domain"
-version.workspace = true
+version = "0.1.1"
 publish = false
 edition.workspace = true
 license.workspace = true

--- a/contexts/configuration/infrastructure/Cargo.toml
+++ b/contexts/configuration/infrastructure/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "configuration-infrastructure"
-version.workspace = true
+version = "0.1.1"
 publish = false
 edition.workspace = true
 license.workspace = true

--- a/contexts/merge_readiness/application/Cargo.toml
+++ b/contexts/merge_readiness/application/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merge-readiness-application"
-version.workspace = true
+version = "0.1.1"
 publish = false
 edition.workspace = true
 license.workspace = true

--- a/contexts/merge_readiness/domain/Cargo.toml
+++ b/contexts/merge_readiness/domain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merge-readiness-domain"
-version.workspace = true
+version = "0.1.1"
 publish = false
 edition.workspace = true
 license.workspace = true

--- a/contexts/merge_readiness/infrastructure/Cargo.toml
+++ b/contexts/merge_readiness/infrastructure/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merge-readiness-infrastructure"
-version.workspace = true
+version = "0.1.1"
 publish = false
 edition.workspace = true
 license.workspace = true

--- a/contexts/merge_readiness/interface/Cargo.toml
+++ b/contexts/merge_readiness/interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merge-readiness-interface"
-version.workspace = true
+version = "0.1.1"
 publish = false
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary
- `[workspace.package]` から `version` を削除
- 全 7 パッケージに個別の `version = "0.1.1"` を設定
- release-plz が各パッケージの変更を独立してバージョニングできるようになる

## 影響
- `merge-ready`: 引き続き release-plz で管理、crates.io に publish
- 内部 6 クレート: `publish = false` のため crates.io への publish なし、バージョンは release-plz が独立管理

🤖 Generated with [Claude Code](https://claude.com/claude-code)