### PR TITLE
ci: reduce deny runtime with cached cargo-deny binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,14 +67,19 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: "ci"
-          cache-all-crates: true
-      - name: Install cargo-deny (if needed)
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            ~/.cargo/bin/cargo-deny
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
+          key: cargo-deny-${{ runner.os }}-0.19.4-v2
+      - name: Install cargo-deny (if missing)
         run: |
-          REQUIRED_CARGO_DENY_VERSION="0.19.4"
-          if command -v cargo-deny >/dev/null 2>&1 && cargo deny --version | grep -q "^cargo-deny ${REQUIRED_CARGO_DENY_VERSION}$"; then
-            echo "cargo-deny ${REQUIRED_CARGO_DENY_VERSION} already installed; skipping install."
+          if command -v cargo-deny >/dev/null 2>&1 && [ "$(cargo deny --version | awk '{ print $2 }')" = "0.19.4" ]; then
+            echo "cargo-deny 0.19.4 already installed; skipping install."
           else
-            cargo install cargo-deny --version "${REQUIRED_CARGO_DENY_VERSION}" --locked
+            cargo install cargo-deny --version 0.19.4 --locked
           fi
       - name: Run cargo-deny
         run: cargo deny check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,13 @@ jobs:
         with:
           shared-key: "ci"
           cache-all-crates: true
-      - name: Install cargo-deny
-        run: cargo install cargo-deny --locked
+      - name: Install cargo-deny (if needed)
+        run: |
+          REQUIRED_CARGO_DENY_VERSION="0.19.4"
+          if command -v cargo-deny >/dev/null 2>&1 && cargo deny --version | grep -q "^cargo-deny ${REQUIRED_CARGO_DENY_VERSION}$"; then
+            echo "cargo-deny ${REQUIRED_CARGO_DENY_VERSION} already installed; skipping install."
+          else
+            cargo install cargo-deny --version "${REQUIRED_CARGO_DENY_VERSION}" --locked
+          fi
       - name: Run cargo-deny
         run: cargo deny check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: "ci"
+          cache-all-crates: true
       - name: Install cargo-deny
         run: cargo install cargo-deny --locked
       - name: Run cargo-deny


### PR DESCRIPTION
## Summary
- replace the previous `cache-all-crates` approach with a dedicated `cargo-deny` cache in the `deny` job
- cache `~/.cargo/bin/cargo-deny` plus cargo install metadata using `actions/cache`
- keep `cargo-deny` pinned to `0.19.4` and skip install when that version is already restored

## Why this change
The prior approach did not reduce runtime in practice. A dedicated cache key scoped to `cargo-deny` artifacts makes cache hit behavior explicit and reliably skips the expensive reinstall step.

## Measured result
- run: https://github.com/toshiki670/merge-ready/actions/runs/24673257223
- first run (cache warm-up):
  - `deny` job: 142s
  - `Install cargo-deny (if missing)`: 120s
- rerun (cache hit):
  - `deny` job: 30s
  - `Install cargo-deny (if missing)`: 0s (skipped)

=> `deny` job improved by about 112s on rerun.

## Test plan
- [x] CI succeeds on PR branch
- [x] Confirm `actions/cache` hit for `cargo-deny` key on rerun
- [x] Confirm install step is skipped when cached version exists

Refs #89

Made with [Cursor](https://cursor.com)