### PR TITLE
refactor: adopt Rust 1.95 syntax and APIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,4 +61,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb # v2
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: "ci"
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --locked
+      - name: Run cargo-deny
+        run: cargo deny check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "merge-ready"
 version = "0.1.2"
 edition = "2024"
+rust-version = "1.95"
 description = "Show pull request merge blockers as concise prompt tokens"
 license = "MIT"
 repository = "https://github.com/toshiki670/merge-ready"

--- a/src/contexts/merge_readiness/application.rs
+++ b/src/contexts/merge_readiness/application.rs
@@ -85,21 +85,22 @@ where
     };
 
     let mut tokens: Vec<OutputToken> = Vec::new();
-    if let Some(t) = branch_sync::check(&sync_status) {
-        tokens.push(t);
-    }
-    if let Some(t) = ci_checks::check(&buckets) {
-        tokens.push(t);
-    }
-    if let Some(t) = review::check(&review_status) {
-        tokens.push(t);
+    for token in [
+        branch_sync::check(&sync_status),
+        ci_checks::check(&buckets),
+        review::check(&review_status),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        let _ = tokens.push_mut(token);
     }
 
     // ブロッカーがなければマージ可否を判定
     if tokens.is_empty()
-        && let Some(t) = merge_ready::check(&readiness)
+        && let Some(token) = merge_ready::check(&readiness)
     {
-        tokens.push(t);
+        let _ = tokens.push_mut(token);
     }
 
     tokens

--- a/src/contexts/merge_readiness/application/prompt.rs
+++ b/src/contexts/merge_readiness/application/prompt.rs
@@ -69,7 +69,8 @@ where
 
     impl ErrorPresenter for TrackingPresenter {
         fn show_error(&self, _token: ErrorToken) {
-            self.0.store(true, Ordering::Relaxed);
+            self.0
+                .update(Ordering::Relaxed, Ordering::Relaxed, |_| true);
         }
     }
 

--- a/src/contexts/merge_readiness/infrastructure/gh.rs
+++ b/src/contexts/merge_readiness/infrastructure/gh.rs
@@ -150,15 +150,12 @@ fn translate_lifecycle(state: &str) -> PrLifecycle {
 }
 
 fn translate_sync(mergeable: &str, behind_by: Option<u64>) -> BranchSyncStatus {
-    if mergeable == "CONFLICTING" {
+    match () {
         // conflict は Compare API に依らず判定可能なので Unknown より優先
-        BranchSyncStatus::Conflicting
-    } else {
-        match behind_by {
-            None => BranchSyncStatus::Unknown,
-            Some(0) => BranchSyncStatus::Clean,
-            Some(_) => BranchSyncStatus::Behind,
-        }
+        () if mergeable == "CONFLICTING" => BranchSyncStatus::Conflicting,
+        () if let Some(0) = behind_by => BranchSyncStatus::Clean,
+        () if let Some(_) = behind_by => BranchSyncStatus::Behind,
+        () => BranchSyncStatus::Unknown,
     }
 }
 

--- a/src/contexts/merge_readiness/infrastructure/refresh_lock.rs
+++ b/src/contexts/merge_readiness/infrastructure/refresh_lock.rs
@@ -159,7 +159,7 @@ mod tests {
                     let p = path.clone();
                     s.spawn(move || {
                         if create_with_pid(&p) {
-                            count.fetch_add(1, Ordering::SeqCst);
+                            count.update(Ordering::SeqCst, Ordering::SeqCst, |x| x + 1);
                         }
                     })
                 })

--- a/src/contexts/merge_readiness/infrastructure/tmp_cache_dir.rs
+++ b/src/contexts/merge_readiness/infrastructure/tmp_cache_dir.rs
@@ -15,12 +15,15 @@ pub(super) fn cache_dir() -> std::path::PathBuf {
 const DIR_NAME: &str = "merge-ready";
 
 fn dir_name() -> String {
-    #[cfg(target_os = "linux")]
-    {
-        use std::os::unix::fs::MetadataExt;
-        if let Ok(meta) = std::fs::metadata("/proc/self") {
-            return format!("{DIR_NAME}-{}", meta.uid());
-        }
+    std::cfg_select! {
+        target_os = "linux" => {
+            use std::os::unix::fs::MetadataExt;
+            if let Ok(meta) = std::fs::metadata("/proc/self") {
+                format!("{DIR_NAME}-{}", meta.uid())
+            } else {
+                DIR_NAME.to_owned()
+            }
+        },
+        _ => DIR_NAME.to_owned(),
     }
-    DIR_NAME.to_owned()
 }


### PR DESCRIPTION
## Summary
- Set `rust-version = \"1.95\"` in `Cargo.toml` to make the MSRV explicit.
- Adopt Rust 1.95 constructs in targeted paths: `Vec::push_mut`, `AtomicBool::update` / `AtomicUsize::update`, `match` guards with `if let`, and `std::cfg_select!`.
- Keep existing runtime behavior and pass formatting, linting, and test checks after the migration.

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace`

Made with [Cursor](https://cursor.com)