### PR TITLE
docs: clarify Starship shell setting for prompt latency

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,14 @@ Add merge status to your [Starship](https://starship.rs/) prompt by using a cust
 command = "merge-ready prompt"
 when = true
 require_repo = true
+shell = ["/bin/zsh", "-c"]
 format = "[$output]($style) "
 style = "bold yellow"
 ```
 
 `require_repo = true` limits the module to git repositories without any shell command overhead. `merge-ready prompt` itself returns `? ...` tokens when there is no associated PR, so no additional filtering is needed.
+
+If your environment sets `STARSHIP_SHELL` to a slower shell (for example `fish`), custom modules can be noticeably slower due to shell startup cost. Pinning `shell = ["/bin/zsh", "-c"]` (or another lightweight shell on your system) keeps prompt latency low.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -90,14 +90,14 @@ Add merge status to your [Starship](https://starship.rs/) prompt by using a cust
 command = "merge-ready prompt"
 when = true
 require_repo = true
-shell = ["/bin/zsh", "-c"]
+shell = ["/bin/zsh"]
 format = "[$output]($style) "
 style = "bold yellow"
 ```
 
 `require_repo = true` limits the module to git repositories without any shell command overhead. `merge-ready prompt` itself returns `? ...` tokens when there is no associated PR, so no additional filtering is needed.
 
-If your environment sets `STARSHIP_SHELL` to a slower shell (for example `fish`), custom modules can be noticeably slower due to shell startup cost. Pinning `shell = ["/bin/zsh", "-c"]` (or another lightweight shell on your system) keeps prompt latency low.
+If your environment sets `STARSHIP_SHELL` to a slower shell (for example `fish`), custom modules can be noticeably slower due to shell startup cost. Pinning `shell = ["/bin/zsh"]` (or another lightweight shell on your system) keeps prompt latency low.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- update the Starship integration example for `custom.merge_ready` to use `shell = ["/bin/zsh"]`
- document that `STARSHIP_SHELL` startup cost (for example fish) can dominate custom module latency
- clarify that pinning a lightweight shell keeps prompt response time predictable
- fix the previous shell example: including `-c` in the array causes command execution errors in Starship custom modules

## Test plan
- [x] run `starship timings` before/after config update locally and confirm `custom.merge_ready` improves
- [x] verify `starship module custom.merge_ready` runs without shell argument errors
- [x] verify README example remains valid TOML