### PR TITLE
feat: config edit / update サブコマンドを追加

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,9 +105,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bstr"
@@ -444,9 +444,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -617,9 +617,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -880,11 +880,11 @@ dependencies = [
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -893,7 +893,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -1045,6 +1045,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/src/contexts/configuration.rs
+++ b/src/contexts/configuration.rs
@@ -1,3 +1,4 @@
 pub mod application;
 pub mod domain;
 pub mod infrastructure;
+pub mod interface;

--- a/src/contexts/configuration/application.rs
+++ b/src/contexts/configuration/application.rs
@@ -1,1 +1,3 @@
 pub mod config_service;
+pub mod config_updater;
+pub use super::domain::repository::ConfigRepository;

--- a/src/contexts/configuration/application/config_updater.rs
+++ b/src/contexts/configuration/application/config_updater.rs
@@ -10,3 +10,43 @@ pub fn run(repo: &impl ConfigRepository) {
     config.fill_defaults();
     repo.save(&config);
 }
+
+pub fn default_config_toml() -> String {
+    format!(
+        "\
+version = {CURRENT_VERSION}
+
+# merge-ready configuration
+# All fields are optional; omit a section to use built-in defaults.
+
+# [merge_ready]
+# symbol = \"✓\"
+# label = \"merge-ready\"
+# format = \"$symbol $label\"
+
+# [conflict]
+# symbol = \"✗\"
+# label = \"conflict\"
+
+# [update_branch]
+# symbol = \"✗\"
+# label = \"update-branch\"
+
+# [sync_unknown]
+# symbol = \"?\"
+# label = \"sync-unknown\"
+
+# [ci_fail]
+# symbol = \"✗\"
+# label = \"ci-fail\"
+
+# [ci_action]
+# symbol = \"⚠\"
+# label = \"ci-action\"
+
+# [review]
+# symbol = \"⚠\"
+# label = \"review\"
+"
+    )
+}

--- a/src/contexts/configuration/application/config_updater.rs
+++ b/src/contexts/configuration/application/config_updater.rs
@@ -1,52 +1,19 @@
-use super::super::domain::config::CURRENT_VERSION;
+use super::super::domain::config::{CURRENT_VERSION, Config};
 use super::super::domain::repository::ConfigRepository;
 
-pub fn run(repo: &impl ConfigRepository) {
+pub fn run(repo: &impl ConfigRepository) -> Result<(), std::io::Error> {
     let mut config = repo.load();
     if config.version == CURRENT_VERSION {
-        return;
+        return Ok(());
     }
     config.version = CURRENT_VERSION;
     config.fill_defaults();
-    repo.save(&config);
+    repo.save(&config)
 }
 
-pub fn default_config_toml() -> String {
-    format!(
-        "\
-version = {CURRENT_VERSION}
-
-# merge-ready configuration
-# All fields are optional; omit a section to use built-in defaults.
-
-# [merge_ready]
-# symbol = \"✓\"
-# label = \"merge-ready\"
-# format = \"$symbol $label\"
-
-# [conflict]
-# symbol = \"✗\"
-# label = \"conflict\"
-
-# [update_branch]
-# symbol = \"✗\"
-# label = \"update-branch\"
-
-# [sync_unknown]
-# symbol = \"?\"
-# label = \"sync-unknown\"
-
-# [ci_fail]
-# symbol = \"✗\"
-# label = \"ci-fail\"
-
-# [ci_action]
-# symbol = \"⚠\"
-# label = \"ci-action\"
-
-# [review]
-# symbol = \"⚠\"
-# label = \"review\"
-"
-    )
+pub fn default_config() -> Config {
+    Config {
+        version: CURRENT_VERSION,
+        ..Config::default()
+    }
 }

--- a/src/contexts/configuration/application/config_updater.rs
+++ b/src/contexts/configuration/application/config_updater.rs
@@ -1,0 +1,12 @@
+use super::super::domain::config::CURRENT_VERSION;
+use super::super::domain::repository::ConfigRepository;
+
+pub fn run(repo: &impl ConfigRepository) {
+    let mut config = repo.load();
+    if config.version == CURRENT_VERSION {
+        return;
+    }
+    config.version = CURRENT_VERSION;
+    config.fill_defaults();
+    repo.save(&config);
+}

--- a/src/contexts/configuration/application/config_updater.rs
+++ b/src/contexts/configuration/application/config_updater.rs
@@ -12,8 +12,10 @@ pub fn run(repo: &impl ConfigRepository) -> Result<(), std::io::Error> {
 }
 
 pub fn default_config() -> Config {
-    Config {
+    let mut config = Config {
         version: CURRENT_VERSION,
         ..Config::default()
-    }
+    };
+    config.fill_defaults();
+    config
 }

--- a/src/contexts/configuration/domain/config.rs
+++ b/src/contexts/configuration/domain/config.rs
@@ -1,9 +1,13 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 const DEFAULT_FORMAT: &str = "$symbol $label";
 
-#[derive(Deserialize, Default)]
+pub const CURRENT_VERSION: u32 = 1;
+
+#[derive(Deserialize, Serialize, Default)]
 pub struct Config {
+    #[serde(default)]
+    pub version: u32,
     pub merge_ready: Option<TokenConfig>,
     pub conflict: Option<TokenConfig>,
     pub update_branch: Option<TokenConfig>,
@@ -14,7 +18,28 @@ pub struct Config {
     pub error: Option<ErrorConfig>,
 }
 
-#[derive(Deserialize, Default)]
+impl Config {
+    pub fn fill_defaults(&mut self) {
+        let tok = |symbol: &str, label: &str| TokenConfig {
+            symbol: Some(symbol.to_owned()),
+            label: Some(label.to_owned()),
+            format: None,
+        };
+        self.merge_ready.get_or_insert_with(|| tok("✓", "merge-ready"));
+        self.conflict.get_or_insert_with(|| tok("✗", "conflict"));
+        self.update_branch.get_or_insert_with(|| tok("✗", "update-branch"));
+        self.sync_unknown.get_or_insert_with(|| tok("?", "sync-unknown"));
+        self.ci_fail.get_or_insert_with(|| tok("✗", "ci-fail"));
+        self.ci_action.get_or_insert_with(|| tok("⚠", "ci-action"));
+        self.review.get_or_insert_with(|| tok("⚠", "review"));
+        let error = self.error.get_or_insert_with(ErrorConfig::default);
+        error.auth_required.get_or_insert_with(|| tok("!", "gh auth login"));
+        error.rate_limited.get_or_insert_with(|| tok("✗", "rate-limited"));
+        error.api_error.get_or_insert_with(|| tok("✗", "api-error"));
+    }
+}
+
+#[derive(Deserialize, Serialize, Default)]
 pub struct TokenConfig {
     pub symbol: Option<String>,
     pub label: Option<String>,
@@ -31,7 +56,7 @@ impl TokenConfig {
     }
 }
 
-#[derive(Deserialize, Default)]
+#[derive(Deserialize, Serialize, Default)]
 pub struct ErrorConfig {
     pub auth_required: Option<TokenConfig>,
     pub rate_limited: Option<TokenConfig>,

--- a/src/contexts/configuration/domain/config.rs
+++ b/src/contexts/configuration/domain/config.rs
@@ -25,16 +25,23 @@ impl Config {
             label: Some(label.to_owned()),
             format: None,
         };
-        self.merge_ready.get_or_insert_with(|| tok("✓", "merge-ready"));
+        self.merge_ready
+            .get_or_insert_with(|| tok("✓", "merge-ready"));
         self.conflict.get_or_insert_with(|| tok("✗", "conflict"));
-        self.update_branch.get_or_insert_with(|| tok("✗", "update-branch"));
-        self.sync_unknown.get_or_insert_with(|| tok("?", "sync-unknown"));
+        self.update_branch
+            .get_or_insert_with(|| tok("✗", "update-branch"));
+        self.sync_unknown
+            .get_or_insert_with(|| tok("?", "sync-unknown"));
         self.ci_fail.get_or_insert_with(|| tok("✗", "ci-fail"));
         self.ci_action.get_or_insert_with(|| tok("⚠", "ci-action"));
         self.review.get_or_insert_with(|| tok("⚠", "review"));
         let error = self.error.get_or_insert_with(ErrorConfig::default);
-        error.auth_required.get_or_insert_with(|| tok("!", "gh auth login"));
-        error.rate_limited.get_or_insert_with(|| tok("✗", "rate-limited"));
+        error
+            .auth_required
+            .get_or_insert_with(|| tok("!", "gh auth login"));
+        error
+            .rate_limited
+            .get_or_insert_with(|| tok("✗", "rate-limited"));
         error.api_error.get_or_insert_with(|| tok("✗", "api-error"));
     }
 }

--- a/src/contexts/configuration/domain/repository.rs
+++ b/src/contexts/configuration/domain/repository.rs
@@ -2,5 +2,5 @@ use super::config::Config;
 
 pub trait ConfigRepository {
     fn load(&self) -> Config;
-    fn save(&self, config: &Config);
+    fn save(&self, config: &Config) -> Result<(), std::io::Error>;
 }

--- a/src/contexts/configuration/domain/repository.rs
+++ b/src/contexts/configuration/domain/repository.rs
@@ -2,4 +2,5 @@ use super::config::Config;
 
 pub trait ConfigRepository {
     fn load(&self) -> Config;
+    fn save(&self, config: &Config);
 }

--- a/src/contexts/configuration/infrastructure/toml_loader.rs
+++ b/src/contexts/configuration/infrastructure/toml_loader.rs
@@ -24,3 +24,21 @@ pub(crate) fn config_path() -> Option<PathBuf> {
     let home = std::env::var_os("HOME")?;
     Some(PathBuf::from(home).join(".config").join("merge-ready.toml"))
 }
+
+// バージョンが古い場合に設定ファイルをマイグレーションする。最新バージョンならファイルを変更しない。
+pub(crate) fn migrate_config_if_needed(path: &std::path::Path) {
+    use crate::contexts::configuration::domain::config::{Config, CURRENT_VERSION};
+
+    let content = std::fs::read_to_string(path).unwrap_or_default();
+    let mut config: Config = toml::from_str(&content).unwrap_or_default();
+
+    if config.version == CURRENT_VERSION {
+        return;
+    }
+
+    config.version = CURRENT_VERSION;
+    config.fill_defaults();
+    if let Ok(new_content) = toml::to_string_pretty(&config) {
+        let _ = std::fs::write(path, new_content);
+    }
+}

--- a/src/contexts/configuration/infrastructure/toml_loader.rs
+++ b/src/contexts/configuration/infrastructure/toml_loader.rs
@@ -27,7 +27,7 @@ pub(crate) fn config_path() -> Option<PathBuf> {
 
 // バージョンが古い場合に設定ファイルをマイグレーションする。最新バージョンならファイルを変更しない。
 pub(crate) fn migrate_config_if_needed(path: &std::path::Path) {
-    use crate::contexts::configuration::domain::config::{Config, CURRENT_VERSION};
+    use crate::contexts::configuration::domain::config::{CURRENT_VERSION, Config};
 
     let content = std::fs::read_to_string(path).unwrap_or_default();
     let mut config: Config = toml::from_str(&content).unwrap_or_default();

--- a/src/contexts/configuration/infrastructure/toml_loader.rs
+++ b/src/contexts/configuration/infrastructure/toml_loader.rs
@@ -15,16 +15,16 @@ impl ConfigRepository for TomlConfigRepository {
         toml::from_str(&content).unwrap_or_default()
     }
 
-    fn save(&self, config: &Config) {
-        let Some(path) = config_path() else {
-            return;
-        };
+    fn save(&self, config: &Config) -> Result<(), std::io::Error> {
+        let path = config_path().ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::NotFound, "config path not found")
+        })?;
         if let Some(parent) = path.parent() {
-            let _ = std::fs::create_dir_all(parent);
+            std::fs::create_dir_all(parent)?;
         }
-        if let Ok(content) = toml::to_string_pretty(config) {
-            let _ = std::fs::write(path, content);
-        }
+        let content = toml::to_string_pretty(config)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        std::fs::write(path, content)
     }
 }
 

--- a/src/contexts/configuration/infrastructure/toml_loader.rs
+++ b/src/contexts/configuration/infrastructure/toml_loader.rs
@@ -17,7 +17,7 @@ impl ConfigRepository for TomlConfigRepository {
 }
 
 // XDG_CONFIG_HOME が設定されていればそちらを優先し、なければ $HOME/.config にフォールバックする。
-fn config_path() -> Option<PathBuf> {
+pub(crate) fn config_path() -> Option<PathBuf> {
     if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
         return Some(PathBuf::from(xdg).join("merge-ready.toml"));
     }

--- a/src/contexts/configuration/infrastructure/toml_loader.rs
+++ b/src/contexts/configuration/infrastructure/toml_loader.rs
@@ -14,6 +14,18 @@ impl ConfigRepository for TomlConfigRepository {
         };
         toml::from_str(&content).unwrap_or_default()
     }
+
+    fn save(&self, config: &Config) {
+        let Some(path) = config_path() else {
+            return;
+        };
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        if let Ok(content) = toml::to_string_pretty(config) {
+            let _ = std::fs::write(path, content);
+        }
+    }
 }
 
 // XDG_CONFIG_HOME が設定されていればそちらを優先し、なければ $HOME/.config にフォールバックする。
@@ -23,22 +35,4 @@ pub(crate) fn config_path() -> Option<PathBuf> {
     }
     let home = std::env::var_os("HOME")?;
     Some(PathBuf::from(home).join(".config").join("merge-ready.toml"))
-}
-
-// バージョンが古い場合に設定ファイルをマイグレーションする。最新バージョンならファイルを変更しない。
-pub(crate) fn migrate_config_if_needed(path: &std::path::Path) {
-    use crate::contexts::configuration::domain::config::{CURRENT_VERSION, Config};
-
-    let content = std::fs::read_to_string(path).unwrap_or_default();
-    let mut config: Config = toml::from_str(&content).unwrap_or_default();
-
-    if config.version == CURRENT_VERSION {
-        return;
-    }
-
-    config.version = CURRENT_VERSION;
-    config.fill_defaults();
-    if let Ok(new_content) = toml::to_string_pretty(&config) {
-        let _ = std::fs::write(path, new_content);
-    }
 }

