### PR TITLE
chore: remove LGPL-2.1-or-later from deny.toml allow list

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -95,7 +95,6 @@ allow = [
     "Unicode-3.0",
     "Unlicense",
     "Zlib",
-    "LGPL-2.1-or-later",
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the


### PR DESCRIPTION
## Summary

- `deny.toml` の `allow` リストから `LGPL-2.1-or-later` を削除

## Motivation

Rust はデフォルトで静的リンクを行うため、LGPL クレートを静的リンクするとエンドユーザーへの再リンク義務が生じる可能性がある。許可リストから外すことで、意図せず LGPL クレートが追加された際に `cargo deny check` がエラーを出して検出できるようにする。

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)