### PR TITLE
fix: バージョンを 0.1.0 に戻す

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,22 +2,6 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.1.1] - 2026-04-18
-### Bug Fixes
-- Add toolchain input to dtolnay/rust-toolchain in CodeQL workflow ([`8074938`](https://github.com/toshiki670/merge-ready/commit/807493850b903e0a7f04b3d21b0d487c2a042e12))
-- Change CodeQL Rust build-mode from manual to none ([`31bad17`](https://github.com/toshiki670/merge-ready/commit/31bad175817ce11fc21c7dd84083a0b456e25a01))
-- Squash-merge 専用の commit_preprocessors Step 2 を削除 ([`510d2c7`](https://github.com/toshiki670/merge-ready/commit/510d2c7bf3d91c4c282eec4615cc1d18b21fb9c1))
-- テスト環境から XDG_CONFIG_HOME を除去して設定読み込みを隔離 ([`cddef71`](https://github.com/toshiki670/merge-ready/commit/cddef71d179c16d19557df65df71cb7e358034c6))
-- テスト環境で XDG_CONFIG_HOME を HOME/.config に固定 ([`2b2a3a3`](https://github.com/toshiki670/merge-ready/commit/2b2a3a37190eafdae81fc7cb351854bf2fd8894c))
-- Release-plz で feat が minor バンプ・CHANGELOG に反映されない問題を修正 ([`64e4227`](https://github.com/toshiki670/merge-ready/commit/64e4227fee87e0b2528dd75d6aa655821e569ed0))
-- Link_parsers を削除 ([#53](https://github.com/toshiki670/merge-ready/pull/53)) ([`2c6224e`](https://github.com/toshiki670/merge-ready/commit/2c6224e6ef16dfcbb53522459b0e52506194c23b))
-### Features
-- ~/.config/merge-ready.toml によるシンボル・フォーマットのカスタマイズ ([`f1b8759`](https://github.com/toshiki670/merge-ready/commit/f1b8759af2e0e45320129a39f97c9aadd32f294c))
-- XDG_CONFIG_HOME に対応した設定ファイルパス解決 ([`73252a7`](https://github.com/toshiki670/merge-ready/commit/73252a7e3d4814660a9354c30eed3970fb14decd))
-### Performance
-- キャッシュパスを tmpfs（/tmp）に変更 ([`a79d6bc`](https://github.com/toshiki670/merge-ready/commit/a79d6bc59b6900907020a9e1f94928da2bcaca57))
-- Git 子プロセスを廃止し .git ディレクトリ直接読み取りで repo_id を生成 ([#36](https://github.com/toshiki670/merge-ready/pull/36)) ([`cd86f2a`](https://github.com/toshiki670/merge-ready/commit/cd86f2adbdacce71e479a85bda0bf6425f2439f9))
-
 ## [0.1.0] - 2026-04-15
 ### Bug Fixes
 - Treat "no checks reported" as empty CI checks instead of api-error ([`bfebf5d`](https://github.com/toshiki670/merge-ready/commit/bfebf5d6f9996e6ca5db335bc04a7ac422c762ce))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,14 +223,14 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "configuration-domain"
-version = "0.1.1"
+version = "0.1.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "configuration-infrastructure"
-version = "0.1.1"
+version = "0.1.0"
 dependencies = [
  "configuration-domain",
  "serde",
@@ -484,18 +484,18 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "merge-readiness-application"
-version = "0.1.1"
+version = "0.1.0"
 dependencies = [
  "merge-readiness-domain",
 ]
 
 [[package]]
 name = "merge-readiness-domain"
-version = "0.1.1"
+version = "0.1.0"
 
 [[package]]
 name = "merge-readiness-infrastructure"
-version = "0.1.1"
+version = "0.1.0"
 dependencies = [
  "merge-readiness-application",
  "merge-readiness-domain",
@@ -506,7 +506,7 @@ dependencies = [
 
 [[package]]
 name = "merge-readiness-interface"
-version = "0.1.1"
+version = "0.1.0"
 dependencies = [
  "clap",
  "merge-readiness-application",
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "merge-ready"
-version = "0.1.1"
+version = "0.1.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ pedantic = "warn"
 
 [package]
 name = "merge-ready"
-version = "0.1.1"
+version = "0.1.0"
 edition.workspace = true
 description = "Show pull request merge blockers as concise prompt tokens"
 license.workspace = true

--- a/contexts/configuration/domain/Cargo.toml
+++ b/contexts/configuration/domain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "configuration-domain"
-version = "0.1.1"
+version = "0.1.0"
 publish = false
 edition.workspace = true
 license.workspace = true

--- a/contexts/configuration/infrastructure/Cargo.toml
+++ b/contexts/configuration/infrastructure/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "configuration-infrastructure"
-version = "0.1.1"
+version = "0.1.0"
 publish = false
 edition.workspace = true
 license.workspace = true

--- a/contexts/merge_readiness/application/Cargo.toml
+++ b/contexts/merge_readiness/application/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merge-readiness-application"
-version = "0.1.1"
+version = "0.1.0"
 publish = false
 edition.workspace = true
 license.workspace = true

--- a/contexts/merge_readiness/domain/Cargo.toml
+++ b/contexts/merge_readiness/domain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merge-readiness-domain"
-version = "0.1.1"
+version = "0.1.0"
 publish = false
 edition.workspace = true
 license.workspace = true

--- a/contexts/merge_readiness/infrastructure/Cargo.toml
+++ b/contexts/merge_readiness/infrastructure/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merge-readiness-infrastructure"
-version = "0.1.1"
+version = "0.1.0"
 publish = false
 edition.workspace = true
 license.workspace = true

--- a/contexts/merge_readiness/interface/Cargo.toml
+++ b/contexts/merge_readiness/interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merge-readiness-interface"
-version = "0.1.1"
+version = "0.1.0"
 publish = false
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary
- 全パッケージのバージョンを `0.1.1` → `0.1.0` に差し戻す
- CHANGELOG.md から失敗したリリースで混入した `[0.1.1]` セクションを削除

## 理由
release PR (#54) で `0.1.1` に上げたが、release ワークフローが失敗し `v0.1.1` タグが作成されなかった。バージョンを `0.1.0` に戻し CHANGELOG をクリーンにすることで、次回 release-prepare 実行時に release-plz が正しく `0.1.1` を生成できるようにする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)