--- a/src/contexts/configuration/interface.rs
+++ b/src/contexts/configuration/interface.rs
@@ -1,0 +1,1 @@
+pub mod cli;

--- a/src/contexts/configuration/interface/cli.rs
+++ b/src/contexts/configuration/interface/cli.rs
@@ -1,0 +1,1 @@
+pub mod config;

--- a/src/contexts/configuration/interface/cli/config.rs
+++ b/src/contexts/configuration/interface/cli/config.rs
@@ -1,0 +1,2 @@
+pub mod edit;
+pub mod update;

--- a/src/contexts/configuration/interface/cli/config/edit.rs
+++ b/src/contexts/configuration/interface/cli/config/edit.rs
@@ -17,6 +17,7 @@ fn ensure_config_file(path: &Path) {
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
-    let content = crate::contexts::configuration::application::config_updater::default_config_toml();
+    let content =
+        crate::contexts::configuration::application::config_updater::default_config_toml();
     let _ = std::fs::write(path, content.as_bytes());
 }

--- a/src/contexts/configuration/interface/cli/config/edit.rs
+++ b/src/contexts/configuration/interface/cli/config/edit.rs
@@ -7,8 +7,21 @@ pub fn run(path: &Path) -> Result<(), std::io::Error> {
         .unwrap_or_else(|| OsString::from("vi"));
 
     ensure_config_file(path)?;
-    // TODO: エディタの終了コードを確認してエラー処理する
-    let _ = std::process::Command::new(editor).arg(path).status();
+    let status = std::process::Command::new(&editor)
+        .arg(path)
+        .status()
+        .map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("failed to launch editor {:?}: {e}", editor),
+            )
+        })?;
+    if !status.success() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("editor {:?} exited with {status}", editor),
+        ));
+    }
     Ok(())
 }
 

