### PR TITLE
fix: add timeout to gh command execution to prevent indefinite hang

### DIFF
--- a/src/contexts/merge_readiness/infrastructure/gh.rs
+++ b/src/contexts/merge_readiness/infrastructure/gh.rs
@@ -1,6 +1,7 @@
-use std::io::ErrorKind;
-use std::process::Command;
-use std::sync::OnceLock;
+use std::io::{ErrorKind, Read};
+use std::process::{Command, Stdio};
+use std::sync::{OnceLock, mpsc};
+use std::time::{Duration, Instant};
 
 use serde::Deserialize;
 
@@ -254,24 +255,67 @@ impl From<GhError> for RepositoryError {
     }
 }
 
+fn gh_timeout() -> Duration {
+    let secs = std::env::var("MERGE_READY_GH_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(30);
+    Duration::from_secs(secs)
+}
+
 fn run_gh(args: &[&str], cwd: Option<&std::path::Path>) -> Result<Vec<u8>, RepositoryError> {
     let mut cmd = Command::new("gh");
     cmd.args(args);
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
     if let Some(dir) = cwd {
         cmd.current_dir(dir);
     }
-    let output = cmd.output();
-    let gh_err = match output {
-        Err(e) if e.kind() == ErrorKind::NotFound => GhError::NotInstalled,
-        Err(e) => GhError::ApiError(e.to_string()),
-        Ok(out) if out.status.success() => return Ok(out.stdout),
-        Ok(out) => {
-            let exit_code = out.status.code().unwrap_or(1);
-            let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-            classify_gh_error(exit_code, &stderr)
-        }
+
+    let mut child = match cmd.spawn() {
+        Err(e) if e.kind() == ErrorKind::NotFound => return Err(GhError::NotInstalled.into()),
+        Err(e) => return Err(GhError::ApiError(e.to_string()).into()),
+        Ok(c) => c,
     };
-    Err(gh_err.into())
+
+    let mut stdout_pipe = child.stdout.take().expect("piped");
+    let mut stderr_pipe = child.stderr.take().expect("piped");
+
+    let (tx_out, rx_out) = mpsc::channel::<Vec<u8>>();
+    let (tx_err, rx_err) = mpsc::channel::<Vec<u8>>();
+    std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = stdout_pipe.read_to_end(&mut buf);
+        let _ = tx_out.send(buf);
+    });
+    std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = stderr_pipe.read_to_end(&mut buf);
+        let _ = tx_err.send(buf);
+    });
+
+    let deadline = Instant::now() + gh_timeout();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let stdout = rx_out.recv().unwrap_or_default();
+                let stderr = rx_err.recv().unwrap_or_default();
+                if status.success() {
+                    return Ok(stdout);
+                }
+                let exit_code = status.code().unwrap_or(1);
+                let stderr_str = String::from_utf8_lossy(&stderr).into_owned();
+                return Err(classify_gh_error(exit_code, &stderr_str).into());
+            }
+            Ok(None) if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(GhError::ApiError("gh command timed out".to_string()).into());
+            }
+            Ok(None) => std::thread::sleep(Duration::from_millis(50)),
+            Err(e) => return Err(GhError::ApiError(e.to_string()).into()),
+        }
+    }
 }
 
 fn classify_gh_error(exit_code: i32, stderr: &str) -> GhError {

--- a/tests/e2e/errors.rs
+++ b/tests/e2e/errors.rs
@@ -109,6 +109,25 @@ fn test_rate_limited() {
         .stderr("");
 }
 
+// ─── タイムアウト ─────────────────────────────────────────────────────────
+
+/// `gh` がハングした場合、タイムアウト後に `✗ api-error` を返すこと。
+///
+/// `MERGE_READY_GH_TIMEOUT_SECS=2` でタイムアウト、テスト自体は 5 秒で強制終了。
+#[test]
+fn test_gh_timeout() {
+    let env = TestEnv::with_hanging_gh();
+    let mut cmd = Command::cargo_bin("merge-ready").unwrap();
+    env.apply(&mut cmd);
+
+    cmd.args(["prompt", "--no-cache"])
+        .env("MERGE_READY_GH_TIMEOUT_SECS", "2")
+        .timeout(std::time::Duration::from_secs(5))
+        .assert()
+        .success()
+        .stdout("✗ api-error");
+}
+
 // ─── エラーログ ───────────────────────────────────────────────────────────
 
 /// API エラー発生時に `$HOME/.cache/ci-status/error.log` へ追記されること。

--- a/tests/e2e/helpers.rs
+++ b/tests/e2e/helpers.rs
@@ -244,6 +244,17 @@ impl TestEnv {
         }
     }
 
+    /// `gh` バイナリが無期限にハングするシナリオ（タイムアウト検証用）
+    pub fn with_hanging_gh() -> Self {
+        let (bin_dir, home_dir, repo_dir) = Self::setup_with_git();
+        write_executable(bin_dir.path().join("gh"), "#!/bin/sh\nsleep 9999\n");
+        Self {
+            bin_dir,
+            home_dir,
+            repo_dir,
+        }
+    }
+
     /// `PATH` 文字列を返す（`bin_dir` を先頭に追加）
     pub fn path_env(&self) -> String {
         format!("{}:/bin:/usr/bin", self.bin_dir.path().display())


### PR DESCRIPTION
## Summary

- `run_gh` をポーリング方式（`spawn` + `try_wait`）に書き換え、`MERGE_READY_GH_TIMEOUT_SECS`（デフォルト 30 秒）超過時に子プロセスを `kill` して `RepositoryError::Unexpected` を返す
- E2E テスト `test_gh_timeout` を追加：`sleep 9999` する fake gh + `assert_cmd::timeout(5s)` で、実装なしでもテストがハングせず fail することを保証
- `TestEnv::with_hanging_gh()` ヘルパーを追加

Closes #17

## Test plan

- [x] `cargo test --test e2e test_gh_timeout` — 2 秒タイムアウトで `✗ api-error` が返る
- [x] `cargo test --test e2e` — 全 70 テスト通過
- [x] `cargo clippy` — 警告なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)