### PR TITLE
fix: レイヤー依存違反を設計レベルで修正

### DIFF
--- a/src/contexts/configuration.rs
+++ b/src/contexts/configuration.rs
@@ -1,2 +1,3 @@
+pub mod application;
 pub mod domain;
 pub mod infrastructure;

--- a/src/contexts/configuration/application.rs
+++ b/src/contexts/configuration/application.rs
@@ -1,0 +1,1 @@
+pub mod config_service;

--- a/src/contexts/configuration/application/config_service.rs
+++ b/src/contexts/configuration/application/config_service.rs
@@ -1,0 +1,68 @@
+use super::super::domain::config::{Config, TokenConfig};
+use super::super::domain::repository::ConfigRepository;
+
+pub struct ConfigService(Config);
+
+impl ConfigService {
+    pub fn new(repo: &impl ConfigRepository) -> Self {
+        Self(repo.load())
+    }
+
+    pub fn render_merge_ready(&self) -> String {
+        self.0.merge_ready.as_ref().unwrap_or(&TokenConfig::default()).render("✓", "merge-ready")
+    }
+
+    pub fn render_conflict(&self) -> String {
+        self.0.conflict.as_ref().unwrap_or(&TokenConfig::default()).render("✗", "conflict")
+    }
+
+    pub fn render_update_branch(&self) -> String {
+        self.0.update_branch.as_ref().unwrap_or(&TokenConfig::default()).render("✗", "update-branch")
+    }
+
+    pub fn render_sync_unknown(&self) -> String {
+        self.0.sync_unknown.as_ref().unwrap_or(&TokenConfig::default()).render("?", "sync-unknown")
+    }
+
+    pub fn render_ci_fail(&self) -> String {
+        self.0.ci_fail.as_ref().unwrap_or(&TokenConfig::default()).render("✗", "ci-fail")
+    }
+
+    pub fn render_ci_action(&self) -> String {
+        self.0.ci_action.as_ref().unwrap_or(&TokenConfig::default()).render("⚠", "ci-action")
+    }
+
+    pub fn render_review(&self) -> String {
+        self.0.review.as_ref().unwrap_or(&TokenConfig::default()).render("⚠", "review")
+    }
+
+    pub fn render_auth_required(&self) -> String {
+        let default = TokenConfig::default();
+        self.0
+            .error
+            .as_ref()
+            .and_then(|ec| ec.auth_required.as_ref())
+            .unwrap_or(&default)
+            .render("!", "gh auth login")
+    }
+
+    pub fn render_rate_limited(&self) -> String {
+        let default = TokenConfig::default();
+        self.0
+            .error
+            .as_ref()
+            .and_then(|ec| ec.rate_limited.as_ref())
+            .unwrap_or(&default)
+            .render("✗", "rate-limited")
+    }
+
+    pub fn render_api_error(&self) -> String {
+        let default = TokenConfig::default();
+        self.0
+            .error
+            .as_ref()
+            .and_then(|ec| ec.api_error.as_ref())
+            .unwrap_or(&default)
+            .render("✗", "api-error")
+    }
+}