--- a/src/contexts/configuration/interface/cli/config/edit.rs
+++ b/src/contexts/configuration/interface/cli/config/edit.rs
@@ -11,16 +11,13 @@ pub fn run(path: &Path) -> Result<(), std::io::Error> {
         .arg(path)
         .status()
         .map_err(|e| {
-            std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!("failed to launch editor {:?}: {e}", editor),
-            )
+            std::io::Error::other(format!("failed to launch editor {}: {e}", editor.display()))
         })?;
     if !status.success() {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            format!("editor {:?} exited with {status}", editor),
-        ));
+        return Err(std::io::Error::other(format!(
+            "editor {} exited with {status}",
+            editor.display()
+        )));
     }
     Ok(())
 }

--- a/src/contexts/configuration/interface/cli/config/edit.rs
+++ b/src/contexts/configuration/interface/cli/config/edit.rs
@@ -1,23 +1,26 @@
 use std::path::Path;
 
-pub fn run(path: &Path) {
+pub fn run(path: &Path) -> Result<(), std::io::Error> {
     use std::ffi::OsString;
     let editor = std::env::var_os("VISUAL")
         .or_else(|| std::env::var_os("EDITOR"))
         .unwrap_or_else(|| OsString::from("vi"));
 
-    ensure_config_file(path);
+    ensure_config_file(path)?;
+    // TODO: エディタの終了コードを確認してエラー処理する
     let _ = std::process::Command::new(editor).arg(path).status();
+    Ok(())
 }
 
-fn ensure_config_file(path: &Path) {
+fn ensure_config_file(path: &Path) -> Result<(), std::io::Error> {
     if path.exists() {
-        return;
+        return Ok(());
     }
     if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
+        std::fs::create_dir_all(parent)?;
     }
-    let content =
-        crate::contexts::configuration::application::config_updater::default_config_toml();
-    let _ = std::fs::write(path, content.as_bytes());
+    let config = crate::contexts::configuration::application::config_updater::default_config();
+    let content = toml::to_string_pretty(&config)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    std::fs::write(path, content.as_bytes())
 }

--- a/src/contexts/configuration/interface/cli/config/edit.rs
+++ b/src/contexts/configuration/interface/cli/config/edit.rs
@@ -17,41 +17,6 @@ fn ensure_config_file(path: &Path) {
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
-    let _ = std::fs::write(path, default_config_toml());
-}
-
-fn default_config_toml() -> &'static str {
-    "\
-# merge-ready configuration
-# All fields are optional; omit a section to use built-in defaults.
-
-# [merge_ready]
-# symbol = \"✓\"
-# label = \"merge-ready\"
-# format = \"$symbol $label\"
-
-# [conflict]
-# symbol = \"✗\"
-# label = \"conflict\"
-
-# [update_branch]
-# symbol = \"✗\"
-# label = \"update-branch\"
-
-# [sync_unknown]
-# symbol = \"?\"
-# label = \"sync-unknown\"
-
-# [ci_fail]
-# symbol = \"✗\"
-# label = \"ci-fail\"
-
-# [ci_action]
-# symbol = \"⚠\"
-# label = \"ci-action\"
-
-# [review]
-# symbol = \"⚠\"
-# label = \"review\"
-"
+    let content = crate::contexts::configuration::application::config_updater::default_config_toml();
+    let _ = std::fs::write(path, content.as_bytes());
 }

--- a/src/contexts/configuration/interface/cli/config/edit.rs
+++ b/src/contexts/configuration/interface/cli/config/edit.rs
@@ -1,0 +1,57 @@
+use std::path::Path;
+
+pub fn run(path: &Path) {
+    use std::ffi::OsString;
+    let editor = std::env::var_os("VISUAL")
+        .or_else(|| std::env::var_os("EDITOR"))
+        .unwrap_or_else(|| OsString::from("vi"));
+
+    ensure_config_file(path);
+    let _ = std::process::Command::new(editor).arg(path).status();
+}
+
+fn ensure_config_file(path: &Path) {
+    if path.exists() {
+        return;
+    }
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::write(path, default_config_toml());
+}
+
+fn default_config_toml() -> &'static str {
+    "\
+# merge-ready configuration
+# All fields are optional; omit a section to use built-in defaults.
+
+# [merge_ready]
+# symbol = \"✓\"
+# label = \"merge-ready\"
+# format = \"$symbol $label\"
+
+# [conflict]
+# symbol = \"✗\"
+# label = \"conflict\"
+
+# [update_branch]
+# symbol = \"✗\"
+# label = \"update-branch\"
+
+# [sync_unknown]
+# symbol = \"?\"
+# label = \"sync-unknown\"
+
+# [ci_fail]
+# symbol = \"✗\"
+# label = \"ci-fail\"
+
+# [ci_action]
+# symbol = \"⚠\"
+# label = \"ci-action\"
+
+# [review]
+# symbol = \"⚠\"
+# label = \"review\"
+"
+}

--- a/src/contexts/configuration/interface/cli/config/update.rs
+++ b/src/contexts/configuration/interface/cli/config/update.rs
@@ -1,5 +1,5 @@
 use crate::contexts::configuration::application::{self, ConfigRepository};
 
-pub fn run(repo: &impl ConfigRepository) {
-    application::config_updater::run(repo);
+pub fn run(repo: &impl ConfigRepository) -> Result<(), std::io::Error> {
+    application::config_updater::run(repo)
 }

--- a/src/contexts/configuration/interface/cli/config/update.rs
+++ b/src/contexts/configuration/interface/cli/config/update.rs
@@ -1,0 +1,5 @@
+use crate::contexts::configuration::application::{self, ConfigRepository};
+
+pub fn run(repo: &impl ConfigRepository) {
+    application::config_updater::run(repo);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,85 +105,20 @@ fn main() {
             }
         }
         Some(Command::Config { subcommand }) => match subcommand {
-            ConfigCommand::Edit => run_config_edit(),
-            ConfigCommand::Update => run_config_update(),
+            ConfigCommand::Edit => {
+                let Some(path) =
+                    contexts::configuration::infrastructure::toml_loader::config_path()
+                else {
+                    return;
+                };
+                contexts::configuration::interface::cli::config::edit::run(&path);
+            }
+            ConfigCommand::Update => {
+                contexts::configuration::interface::cli::config::update::run(&TomlConfigRepository);
+            }
         },
         None => {
             let _ = Cli::command().print_help();
         }
     }
