### PR TITLE
docs: add Starship integration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,21 @@ On the first query the daemon has no cache yet, so `? loading` is printed while 
 
 The daemon exits automatically after 30 minutes of inactivity.
 
+## Starship Integration
+
+Add merge status to your [Starship](https://starship.rs/) prompt by using a custom command module in `~/.config/starship.toml`:
+
+```toml
+[custom.merge_ready]
+command = "merge-ready prompt"
+when = true
+require_repo = true
+format = "[$output]($style) "
+style = "bold yellow"
+```
+
+`require_repo = true` limits the module to git repositories without any shell command overhead. `merge-ready prompt` itself returns `? ...` tokens when there is no associated PR, so no additional filtering is needed.
+
 ## Requirements
 
 - `gh` CLI installed and authenticated


### PR DESCRIPTION
## Summary

- `~/.config/starship.toml` への `[custom.merge_ready]` 設定例を README に追加
- `require_repo = true` で git リポジトリ外では非表示（ネットワーク呼び出しなし）
- `when = true` で `detect_*` が空でもモジュールが有効になるよう設定

## Test plan

- [ ] `require_repo = true` と `when = true` の組み合わせで git リポジトリ内のみ表示されることを確認
- [ ] PR がない git リポジトリで `? ...` トークンが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)