--- a/src/contexts/configuration/application/config_service.rs
+++ b/src/contexts/configuration/application/config_service.rs
@@ -9,31 +9,59 @@ impl ConfigService {
     }
 
     pub fn render_merge_ready(&self) -> String {
-        self.0.merge_ready.as_ref().unwrap_or(&TokenConfig::default()).render("✓", "merge-ready")
+        self.0
+            .merge_ready
+            .as_ref()
+            .unwrap_or(&TokenConfig::default())
+            .render("✓", "merge-ready")
     }
 
     pub fn render_conflict(&self) -> String {
-        self.0.conflict.as_ref().unwrap_or(&TokenConfig::default()).render("✗", "conflict")
+        self.0
+            .conflict
+            .as_ref()
+            .unwrap_or(&TokenConfig::default())
+            .render("✗", "conflict")
     }
 
     pub fn render_update_branch(&self) -> String {
-        self.0.update_branch.as_ref().unwrap_or(&TokenConfig::default()).render("✗", "update-branch")
+        self.0
+            .update_branch
+            .as_ref()
+            .unwrap_or(&TokenConfig::default())
+            .render("✗", "update-branch")
     }
 
     pub fn render_sync_unknown(&self) -> String {
-        self.0.sync_unknown.as_ref().unwrap_or(&TokenConfig::default()).render("?", "sync-unknown")
+        self.0
+            .sync_unknown
+            .as_ref()
+            .unwrap_or(&TokenConfig::default())
+            .render("?", "sync-unknown")
     }
 
     pub fn render_ci_fail(&self) -> String {
-        self.0.ci_fail.as_ref().unwrap_or(&TokenConfig::default()).render("✗", "ci-fail")
+        self.0
+            .ci_fail
+            .as_ref()
+            .unwrap_or(&TokenConfig::default())
+            .render("✗", "ci-fail")
     }
 
     pub fn render_ci_action(&self) -> String {
-        self.0.ci_action.as_ref().unwrap_or(&TokenConfig::default()).render("⚠", "ci-action")
+        self.0
+            .ci_action
+            .as_ref()
+            .unwrap_or(&TokenConfig::default())
+            .render("⚠", "ci-action")
     }
 
     pub fn render_review(&self) -> String {
-        self.0.review.as_ref().unwrap_or(&TokenConfig::default()).render("⚠", "review")
+        self.0
+            .review
+            .as_ref()
+            .unwrap_or(&TokenConfig::default())
+            .render("⚠", "review")
     }
 
     pub fn render_auth_required(&self) -> String {

--- a/src/contexts/configuration/application/config_service.rs
+++ b/src/contexts/configuration/application/config_service.rs
@@ -12,7 +12,7 @@ impl ConfigService {
         self.0
             .merge_ready
             .as_ref()
-            .unwrap_or(&TokenConfig::default())
+            .unwrap_or(&default_token())
             .render("✓", "merge-ready")
     }
 
@@ -20,7 +20,7 @@ impl ConfigService {
         self.0
             .conflict
             .as_ref()
-            .unwrap_or(&TokenConfig::default())
+            .unwrap_or(&default_token())
             .render("✗", "conflict")
     }
 
@@ -28,7 +28,7 @@ impl ConfigService {
         self.0
             .update_branch
             .as_ref()
-            .unwrap_or(&TokenConfig::default())
+            .unwrap_or(&default_token())
             .render("✗", "update-branch")
     }
 
@@ -36,7 +36,7 @@ impl ConfigService {
         self.0
             .sync_unknown
             .as_ref()
-            .unwrap_or(&TokenConfig::default())
+            .unwrap_or(&default_token())
             .render("?", "sync-unknown")
     }
 
@@ -44,7 +44,7 @@ impl ConfigService {
         self.0
             .ci_fail
             .as_ref()
-            .unwrap_or(&TokenConfig::default())
+            .unwrap_or(&default_token())
             .render("✗", "ci-fail")
     }
 
@@ -52,7 +52,7 @@ impl ConfigService {
         self.0
             .ci_action
             .as_ref()
-            .unwrap_or(&TokenConfig::default())
+            .unwrap_or(&default_token())
             .render("⚠", "ci-action")
     }
 
@@ -60,37 +60,38 @@ impl ConfigService {
         self.0
             .review
             .as_ref()
-            .unwrap_or(&TokenConfig::default())
+            .unwrap_or(&default_token())
             .render("⚠", "review")
     }
 
     pub fn render_auth_required(&self) -> String {
-        let default = TokenConfig::default();
         self.0
             .error
             .as_ref()
             .and_then(|ec| ec.auth_required.as_ref())
-            .unwrap_or(&default)
+            .unwrap_or(&default_token())
             .render("!", "gh auth login")
     }
 
     pub fn render_rate_limited(&self) -> String {
-        let default = TokenConfig::default();
         self.0
             .error
             .as_ref()
             .and_then(|ec| ec.rate_limited.as_ref())
-            .unwrap_or(&default)
+            .unwrap_or(&default_token())
             .render("✗", "rate-limited")
     }
 
     pub fn render_api_error(&self) -> String {
-        let default = TokenConfig::default();
         self.0
             .error
             .as_ref()
             .and_then(|ec| ec.api_error.as_ref())
-            .unwrap_or(&default)
+            .unwrap_or(&default_token())
             .render("✗", "api-error")
     }
+}
+
+fn default_token() -> TokenConfig {
+    TokenConfig::default()
 }

