### PR TITLE
refactor: remove unused _repo_id_port parameter from resolve_mode

### DIFF
--- a/src/contexts/merge_readiness/interface/cli/prompt.rs
+++ b/src/contexts/merge_readiness/interface/cli/prompt.rs
@@ -4,9 +4,9 @@ pub mod direct;
 
 pub use args::{AFTER_HELP, PromptArgs};
 
-use crate::contexts::merge_readiness::application::prompt::{ExecutionMode, RepoIdPort};
+use crate::contexts::merge_readiness::application::prompt::ExecutionMode;
 
-pub fn resolve_mode(args: &PromptArgs, _repo_id_port: &impl RepoIdPort) -> ExecutionMode {
+pub fn resolve_mode(args: &PromptArgs) -> ExecutionMode {
     if args.no_cache {
         return ExecutionMode::Direct;
     }
@@ -17,24 +17,17 @@ pub fn resolve_mode(args: &PromptArgs, _repo_id_port: &impl RepoIdPort) -> Execu
 mod tests {
     use super::*;
 
-    struct FixedRepoIdPort;
-    impl RepoIdPort for FixedRepoIdPort {
-        fn get(&self) -> Option<String> {
-            Some("repo-id".to_owned())
-        }
-    }
-
     #[test]
     fn no_cache_returns_direct() {
         let args = PromptArgs { no_cache: true };
-        let mode = resolve_mode(&args, &FixedRepoIdPort);
+        let mode = resolve_mode(&args);
         assert!(matches!(mode, ExecutionMode::Direct));
     }
 
     #[test]
     fn default_returns_cached() {
         let args = PromptArgs { no_cache: false };
-        let mode = resolve_mode(&args, &FixedRepoIdPort);
+        let mode = resolve_mode(&args);
         assert!(matches!(mode, ExecutionMode::Cached));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,7 +103,7 @@ impl PresentationConfigPort for ConfigAdapter {
 fn main() {
     let repo_id_port = InfraRepoIdPort;
     match Cli::parse().command {
-        Some(Command::Prompt(args)) => match prompt::resolve_mode(&args, &repo_id_port) {
+        Some(Command::Prompt(args)) => match prompt::resolve_mode(&args) {
             ExecutionMode::Direct => {
                 contexts::merge_readiness::interface::cli::prompt::direct::run(
                     &GhClient::new(),


### PR DESCRIPTION
## Summary

- `resolve_mode` の第2引数 `_repo_id_port: &impl RepoIdPort` を削除（関数本体で未使用だった）
- 不要になった `RepoIdPort` のインポートおよびテスト内の `FixedRepoIdPort` スタブを削除
- `main.rs` の呼び出しサイトを更新

## Test plan

- [x] `cargo build --workspace` — コンパイル通過
- [x] `cargo test --workspace` — 94テスト全通過
- [x] `cargo clippy --workspace -- -D warnings` — 警告なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)