### PR TITLE
chore: 単一クレート構成のため workspace 設定を削除

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,47 +1,26 @@
-[workspace]
-members = ["."]
-resolver = "2"
-
-[workspace.package]
+[package]
+name = "merge-ready"
 version = "0.1.0"
 edition = "2024"
+description = "Show pull request merge blockers as concise prompt tokens"
 license = "MIT"
 repository = "https://github.com/toshiki670/merge-ready"
 homepage = "https://github.com/toshiki670/merge-ready"
-
-[workspace.dependencies]
-clap = { version = "4", features = ["derive", "cargo"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-toml = "0.8"
-tempfile = "3"
-
-[workspace.lints.rust]
-unsafe_code = "forbid"
-
-[workspace.lints.clippy]
-pedantic = "warn"
-
-[package]
-name = "merge-ready"
-version.workspace = true
-edition.workspace = true
-description = "Show pull request merge blockers as concise prompt tokens"
-license.workspace = true
-repository.workspace = true
-homepage.workspace = true
 readme = "README.md"
 keywords = ["pull-request", "cli", "prompt", "developer-tools", "merge"]
 categories = ["command-line-utilities", "development-tools"]
 
-[lints]
-workspace = true
+[lints.rust]
+unsafe_code = "forbid"
+
+[lints.clippy]
+pedantic = "warn"
 
 [dependencies]
-clap.workspace = true
-serde.workspace = true
-serde_json.workspace = true
-toml.workspace = true
+clap = { version = "4", features = ["derive", "cargo"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+toml = "0.8"
 
 [[test]]
 name = "e2e"
@@ -51,8 +30,8 @@ path = "tests/e2e/mod.rs"
 assert_cmd = "2"
 criterion = { version = "0.8", features = ["html_reports"] }
 predicates = "3"
-serde_json.workspace = true
-tempfile.workspace = true
+serde_json = "1"
+tempfile = "3"
 
 [[bench]]
 name = "hot_path"


### PR DESCRIPTION
## Summary

- 複数クレートへの再分割計画がないため `[workspace]` セクションを削除
- `workspace.package`、`workspace.dependencies`、`workspace.lints` を直接定義に統一
- `cargo check` でビルド正常を確認済み

## Test plan

- [x] `cargo check` が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)