--- a/src/contexts/merge_readiness/application/cache.rs
+++ b/src/contexts/merge_readiness/application/cache.rs
@@ -1,14 +1,4 @@
-/// キャッシュの状態（アプリケーション層の表現）
-pub enum CacheState {
-    Fresh(String),
-    Stale(String),
-    Miss,
-}
-
-/// キャッシュ読み取りを抽象化するポート
-pub trait CachePort {
-    fn check(&self, repo_id: &str) -> CacheState;
-}
+pub use crate::contexts::merge_readiness::domain::cache::{CachePort, CacheState};
 
 /// main に伝える表示アクション
 pub(crate) enum DisplayAction {

--- a/src/contexts/merge_readiness/application/errors.rs
+++ b/src/contexts/merge_readiness/application/errors.rs
@@ -1,3 +1,4 @@
+pub use crate::contexts::merge_readiness::domain::error::ErrorLogger;
 use crate::contexts::merge_readiness::domain::error::RepositoryError;
 
 /// エラー時に表示するトークンの意味オブジェクト
@@ -11,11 +12,6 @@ pub enum ErrorToken {
     RateLimited,
     /// 予期しない API エラー
     ApiError,
-}
-
-/// エラーをログに記録するポート
-pub trait ErrorLogger {
-    fn log(&self, msg: &str);
 }
 
 /// エラーをユーザーに表示するポート

--- a/src/contexts/merge_readiness/domain.rs
+++ b/src/contexts/merge_readiness/domain.rs
@@ -1,4 +1,5 @@
 pub mod branch_sync;
+pub mod cache;
 pub mod ci_checks;
 pub mod error;
 pub mod merge_ready;

--- a/src/contexts/merge_readiness/domain/cache.rs
+++ b/src/contexts/merge_readiness/domain/cache.rs
@@ -1,0 +1,9 @@
+pub enum CacheState {
+    Fresh(String),
+    Stale(String),
+    Miss,
+}
+
+pub trait CachePort {
+    fn check(&self, repo_id: &str) -> CacheState;
+}

--- a/src/contexts/merge_readiness/domain/error.rs
+++ b/src/contexts/merge_readiness/domain/error.rs
@@ -1,3 +1,7 @@
+pub trait ErrorLogger {
+    fn log(&self, msg: &str);
+}
+
 /// リポジトリ操作で発生しうるエラー種別（全ドメイントレイト共通）
 ///
 /// infra の実装手段（CLI・REST 等）に依存しない抽象的な分類のみを持つ。

--- a/src/contexts/merge_readiness/infrastructure/cache.rs
+++ b/src/contexts/merge_readiness/infrastructure/cache.rs
@@ -3,7 +3,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
-use crate::contexts::merge_readiness::application::cache::{CachePort, CacheState};
+use crate::contexts::merge_readiness::domain::cache::{CachePort, CacheState};
 
 use super::tmp_cache_dir;
 

--- a/src/contexts/merge_readiness/infrastructure/logger.rs
+++ b/src/contexts/merge_readiness/infrastructure/logger.rs
@@ -1,7 +1,7 @@
 use std::fs::{self, OpenOptions};
 use std::io::Write as _;
 
-use crate::contexts::merge_readiness::application::errors::ErrorLogger;
+use crate::contexts::merge_readiness::domain::error::ErrorLogger;
 
 pub struct Logger;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,7 @@ mod contexts;
 mod refresh;
 
 use clap::{CommandFactory, Parser, Subcommand};
-use contexts::configuration::domain::config::TokenConfig;
-use contexts::configuration::domain::repository::ConfigRepository as _;
+use contexts::configuration::application::config_service::ConfigService;
 use contexts::configuration::infrastructure::toml_loader::TomlConfigRepository;
 use contexts::merge_readiness::application::{
     OutputToken,
@@ -43,79 +42,32 @@ impl RepoIdPort for InfraRepoIdPort {
     }
 }
 
-pub(crate) struct ConfigAdapter(contexts::configuration::domain::config::Config);
+pub(crate) struct ConfigAdapter(ConfigService);
 
 impl ConfigAdapter {
     pub(crate) fn load() -> Self {
-        Self(TomlConfigRepository.load())
+        Self(ConfigService::new(&TomlConfigRepository))
     }
 }
 
 impl PresentationConfigPort for ConfigAdapter {
     fn render_token(&self, token: &OutputToken) -> String {
-        let default = TokenConfig::default();
         match token {
-            OutputToken::MergeReady => self
-                .0
-                .merge_ready
-                .as_ref()
-                .unwrap_or(&default)
-                .render("✓", "merge-ready"),
-            OutputToken::Conflict => self
-                .0
-                .conflict
-                .as_ref()
-                .unwrap_or(&default)
-                .render("✗", "conflict"),
-            OutputToken::UpdateBranch => self
-                .0
-                .update_branch
-                .as_ref()
-                .unwrap_or(&default)
-                .render("✗", "update-branch"),
-            OutputToken::SyncUnknown => self
-                .0
-                .sync_unknown
-                .as_ref()
-                .unwrap_or(&default)
-                .render("?", "sync-unknown"),
-            OutputToken::CiFail => self
-                .0
-                .ci_fail
-                .as_ref()
-                .unwrap_or(&default)
-                .render("✗", "ci-fail"),
-            OutputToken::CiAction => self
-                .0
-                .ci_action
-                .as_ref()
-                .unwrap_or(&default)
-                .render("⚠", "ci-action"),
-            OutputToken::ReviewRequested => self
-                .0
-                .review
-                .as_ref()
-                .unwrap_or(&default)
-                .render("⚠", "review"),
+            OutputToken::MergeReady => self.0.render_merge_ready(),
+            OutputToken::Conflict => self.0.render_conflict(),
+            OutputToken::UpdateBranch => self.0.render_update_branch(),
+            OutputToken::SyncUnknown => self.0.render_sync_unknown(),
+            OutputToken::CiFail => self.0.render_ci_fail(),
+            OutputToken::CiAction => self.0.render_ci_action(),
+            OutputToken::ReviewRequested => self.0.render_review(),
         }
     }
 
     fn render_error_token(&self, token: ErrorToken) -> String {
-        let default = TokenConfig::default();
-        let err = self.0.error.as_ref();
         match token {
-            ErrorToken::AuthRequired => err
-                .and_then(|ec| ec.auth_required.as_ref())
-                .unwrap_or(&default)
-                .render("!", "gh auth login"),
-            ErrorToken::RateLimited => err
-                .and_then(|ec| ec.rate_limited.as_ref())
-                .unwrap_or(&default)
-                .render("✗", "rate-limited"),
-            ErrorToken::ApiError => err
-                .and_then(|ec| ec.api_error.as_ref())
-                .unwrap_or(&default)
-                .render("✗", "api-error"),
+            ErrorToken::AuthRequired => self.0.render_auth_required(),
+            ErrorToken::RateLimited => self.0.render_rate_limited(),
+            ErrorToken::ApiError => self.0.render_api_error(),
         }
     }
 }


### PR DESCRIPTION
## Summary

- `CachePort`/`CacheState` を `application/cache.rs` から `domain/cache.rs` へ移動（infra→application の依存逆転を解消）
- `ErrorLogger` を `application/errors.rs` から `domain/error.rs` へ移動（同上）
- `configuration::application` 層を新設し `ConfigService` を実装（main.rs が `configuration::domain` を直接参照する違反を解消）
- `ConfigService` は `ConfigRepository` トレイト経由で依存注入を受け、domain型を外部に露出しない。composition root（main.rs）が2コンテキストをつなぐ役割を担う

## Test plan

- [x] `cargo build` 成功
- [x] `cargo test` 全71件通過
- [x] `bash scripts/check-layer-deps.sh` 違反なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)