### PR TITLE
revert: 独立バージョニングを取り消しworkspace共有に戻す

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
+version = "0.1.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/toshiki670/merge-ready"
@@ -31,7 +32,7 @@ pedantic = "warn"
 
 [package]
 name = "merge-ready"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 description = "Show pull request merge blockers as concise prompt tokens"
 license.workspace = true

--- a/contexts/configuration/domain/Cargo.toml
+++ b/contexts/configuration/domain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "configuration-domain"
-version = "0.1.0"
+version.workspace = true
 publish = false
 edition.workspace = true
 license.workspace = true

--- a/contexts/configuration/infrastructure/Cargo.toml
+++ b/contexts/configuration/infrastructure/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "configuration-infrastructure"
-version = "0.1.0"
+version.workspace = true
 publish = false
 edition.workspace = true
 license.workspace = true

--- a/contexts/merge_readiness/application/Cargo.toml
+++ b/contexts/merge_readiness/application/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merge-readiness-application"
-version = "0.1.0"
+version.workspace = true
 publish = false
 edition.workspace = true
 license.workspace = true

--- a/contexts/merge_readiness/domain/Cargo.toml
+++ b/contexts/merge_readiness/domain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merge-readiness-domain"
-version = "0.1.0"
+version.workspace = true
 publish = false
 edition.workspace = true
 license.workspace = true

--- a/contexts/merge_readiness/infrastructure/Cargo.toml
+++ b/contexts/merge_readiness/infrastructure/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merge-readiness-infrastructure"
-version = "0.1.0"
+version.workspace = true
 publish = false
 edition.workspace = true
 license.workspace = true

--- a/contexts/merge_readiness/interface/Cargo.toml
+++ b/contexts/merge_readiness/interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merge-readiness-interface"
-version = "0.1.0"
+version.workspace = true
 publish = false
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
Reverts #58

## Summary
- `[workspace.package]` に `version = "0.1.0"` を復元
- 全パッケージを `version.workspace = true` に戻す

## 理由
`publish = false` のクレートは release-plz がデフォルトで `release = false` として扱うため、独立バージョニングにしてもバージョン管理・CHANGELOG 生成が行われなかった。workspace 共有に戻して root の `merge-ready` のみ release-plz で管理する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)