-}
-
-fn run_config_edit() {
-    use std::ffi::OsString;
-
-    let editor = std::env::var_os("VISUAL")
-        .or_else(|| std::env::var_os("EDITOR"))
-        .unwrap_or_else(|| OsString::from("vi"));
-
-    let Some(path) = contexts::configuration::infrastructure::toml_loader::config_path() else {
-        return;
-    };
-
-    ensure_config_file(&path);
-    let _ = std::process::Command::new(editor).arg(&path).status();
-}
-
-fn run_config_update() {
-    let Some(path) = contexts::configuration::infrastructure::toml_loader::config_path() else {
-        return;
-    };
-
-    if !path.exists() {
-        ensure_config_file(&path);
-        return;
-    }
-
-    contexts::configuration::infrastructure::toml_loader::migrate_config_if_needed(&path);
-}
-
-fn ensure_config_file(path: &std::path::Path) {
-    if path.exists() {
-        return;
-    }
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-    let _ = std::fs::write(path, default_config_toml());
-}
-
-fn default_config_toml() -> &'static str {
-    "\
-# merge-ready configuration
-# All fields are optional; omit a section to use built-in defaults.
-
-# [merge_ready]
-# symbol = \"✓\"
-# label = \"merge-ready\"
-# format = \"$symbol $label\"
-
-# [conflict]
-# symbol = \"✗\"
-# label = \"conflict\"
-
-# [update_branch]
-# symbol = \"✗\"
-# label = \"update-branch\"
-
-# [sync_unknown]
-# symbol = \"?\"
-# label = \"sync-unknown\"
-
-# [ci_fail]
-# symbol = \"✗\"
-# label = \"ci-fail\"
-
-# [ci_action]
-# symbol = \"⚠\"
-# label = \"ci-action\"
-
-# [review]
-# symbol = \"⚠\"
-# label = \"review\"
-"
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,10 +111,18 @@ fn main() {
                 else {
                     return;
                 };
-                contexts::configuration::interface::cli::config::edit::run(&path);
+                if let Err(e) = contexts::configuration::interface::cli::config::edit::run(&path) {
+                    eprintln!("failed to edit config: {e}");
+                    std::process::exit(1);
+                }
             }
             ConfigCommand::Update => {
-                contexts::configuration::interface::cli::config::update::run(&TomlConfigRepository);
+                if let Err(e) = contexts::configuration::interface::cli::config::update::run(
+                    &TomlConfigRepository,
+                ) {
+                    eprintln!("failed to update config: {e}");
+                    std::process::exit(1);
+                }
             }
         },
         None => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,19 @@ enum Command {
     /// Show PR merge status for your shell prompt
     #[command(after_help = AFTER_HELP)]
     Prompt(PromptArgs),
+    /// Manage the configuration file
+    Config {
+        #[command(subcommand)]
+        subcommand: ConfigCommand,
+    },
+}
+
+#[derive(Subcommand)]
+enum ConfigCommand {
+    /// Open the configuration file in an editor (creates it with defaults if absent)
+    Edit,
+    /// Update the configuration file to the latest schema (preserves valid keys, removes obsolete ones, adds missing ones with defaults)
+    Update,
 }
 
 struct InfraRepoIdPort;
