### PR TITLE
fix: PRのないブランチで「? loading」が永続表示されるバグを修正

### DIFF
--- a/src/contexts/merge_readiness/interface/cli/prompt/cached.rs
+++ b/src/contexts/merge_readiness/interface/cli/prompt/cached.rs
@@ -2,11 +2,11 @@ use crate::contexts::merge_readiness::application::prompt::RepoIdPort;
 
 pub fn run(repo_id_port: &impl RepoIdPort, query: impl Fn(&str) -> Option<String>) {
     let Some(id) = repo_id_port.get() else { return };
-    run_with_writer(id, query, &mut std::io::stdout());
+    run_with_writer(&id, query, &mut std::io::stdout());
 }
 
-fn run_with_writer(id: String, query: impl Fn(&str) -> Option<String>, w: &mut impl std::io::Write) {
-    match query(&id) {
+fn run_with_writer(id: &str, query: impl Fn(&str) -> Option<String>, w: &mut impl std::io::Write) {
+    match query(id) {
         Some(s) if !s.is_empty() => write!(w, "{s}").unwrap(),
         Some(_) => {}
         None => write!(w, "? loading").unwrap(),
@@ -26,7 +26,7 @@ mod tests {
 
     fn run_capture(id: &str, query: impl Fn(&str) -> Option<String>) -> String {
         let mut buf = Vec::new();
-        run_with_writer(id.to_owned(), query, &mut buf);
+        run_with_writer(id, query, &mut buf);
         String::from_utf8(buf).unwrap()
     }
 

--- a/src/contexts/merge_readiness/interface/cli/prompt/cached.rs
+++ b/src/contexts/merge_readiness/interface/cli/prompt/cached.rs
@@ -2,8 +2,50 @@ use crate::contexts::merge_readiness::application::prompt::RepoIdPort;
 
 pub fn run(repo_id_port: &impl RepoIdPort, query: impl Fn(&str) -> Option<String>) {
     let Some(id) = repo_id_port.get() else { return };
+    run_with_writer(id, query, &mut std::io::stdout());
+}
+
+fn run_with_writer(id: String, query: impl Fn(&str) -> Option<String>, w: &mut impl std::io::Write) {
     match query(&id) {
-        Some(s) => print!("{s}"),
-        None => print!("? loading"),
+        Some(s) if !s.is_empty() => write!(w, "{s}").unwrap(),
+        Some(_) => {}
+        None => write!(w, "? loading").unwrap(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct FixedRepoId(Option<String>);
+    impl RepoIdPort for FixedRepoId {
+        fn get(&self) -> Option<String> {
+            self.0.clone()
+        }
+    }
+
+    fn run_capture(id: &str, query: impl Fn(&str) -> Option<String>) -> String {
+        let mut buf = Vec::new();
+        run_with_writer(id.to_owned(), query, &mut buf);
+        String::from_utf8(buf).unwrap()
+    }
+
+    #[test]
+    fn miss_shows_loading() {
+        let out = run_capture("id", |_| None);
+        assert_eq!(out, "? loading");
+    }
+
+    #[test]
+    fn cached_empty_shows_nothing() {
+        // PRなし = キャッシュ済みの空文字列 → 何も表示しない
+        let out = run_capture("id", |_| Some(String::new()));
+        assert_eq!(out, "");
+    }
+
+    #[test]
+    fn cached_output_shows_output() {
+        let out = run_capture("id", |_| Some("✓ merge-ready".into()));
+        assert_eq!(out, "✓ merge-ready");
     }
 }

--- a/src/contexts/status_cache/infrastructure/daemon_client.rs
+++ b/src/contexts/status_cache/infrastructure/daemon_client.rs
@@ -89,10 +89,58 @@ impl DaemonClient {
 }
 
 /// `DaemonClient` を使ってキャッシュを問い合わせる。
-/// Fresh/Stale かつ出力が空でなければ `Some(出力文字列)`、それ以外は `None`。
+/// `Fresh(s)` → `Some(s)`（空文字 = PRなし）、`Stale("")` / `Miss` / 接続失敗 → `None`（ロード中）。
 pub fn query_via_daemon(repo_id: &str) -> Option<String> {
-    match DaemonClient.query(repo_id) {
-        Ok(CacheState::Fresh(s) | CacheState::Stale(s)) if !s.is_empty() => Some(s),
+    cache_state_to_output(DaemonClient.query(repo_id))
+}
+
+fn cache_state_to_output(state: Result<CacheState, ()>) -> Option<String> {
+    match state {
+        Ok(CacheState::Fresh(s)) => Some(s),
+        Ok(CacheState::Stale(s)) if !s.is_empty() => Some(s),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fresh_with_output_returns_some() {
+        let result = cache_state_to_output(Ok(CacheState::Fresh("✓ merge-ready".into())));
+        assert_eq!(result, Some("✓ merge-ready".into()));
+    }
+
+    #[test]
+    fn stale_with_output_returns_some() {
+        let result = cache_state_to_output(Ok(CacheState::Stale("✓ merge-ready".into())));
+        assert_eq!(result, Some("✓ merge-ready".into()));
+    }
+
+    #[test]
+    fn miss_returns_none() {
+        let result = cache_state_to_output(Ok(CacheState::Miss));
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn error_returns_none() {
+        let result = cache_state_to_output(Err(()));
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn fresh_empty_returns_some_empty() {
+        // PRなし = キャッシュ済みの空文字列 → Some("") であり None ではない
+        let result = cache_state_to_output(Ok(CacheState::Fresh(String::new())));
+        assert_eq!(result, Some(String::new()));
+    }
+
+    #[test]
+    fn stale_empty_returns_none() {
+        // Stale("") はリフレッシュ中の空プレースホルダーの可能性があるため None
+        let result = cache_state_to_output(Ok(CacheState::Stale(String::new())));
+        assert_eq!(result, None);
     }
 }

--- a/tests/e2e/cache.rs
+++ b/tests/e2e/cache.rs
@@ -98,6 +98,41 @@ fn test_daemon_stale_returns_output() {
     cmd.assert().success().stdout(predicate::str::contains("✓"));
 }
 
+// ── PR なし（main ブランチ等）────────────────────────────────────────────────
+
+/// PR なしブランチで直接実行（--no-cache）→ 何も出力しない
+#[test]
+fn test_no_pr_direct_shows_nothing() {
+    let env = TestEnv::with_no_pr();
+
+    let mut cmd = Command::cargo_bin(BIN).unwrap();
+    env.apply(&mut cmd);
+    cmd.args(["prompt", "--no-cache"]);
+    cmd.assert().success().stdout(predicate::str::is_empty());
+}
+
+/// PR なしブランチで daemon 経由: リフレッシュ完了後に「? loading」が消える（issue #88）
+#[test]
+fn test_daemon_no_pr_shows_nothing_after_refresh() {
+    let env = TestEnv::with_no_pr();
+    let _daemon = DaemonHandle::start(&env);
+
+    // 初回クエリ: キャッシュミス → ? loading
+    let mut cmd = Command::cargo_bin(BIN).unwrap();
+    env.apply_with_cache(&mut cmd);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::diff("? loading"));
+
+    // daemon リフレッシュ完了を待つ（? loading でなくなる ＝ キャッシュ確定）
+    DaemonHandle::wait_for_cache(&env, 5000);
+
+    // キャッシュ確定後は何も出力しない（? loading が永続しないことを確認）
+    let mut cmd = Command::cargo_bin(BIN).unwrap();
+    env.apply_with_cache(&mut cmd);
+    cmd.assert().success().stdout(predicate::str::is_empty());
+}
+
 // ── git リポジトリ外 ────────────────────────────────────────────────────
 
 /// git リポジトリでない場合、何も出力しない

--- a/tests/e2e/helpers.rs
+++ b/tests/e2e/helpers.rs
@@ -229,6 +229,18 @@ impl TestEnv {
         }
     }
 
+    /// PRなしシナリオ: `gh pr view` が "no pull requests found" で exit 1 を返す。
+    pub fn with_no_pr() -> Self {
+        let (bin_dir, home_dir, repo_dir) = Self::setup_with_git();
+        let script = "#!/bin/sh\nprintf 'no pull requests found' >&2\nexit 1\n";
+        write_executable(bin_dir.path().join("gh"), script);
+        Self {
+            bin_dir,
+            home_dir,
+            repo_dir,
+        }
+    }
+
     /// git リポジトリ外シナリオ（`.git` のない空ディレクトリで実行）
     pub fn without_git_remote() -> Self {
         let (bin_dir, home_dir, repo_dir) = Self::setup_without_git();


### PR DESCRIPTION
Closes #88

## Summary

- `Fresh("")`（TTL内のキャッシュで出力が空 = PRなし確定）を `Some("")` として返すよう変更
- `cached::run` で `Some("")` を受け取った場合は何も出力しない（`? loading` を表示しない）
- `Stale("")` はリフレッシュ中の空プレースホルダーと区別できないため `None` のまま維持

## 根本原因

`query_via_daemon` の `!s.is_empty()` ガードが `Fresh("")` を `Miss` と同一視していた。
PRのないブランチでは daemon が `""` をキャッシュするが、そのまま `None` → `? loading` になっていた。

## テスト

TDD（Red → Green → Refactor）で実装。

- `cache_state_to_output` を抽出して単体テストを追加（6ケース）
- `cached::run_with_writer` を抽出して単体テストを追加（3ケース）
- E2E テスト追加（2ケース）
  - `test_no_pr_direct_shows_nothing` — `--no-cache` で PRなし → 空出力
  - `test_daemon_no_pr_shows_nothing_after_refresh` — daemon リフレッシュ後に `? loading` が消える
- 全94テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)