@@ -74,25 +87,118 @@ impl PresentationConfigPort for ConfigAdapter {
 
 fn main() {
     let repo_id_port = InfraRepoIdPort;
-    let Some(mode) = (match Cli::parse().command {
-        Some(Command::Prompt(args)) => prompt::resolve_mode(&args, &repo_id_port),
+    match Cli::parse().command {
+        Some(Command::Prompt(args)) => {
+            let Some(mode) = prompt::resolve_mode(&args, &repo_id_port) else {
+                return;
+            };
+            match mode {
+                ExecutionMode::Direct => {
+                    contexts::merge_readiness::interface::cli::prompt::direct::run(
+                        &GhClient::new(),
+                        &Logger,
+                        ConfigAdapter::load(),
+                    );
+                }
+                ExecutionMode::Cached => cached::run(),
+                ExecutionMode::BackgroundRefresh { repo_id } => refresh::run(&repo_id),
+            }
+        }
+        Some(Command::Config { subcommand }) => match subcommand {
+            ConfigCommand::Edit => run_config_edit(),
+            ConfigCommand::Update => run_config_update(),
+        },
         None => {
             let _ = Cli::command().print_help();
-            None
         }
-    }) else {
-        return;
+    }
+}
+
+fn run_config_edit() {
+    use std::ffi::OsString;
+
+    let editor = std::env::var_os("VISUAL")
+        .or_else(|| std::env::var_os("EDITOR"))
+        .unwrap_or_else(|| OsString::from("vi"));
+
+    let path = match contexts::configuration::infrastructure::toml_loader::config_path() {
+        Some(p) => p,
+        None => return,
     };
 
-    match mode {
-        ExecutionMode::Direct => {
-            contexts::merge_readiness::interface::cli::prompt::direct::run(
-                &GhClient::new(),
-                &Logger,
-                ConfigAdapter::load(),
-            );
-        }
-        ExecutionMode::Cached => cached::run(),
-        ExecutionMode::BackgroundRefresh { repo_id } => refresh::run(&repo_id),
+    ensure_config_file(&path);
+    let _ = std::process::Command::new(editor).arg(&path).status();
+}
+
+fn run_config_update() {
+    use contexts::configuration::domain::config::{Config, CURRENT_VERSION};
+
+    let path = match contexts::configuration::infrastructure::toml_loader::config_path() {
+        Some(p) => p,
+        None => return,
+    };
+
+    if !path.exists() {
+        ensure_config_file(&path);
+        return;
     }
+
+    let content = std::fs::read_to_string(&path).unwrap_or_default();
+    let mut config: Config = toml::from_str(&content).unwrap_or_default();
+
+    if config.version == CURRENT_VERSION {
+        return;
+    }
+
+    config.version = CURRENT_VERSION;
+    config.fill_defaults();
+    if let Ok(new_content) = toml::to_string_pretty(&config) {
+        let _ = std::fs::write(&path, new_content);
+    }
+}
+
+fn ensure_config_file(path: &std::path::Path) {
+    if path.exists() {
+        return;
+    }
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::write(path, default_config_toml());
+}
+
+fn default_config_toml() -> &'static str {
+    "\
+# merge-ready configuration
+# All fields are optional; omit a section to use built-in defaults.
+
+# [merge_ready]
+# symbol = \"✓\"
+# label = \"merge-ready\"
+# format = \"$symbol $label\"
+
+# [conflict]
+# symbol = \"✗\"
+# label = \"conflict\"
+
+# [update_branch]
+# symbol = \"✗\"
+# label = \"update-branch\"
+
+# [sync_unknown]
+# symbol = \"?\"
+# label = \"sync-unknown\"
+
+# [ci_fail]
+# symbol = \"✗\"
+# label = \"ci-fail\"
+
+# [ci_action]
+# symbol = \"⚠\"
+# label = \"ci-action\"
+
+# [review]
+# symbol = \"⚠\"
+# label = \"review\"
+"
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,7 +109,10 @@ fn main() {
                 let Some(path) =
                     contexts::configuration::infrastructure::toml_loader::config_path()
                 else {
-                    return;
+                    eprintln!(
+                        "failed to edit config: could not determine config path (HOME or XDG_CONFIG_HOME required)"
+                    );
+                    std::process::exit(1);
                 };
                 if let Err(e) = contexts::configuration::interface::cli::config::edit::run(&path) {
                     eprintln!("failed to edit config: {e}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,8 +130,6 @@ fn run_config_edit() {
 }
 
 fn run_config_update() {
-    use contexts::configuration::domain::config::{CURRENT_VERSION, Config};
-
     let Some(path) = contexts::configuration::infrastructure::toml_loader::config_path() else {
         return;
     };
@@ -141,18 +139,7 @@ fn run_config_update() {
         return;
     }
 
-    let content = std::fs::read_to_string(&path).unwrap_or_default();
-    let mut config: Config = toml::from_str(&content).unwrap_or_default();
-
-    if config.version == CURRENT_VERSION {
-        return;
-    }
-
-    config.version = CURRENT_VERSION;
-    config.fill_defaults();
-    if let Ok(new_content) = toml::to_string_pretty(&config) {
-        let _ = std::fs::write(&path, new_content);
-    }
+    contexts::configuration::infrastructure::toml_loader::migrate_config_if_needed(&path);
 }
 
 fn ensure_config_file(path: &std::path::Path) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,9 +121,8 @@ fn run_config_edit() {
         .or_else(|| std::env::var_os("EDITOR"))
         .unwrap_or_else(|| OsString::from("vi"));
 
-    let path = match contexts::configuration::infrastructure::toml_loader::config_path() {
-        Some(p) => p,
-        None => return,
+    let Some(path) = contexts::configuration::infrastructure::toml_loader::config_path() else {
+        return;
     };
 
     ensure_config_file(&path);
@@ -131,11 +130,10 @@ fn run_config_edit() {
 }
 
 fn run_config_update() {
-    use contexts::configuration::domain::config::{Config, CURRENT_VERSION};
+    use contexts::configuration::domain::config::{CURRENT_VERSION, Config};
 
-    let path = match contexts::configuration::infrastructure::toml_loader::config_path() {
-        Some(p) => p,
-        None => return,
+    let Some(path) = contexts::configuration::infrastructure::toml_loader::config_path() else {
+        return;
     };
 
     if !path.exists() {

--- a/tests/e2e/config.rs
+++ b/tests/e2e/config.rs
@@ -281,7 +281,10 @@ fn test_config_edit_creates_dir_and_file_when_both_absent() {
 
     // ディレクトリとファイルが作成されていることを確認
     assert!(xdg_dir.exists(), ".config dir was not created");
-    assert!(xdg_dir.join("merge-ready.toml").exists(), "config file was not created");
+    assert!(
+        xdg_dir.join("merge-ready.toml").exists(),
+        "config file was not created"
+    );
 }
 
 // ============================================================
@@ -336,9 +339,15 @@ fn test_config_update_preserves_valid_keys() {
     let config_path = env.home_dir.path().join(".config").join("merge-ready.toml");
     let content = std::fs::read_to_string(&config_path).expect("read config");
     // symbol が保持されている
-    assert!(content.contains("★"), "symbol should be preserved, got:\n{content}");
+    assert!(
+        content.contains("★"),
+        "symbol should be preserved, got:\n{content}"
+    );
     // version が最新になっている
-    assert!(content.contains("version = 1"), "version should be updated, got:\n{content}");
+    assert!(
+        content.contains("version = 1"),
+        "version should be updated, got:\n{content}"
+    );
 }
 
 /// [U4] 旧バージョン・廃止キーあり → 廃止キーが削除される
@@ -380,7 +389,10 @@ fn test_config_update_adds_missing_sections_with_defaults() {
     let config_path = env.home_dir.path().join(".config").join("merge-ready.toml");
     let content = std::fs::read_to_string(&config_path).expect("read config");
     // 既存の symbol が保持されている
-    assert!(content.contains("★"), "symbol should be preserved, got:\n{content}");
+    assert!(
+        content.contains("★"),
+        "symbol should be preserved, got:\n{content}"
+    );
     // 不足していた [conflict] セクションがデフォルト値で追加されている
     assert!(
         content.contains("conflict"),

--- a/tests/e2e/config.rs
+++ b/tests/e2e/config.rs
@@ -266,6 +266,64 @@ fn test_config_edit_creates_dir_and_file_when_both_absent() {
     );
 }
 
+/// エディタが非ゼロ終了した場合、merge-ready も非ゼロ終了し stderr にメッセージを出す
+#[test]
+fn test_config_edit_exits_nonzero_when_editor_fails() {
+    let env = TestEnv::without_gh();
+    env.write_config("[merge_ready]\nsymbol = \"★\"");
+    let editor_path = env.setup_failing_editor();
+
+    let mut c = Command::cargo_bin("merge-ready").unwrap();
+    env.apply(&mut c);
+    c.env("VISUAL", &editor_path);
+    c.args(["config", "edit"]);
+    c.assert()
+        .failure()
+        .stderr(predicates::str::contains("failed to edit config"));
+}
+
+/// HOME も XDG_CONFIG_HOME も未設定の場合、merge-ready は非ゼロ終了し stderr にメッセージを出す
+#[test]
+fn test_config_edit_exits_nonzero_without_config_path() {
+    let env = TestEnv::without_gh();
+    let (editor_path, _log_path) = env.setup_fake_editor();
+
+    let mut c = Command::cargo_bin("merge-ready").unwrap();
+    c.env("PATH", env.path_env());
+    c.env_remove("HOME");
+    c.env_remove("XDG_CONFIG_HOME");
+    c.current_dir(env.repo_dir.path());
+    c.env("VISUAL", &editor_path);
+    c.args(["config", "edit"]);
+    c.assert()
+        .failure()
+        .stderr(predicates::str::contains("failed to edit config"));
+}
+
+/// 設定ファイルなし → デフォルト設定ファイルがデフォルト値付きセクションを含む
+#[test]
+fn test_config_edit_default_contains_sections() {
+    let env = TestEnv::without_gh();
+    let (editor_path, _log_path) = env.setup_fake_editor();
+
+    let mut c = Command::cargo_bin("merge-ready").unwrap();
+    env.apply(&mut c);
+    c.env("VISUAL", &editor_path);
+    c.args(["config", "edit"]);
+    c.assert().success().stderr("");
+
+    let config_path = env.home_dir.path().join(".config").join("merge-ready.toml");
+    let content = std::fs::read_to_string(&config_path).expect("read config");
+    assert!(
+        content.contains("merge_ready"),
+        "config should contain merge_ready section with defaults, got:\n{content}"
+    );
+    assert!(
+        content.contains("conflict"),
+        "config should contain conflict section with defaults, got:\n{content}"
+    );
+}
+
 // ============================================================
 // config update
 // ============================================================

--- a/tests/e2e/config.rs
+++ b/tests/e2e/config.rs
@@ -2,6 +2,13 @@
 //!
 //! symbol / label / format のカスタマイズ、部分設定のフォールバック、
 //! 設定ファイルなし・不正 TOML でのデフォルト出力を検証する。
+//!
+//! # テストリスト（config edit）
+//! - [ ] 設定ファイルあり・$VISUAL 設定済み → $VISUAL がファイルパスを引数として呼ばれる
+//! - [ ] 設定ファイルあり・$VISUAL 未設定・$EDITOR 設定済み → $EDITOR が呼ばれる
+//! - [ ] 設定ファイルあり・$VISUAL / $EDITOR 未設定 → vi がフォールバックとして呼ばれる
+//! - [ ] 設定ファイルなし・エディタ設定済み → デフォルト設定ファイルが作成されてからエディタが呼ばれる
+//! - [ ] 設定ファイルなし・.config/ ディレクトリも存在しない → ディレクトリ作成してからファイル作成してエディタ呼ぶ
 
 use super::helpers::TestEnv;
 use assert_cmd::Command;
@@ -134,4 +141,249 @@ fn test_xdg_config_home_takes_precedence_over_home() {
     c.env("XDG_CONFIG_HOME", xdg_dir.path());
     c.args(["prompt", "--no-cache"]);
     c.assert().success().stdout("★ merge-ready").stderr("");
+}
+
+// ============================================================
+// config edit
+// ============================================================
+
+// テストリスト（config edit）:
+// テストリスト（config update）:
+// [x] [U1] 設定ファイルなし → デフォルト設定ファイルが新規作成される
+// [x] [U2] バージョンが最新 → ファイルが変更されない
+// [x] [U3] 旧バージョン・有効なキーあり → 既存の値が保持される
+// [x] [U4] 旧バージョン・廃止キーあり → 廃止キーが削除される
+// [x] [U5] 旧バージョン・不足キーあり → デフォルト値で不足キーが追加される
+
+// [x] [1] 設定ファイルあり・$VISUAL 設定済み → $VISUAL がファイルパスを引数として呼ばれる
+// [x] [2] 設定ファイルあり・$VISUAL 未設定・$EDITOR 設定済み → $EDITOR が呼ばれる
+// [x] [3] 設定ファイルあり・$VISUAL / $EDITOR 未設定 → vi がフォールバックとして呼ばれる
+// [x] [4] 設定ファイルなし・エディタ設定済み → デフォルト設定ファイルが作成されてからエディタが呼ばれる
+// [ ] [5] 設定ファイルなし・.config/ ディレクトリも存在しない → ディレクトリ作成してからファイル作成してエディタ呼ぶ
+
+/// [1] 設定ファイルあり・$VISUAL 設定済み → $VISUAL がファイルパスを引数として呼ばれる
+#[test]
+fn test_config_edit_uses_visual() {
+    let env = TestEnv::without_gh();
+    env.write_config("[merge_ready]\nsymbol = \"★\"");
+    let (editor_path, log_path) = env.setup_fake_editor();
+
+    let mut c = Command::cargo_bin("merge-ready").unwrap();
+    env.apply(&mut c);
+    c.env("VISUAL", &editor_path);
+    c.env_remove("EDITOR");
+    c.args(["config", "edit"]);
+    c.assert().success().stderr("");
+
+    let called_path = std::fs::read_to_string(&log_path).expect("editor was not called");
+    assert!(
+        called_path.ends_with("merge-ready.toml"),
+        "expected merge-ready.toml, got: {called_path}"
+    );
+}
+
+/// [2] 設定ファイルあり・$VISUAL 未設定・$EDITOR 設定済み → $EDITOR が呼ばれる
+#[test]
+fn test_config_edit_uses_editor_when_visual_unset() {
+    let env = TestEnv::without_gh();
+    env.write_config("[merge_ready]\nsymbol = \"★\"");
+    let (editor_path, log_path) = env.setup_fake_editor();
+
+    let mut c = Command::cargo_bin("merge-ready").unwrap();
+    env.apply(&mut c);
+    c.env_remove("VISUAL");
+    c.env("EDITOR", &editor_path);
+    c.args(["config", "edit"]);
+    c.assert().success().stderr("");
+
+    let called_path = std::fs::read_to_string(&log_path).expect("editor was not called");
+    assert!(
+        called_path.ends_with("merge-ready.toml"),
+        "expected merge-ready.toml, got: {called_path}"
+    );
+}
+
+/// [3] 設定ファイルあり・$VISUAL / $EDITOR 未設定 → vi がフォールバックとして呼ばれる
+#[test]
+fn test_config_edit_falls_back_to_vi() {
+    let env = TestEnv::without_gh();
+    env.write_config("[merge_ready]\nsymbol = \"★\"");
+    let log_path = env.setup_fake_vi();
+
+    let mut c = Command::cargo_bin("merge-ready").unwrap();
+    env.apply(&mut c);
+    c.env_remove("VISUAL");
+    c.env_remove("EDITOR");
+    c.args(["config", "edit"]);
+    c.assert().success().stderr("");
+
+    let called_path = std::fs::read_to_string(&log_path).expect("vi was not called");
+    assert!(
+        called_path.ends_with("merge-ready.toml"),
+        "expected merge-ready.toml, got: {called_path}"
+    );
+}
+
+/// [4] 設定ファイルなし・エディタ設定済み → デフォルト設定ファイルが作成されてからエディタが呼ばれる
+#[test]
+fn test_config_edit_creates_default_when_absent() {
+    let env = TestEnv::without_gh();
+    // 設定ファイルを書かない（.config/ ディレクトリは apply() で XDG として設定されるが、ファイルは存在しない）
+    let (editor_path, log_path) = env.setup_fake_editor();
+
+    let mut c = Command::cargo_bin("merge-ready").unwrap();
+    env.apply(&mut c);
+    c.env("VISUAL", &editor_path);
+    c.args(["config", "edit"]);
+    c.assert().success().stderr("");
+
+    // エディタが呼ばれたことを確認
+    let called_path = std::fs::read_to_string(&log_path).expect("editor was not called");
+    assert!(
+        called_path.ends_with("merge-ready.toml"),
+        "expected merge-ready.toml, got: {called_path}"
+    );
+
+    // デフォルト設定ファイルが作成されていることを確認
+    let config_path = env.home_dir.path().join(".config").join("merge-ready.toml");
+    assert!(config_path.exists(), "config file was not created");
+    let content = std::fs::read_to_string(&config_path).expect("read config");
+    assert!(!content.is_empty(), "config file is empty");
+}
+
+/// [5] 設定ファイルなし・.config/ ディレクトリも存在しない → ディレクトリ作成してからファイル作成してエディタ呼ぶ
+#[test]
+fn test_config_edit_creates_dir_and_file_when_both_absent() {
+    let env = TestEnv::without_gh();
+    // .config/ ディレクトリも作らない。apply() で XDG_CONFIG_HOME を設定するが、そのディレクトリは存在しない。
+    // ただし apply() は XDG_CONFIG_HOME を home_dir/.config に設定するので、ここでは別の XDG を使う。
+    let (editor_path, log_path) = env.setup_fake_editor();
+
+    let mut c = Command::cargo_bin("merge-ready").unwrap();
+    // apply() を使わず手動で設定（ディレクトリが存在しない XDG を使う）
+    c.env("PATH", env.path_env());
+    c.env("HOME", env.home());
+    c.env("TMPDIR", env.home());
+    // XDG_CONFIG_HOME を存在しないディレクトリに指定
+    let xdg_dir = env.home_dir.path().join("no_such_dir");
+    c.env("XDG_CONFIG_HOME", &xdg_dir);
+    c.current_dir(env.repo_dir.path());
+    c.env("VISUAL", &editor_path);
+    c.args(["config", "edit"]);
+    c.assert().success().stderr("");
+
+    // エディタが呼ばれたことを確認
+    let called_path = std::fs::read_to_string(&log_path).expect("editor was not called");
+    assert!(
+        called_path.ends_with("merge-ready.toml"),
+        "expected merge-ready.toml, got: {called_path}"
+    );
+
+    // ディレクトリとファイルが作成されていることを確認
+    assert!(xdg_dir.exists(), ".config dir was not created");
+    assert!(xdg_dir.join("merge-ready.toml").exists(), "config file was not created");
+}
+
+// ============================================================
+// config update
+// ============================================================
+
+/// [U1] 設定ファイルなし → デフォルト設定ファイルが新規作成される
+#[test]
+fn test_config_update_creates_default_when_absent() {
+    let env = TestEnv::without_gh();
+
+    let mut c = Command::cargo_bin("merge-ready").unwrap();
+    env.apply(&mut c);
+    c.args(["config", "update"]);
+    c.assert().success().stderr("");
+
+    let config_path = env.home_dir.path().join(".config").join("merge-ready.toml");
+    assert!(config_path.exists(), "config file was not created");
+    let content = std::fs::read_to_string(&config_path).expect("read config");
+    assert!(!content.is_empty(), "config file is empty");
+}
+
+/// [U2] バージョンが最新 → ファイルが変更されない
+#[test]
+fn test_config_update_no_change_when_latest_version() {
+    let env = TestEnv::without_gh();
+    let original = "version = 1\n\n[merge_ready]\nsymbol = \"★\"\n";
+    env.write_config(original);
+
+    let mut c = Command::cargo_bin("merge-ready").unwrap();
+    env.apply(&mut c);
+    c.args(["config", "update"]);
+    c.assert().success().stderr("");
+
+    let config_path = env.home_dir.path().join(".config").join("merge-ready.toml");
+    let content = std::fs::read_to_string(&config_path).expect("read config");
+    assert_eq!(content, original, "file should not be modified");
+}
+
+/// [U3] 旧バージョン・有効なキーあり → 既存の値が保持され version が更新される
+#[test]
+fn test_config_update_preserves_valid_keys() {
+    let env = TestEnv::without_gh();
+    // version なし（旧バージョン）・有効なキーあり
+    env.write_config("[merge_ready]\nsymbol = \"★\"\n");
+
+    let mut c = Command::cargo_bin("merge-ready").unwrap();
+    env.apply(&mut c);
+    c.args(["config", "update"]);
+    c.assert().success().stderr("");
+
+    let config_path = env.home_dir.path().join(".config").join("merge-ready.toml");
+    let content = std::fs::read_to_string(&config_path).expect("read config");
+    // symbol が保持されている
+    assert!(content.contains("★"), "symbol should be preserved, got:\n{content}");
+    // version が最新になっている
+    assert!(content.contains("version = 1"), "version should be updated, got:\n{content}");
+}
+
+/// [U4] 旧バージョン・廃止キーあり → 廃止キーが削除される
+#[test]
+fn test_config_update_removes_obsolete_keys() {
+    let env = TestEnv::without_gh();
+    // 廃止キー（Config struct に存在しないフィールド）を含む設定ファイル
+    env.write_config("[merge_ready]\nsymbol = \"★\"\n\n[obsolete_section]\nsome_key = \"value\"\n");
+
+    let mut c = Command::cargo_bin("merge-ready").unwrap();
+    env.apply(&mut c);
+    c.args(["config", "update"]);
+    c.assert().success().stderr("");
+
+    let config_path = env.home_dir.path().join(".config").join("merge-ready.toml");
+    let content = std::fs::read_to_string(&config_path).expect("read config");
+    assert!(
+        !content.contains("obsolete_section"),
+        "obsolete_section should be removed, got:\n{content}"
+    );
+    assert!(
+        !content.contains("some_key"),
+        "some_key should be removed, got:\n{content}"
+    );
+}
+
+/// [U5] 旧バージョン・不足キーあり → デフォルト値で不足キーが追加される
+#[test]
+fn test_config_update_adds_missing_sections_with_defaults() {
+    let env = TestEnv::without_gh();
+    // [conflict] セクションが存在しない（version なし）
+    env.write_config("[merge_ready]\nsymbol = \"★\"\n");
+
+    let mut c = Command::cargo_bin("merge-ready").unwrap();
+    env.apply(&mut c);
+    c.args(["config", "update"]);
+    c.assert().success().stderr("");
+
+    let config_path = env.home_dir.path().join(".config").join("merge-ready.toml");
+    let content = std::fs::read_to_string(&config_path).expect("read config");
+    // 既存の symbol が保持されている
+    assert!(content.contains("★"), "symbol should be preserved, got:\n{content}");
+    // 不足していた [conflict] セクションがデフォルト値で追加されている
+    assert!(
+        content.contains("conflict"),
+        "conflict section should be added with defaults, got:\n{content}"
+    );
 }

--- a/tests/e2e/config.rs
+++ b/tests/e2e/config.rs
@@ -2,13 +2,6 @@
 //!
 //! symbol / label / format のカスタマイズ、部分設定のフォールバック、
 //! 設定ファイルなし・不正 TOML でのデフォルト出力を検証する。
-//!
-//! # テストリスト（config edit）
-//! - [ ] 設定ファイルあり・$VISUAL 設定済み → $VISUAL がファイルパスを引数として呼ばれる
-//! - [ ] 設定ファイルあり・$VISUAL 未設定・$EDITOR 設定済み → $EDITOR が呼ばれる
-//! - [ ] 設定ファイルあり・$VISUAL / $EDITOR 未設定 → vi がフォールバックとして呼ばれる
-//! - [ ] 設定ファイルなし・エディタ設定済み → デフォルト設定ファイルが作成されてからエディタが呼ばれる
-//! - [ ] 設定ファイルなし・.config/ ディレクトリも存在しない → ディレクトリ作成してからファイル作成してエディタ呼ぶ
 
 use super::helpers::TestEnv;
 use assert_cmd::Command;
@@ -147,21 +140,7 @@ fn test_xdg_config_home_takes_precedence_over_home() {
 // config edit
 // ============================================================
 
-// テストリスト（config edit）:
-// テストリスト（config update）:
-// [x] [U1] 設定ファイルなし → デフォルト設定ファイルが新規作成される
-// [x] [U2] バージョンが最新 → ファイルが変更されない
-// [x] [U3] 旧バージョン・有効なキーあり → 既存の値が保持される
-// [x] [U4] 旧バージョン・廃止キーあり → 廃止キーが削除される
-// [x] [U5] 旧バージョン・不足キーあり → デフォルト値で不足キーが追加される
-
-// [x] [1] 設定ファイルあり・$VISUAL 設定済み → $VISUAL がファイルパスを引数として呼ばれる
-// [x] [2] 設定ファイルあり・$VISUAL 未設定・$EDITOR 設定済み → $EDITOR が呼ばれる
-// [x] [3] 設定ファイルあり・$VISUAL / $EDITOR 未設定 → vi がフォールバックとして呼ばれる
-// [x] [4] 設定ファイルなし・エディタ設定済み → デフォルト設定ファイルが作成されてからエディタが呼ばれる
-// [ ] [5] 設定ファイルなし・.config/ ディレクトリも存在しない → ディレクトリ作成してからファイル作成してエディタ呼ぶ
-
-/// [1] 設定ファイルあり・$VISUAL 設定済み → $VISUAL がファイルパスを引数として呼ばれる
+/// $VISUAL が設定されている場合、$VISUAL がファイルパスを引数として呼ばれる
 #[test]
 fn test_config_edit_uses_visual() {
     let env = TestEnv::without_gh();
@@ -182,7 +161,7 @@ fn test_config_edit_uses_visual() {
     );
 }
 
-/// [2] 設定ファイルあり・$VISUAL 未設定・$EDITOR 設定済み → $EDITOR が呼ばれる
+/// 設定ファイルあり・$VISUAL 未設定・$EDITOR 設定済み → $EDITOR が呼ばれる
 #[test]
 fn test_config_edit_uses_editor_when_visual_unset() {
     let env = TestEnv::without_gh();
@@ -203,7 +182,7 @@ fn test_config_edit_uses_editor_when_visual_unset() {
     );
 }
 
-/// [3] 設定ファイルあり・$VISUAL / $EDITOR 未設定 → vi がフォールバックとして呼ばれる
+/// 設定ファイルあり・$VISUAL / $EDITOR 未設定 → vi がフォールバックとして呼ばれる
 #[test]
 fn test_config_edit_falls_back_to_vi() {
     let env = TestEnv::without_gh();
@@ -224,7 +203,7 @@ fn test_config_edit_falls_back_to_vi() {
     );
 }
 
-/// [4] 設定ファイルなし・エディタ設定済み → デフォルト設定ファイルが作成されてからエディタが呼ばれる
+/// 設定ファイルなし・エディタ設定済み → デフォルト設定ファイルが作成されてからエディタが呼ばれる
 #[test]
 fn test_config_edit_creates_default_when_absent() {
     let env = TestEnv::without_gh();
@@ -251,7 +230,7 @@ fn test_config_edit_creates_default_when_absent() {
     assert!(!content.is_empty(), "config file is empty");
 }
 
-/// [5] 設定ファイルなし・.config/ ディレクトリも存在しない → ディレクトリ作成してからファイル作成してエディタ呼ぶ
+/// 設定ファイルなし・.config/ ディレクトリも存在しない → ディレクトリ作成してからファイル作成してエディタ呼ぶ
 #[test]
 fn test_config_edit_creates_dir_and_file_when_both_absent() {
     let env = TestEnv::without_gh();
@@ -291,7 +270,7 @@ fn test_config_edit_creates_dir_and_file_when_both_absent() {
 // config update
 // ============================================================
 
-/// [U1] 設定ファイルなし → デフォルト設定ファイルが新規作成される
+/// 設定ファイルなし → デフォルト設定ファイルが新規作成される
 #[test]
 fn test_config_update_creates_default_when_absent() {
     let env = TestEnv::without_gh();
@@ -307,7 +286,7 @@ fn test_config_update_creates_default_when_absent() {
     assert!(!content.is_empty(), "config file is empty");
 }
 
-/// [U2] バージョンが最新 → ファイルが変更されない
+/// バージョンが最新 → ファイルが変更されない
 #[test]
 fn test_config_update_no_change_when_latest_version() {
     let env = TestEnv::without_gh();
@@ -324,7 +303,7 @@ fn test_config_update_no_change_when_latest_version() {
     assert_eq!(content, original, "file should not be modified");
 }
 
-/// [U3] 旧バージョン・有効なキーあり → 既存の値が保持され version が更新される
+/// 旧バージョン・有効なキーあり → 既存の値が保持され version が更新される
 #[test]
 fn test_config_update_preserves_valid_keys() {
     let env = TestEnv::without_gh();
@@ -350,7 +329,7 @@ fn test_config_update_preserves_valid_keys() {
     );
 }
 
-/// [U4] 旧バージョン・廃止キーあり → 廃止キーが削除される
+/// 旧バージョン・廃止キーあり → 廃止キーが削除される
 #[test]
 fn test_config_update_removes_obsolete_keys() {
     let env = TestEnv::without_gh();
@@ -374,7 +353,7 @@ fn test_config_update_removes_obsolete_keys() {
     );
 }
 
-/// [U5] 旧バージョン・不足キーあり → デフォルト値で不足キーが追加される
+/// 旧バージョン・不足キーあり → デフォルト値で不足キーが追加される
 #[test]
 fn test_config_update_adds_missing_sections_with_defaults() {
     let env = TestEnv::without_gh();

--- a/tests/e2e/helpers.rs
+++ b/tests/e2e/helpers.rs
@@ -310,6 +310,34 @@ impl TestEnv {
         fs::write(config_dir.join("merge-ready.toml"), toml_content)
             .expect("write merge-ready.toml");
     }
+
+    /// `bin_dir` に fake editor スクリプトを配置する。
+    /// 呼ばれたファイルパス（第一引数）を `home_dir/editor_log.txt` に書き出す。
+    /// 戻り値: `(editor_path, log_path)`
+    pub fn setup_fake_editor(&self) -> (std::path::PathBuf, std::path::PathBuf) {
+        let editor_path = self.bin_dir.path().join("fake_editor");
+        let log_path = self.home_dir.path().join("editor_log.txt");
+        let script = format!(
+            "#!/bin/sh\nprintf '%s' \"$1\" > \"{}\"\n",
+            log_path.display()
+        );
+        write_executable(&editor_path, &script);
+        (editor_path, log_path)
+    }
+
+    /// `bin_dir/vi` に fake vi スクリプトを配置する（$PATH 経由でフォールバック検証用）。
+    /// 呼ばれたファイルパスを `home_dir/vi_log.txt` に書き出す。
+    /// 戻り値: `log_path`
+    pub fn setup_fake_vi(&self) -> std::path::PathBuf {
+        let vi_path = self.bin_dir.path().join("vi");
+        let log_path = self.home_dir.path().join("vi_log.txt");
+        let script = format!(
+            "#!/bin/sh\nprintf '%s' \"$1\" > \"{}\"\n",
+            log_path.display()
+        );
+        write_executable(&vi_path, &script);
+        log_path
+    }
 }
 
 fn write_executable(path: impl AsRef<Path>, content: &str) {

--- a/tests/e2e/helpers.rs
+++ b/tests/e2e/helpers.rs
@@ -325,6 +325,14 @@ impl TestEnv {
         (editor_path, log_path)
     }
 
+    /// `bin_dir` に常に失敗（exit 1）する fake editor スクリプトを配置する。
+    /// 戻り値: `editor_path`
+    pub fn setup_failing_editor(&self) -> std::path::PathBuf {
+        let editor_path = self.bin_dir.path().join("fail_editor");
+        write_executable(&editor_path, "#!/bin/sh\nexit 1\n");
+        editor_path
+    }
+
     /// `bin_dir/vi` に fake vi スクリプトを配置する（$PATH 経由でフォールバック検証用）。
     /// 呼ばれたファイルパスを `home_dir/vi_log.txt` に書き出す。
     /// 戻り値: `log_path`


### PR DESCRIPTION
## Summary

- `merge-ready config edit`: 設定ファイルをデフォルトエディタで開く。ファイルが存在しない場合はデフォルト値（全セクション）を含む TOML を新規作成してから開く
- `merge-ready config update`: 旧バージョンの設定ファイルをマイグレーション。廃止キー削除・不足キーのデフォルト値追加・`version` フィールド更新。最新バージョンならファイルを変更しない
- エディタ解決順序: `$VISUAL` → `$EDITOR` → `vi`（git / less 等と同じ慣習）
- 異常系: エディタ非ゼロ終了・設定パス未解決（HOME / XDG_CONFIG_HOME 未設定）のいずれも `eprintln!` + 非ゼロ終了

## Design

**CLI 実装を `interface/cli/config/` 層に配置**
`main.rs` はエントリポイントとしてディスパッチのみを担い、サブコマンドのロジックは `interface` 層が持つ。これはレイヤー依存規則（`scripts/check-layer-deps.sh`）の要請でもあり、`bin` クレートから `domain` を直接参照することを禁じている。

**`application/config_updater.rs` が `default_config() -> Config` を返し、TOML 変換は `interface` 層が担う**
`application` 層はユースケースを表現し、TOML という表現形式を知るべきではない。TOML への変換（`toml::to_string_pretty`）は出力フォーマットの関心事であり、`interface` 層の責務とした。

**`default_config()` が `fill_defaults()` 済みの `Config` を返す**
CLI のヘルプには _"creates it with defaults if absent"_ と明記している。`version` のみを含む最小ファイルを生成すると契約と実装がずれる。ユーザーが全設定オプションを確認・編集できるよう、全セクションをデフォルト値で埋めた状態で生成する。`config update` も同じ `fill_defaults()` を経由するため、両コマンドで生成される構造が一致する。

**`ConfigRepository::save()` を `Result<(), io::Error>` に変更**
以前の `save()` はエラーを握りつぶしており、書き込み失敗が無音で成功扱いになっていた。設定の書き込み失敗はユーザーが検知すべき異常であるため、エラーを `Result` として返し、最終的に `eprintln!` + 非ゼロ終了まで伝播させる設計にした。

**エラー時に `eprintln!` + `std::process::exit(1)`**
`config edit` / `config update` はシェルスクリプトや dotfiles セットアップから呼ばれる可能性がある。終了コードを明示することで、呼び出し元がエラー検知できる。

## Changes

- `Config` に `Serialize` / `version: u32` / `CURRENT_VERSION` / `fill_defaults()` を追加
- `ConfigRepository::save()` を `Result<(), io::Error>` に変更し、失敗を呼び出し元まで伝播
- `interface/cli/config/edit.rs` / `update.rs` にサブコマンド実装を配置（DDD 層規則に従い bin → interface 層）
- `application/config_updater.rs` に `run()` / `default_config()` を配置（TOML 表現の知識を application 層から分離）
- `interface/cli/config/edit.rs` が `default_config()` を受け取り `toml::to_string_pretty` で TOML 化（責務の明確化）
- E2E テスト 13 件追加（`config edit` 8 件・`config update` 5 件）
- `TestEnv` に `setup_fake_editor()` / `setup_fake_vi()` / `setup_failing_editor()` ヘルパーを追加

## Test plan

- [x] `config edit`: `$VISUAL` / `$EDITOR` / `vi` フォールバックが正しく呼ばれる
- [x] `config edit`: ファイルなし時にデフォルト設定（全セクション入り）を新規作成し `.config/` ディレクトリも自動作成
- [x] `config edit`: エディタが非ゼロ終了した場合に `stderr` メッセージ + 非ゼロ終了
- [x] `config edit`: HOME / XDG_CONFIG_HOME 未設定時に `stderr` メッセージ + 非ゼロ終了
- [x] `config update`: ファイルなし時にデフォルト設定を新規作成
- [x] `config update`: `version = 1`（最新）ならファイルを変更しない
- [x] `config update`: 旧バージョンの有効なキーを保持しつつ廃止キーを削除・不足キーを追加
- [x] 既存の 51 件の E2E テストにリグレッションなし（全 84 テスト Green）

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)