### PR TITLE
fix: stabilize daemon startup and no-PR stale cache behavior

### DIFF
--- a/src/contexts/status_cache/infrastructure/daemon_client.rs
+++ b/src/contexts/status_cache/infrastructure/daemon_client.rs
@@ -22,16 +22,15 @@ impl CachePort for DaemonClient {
             cwd,
         };
 
-        match Self::send(&request) {
-            Ok(response) => response_to_cache_state(response),
-            Err(()) => {
-                Self::lazy_start();
-                // Retry once without sleeping. This captures the case where another process
-                // has just started the daemon and the socket becomes available immediately.
-                match Self::send(&request) {
-                    Ok(response) => response_to_cache_state(response),
-                    Err(()) => Err(()),
-                }
+        if let Ok(response) = Self::send(&request) {
+            response_to_cache_state(response)
+        } else {
+            Self::lazy_start();
+            // Retry once without sleeping. This captures the case where another process
+            // has just started the daemon and the socket becomes available immediately.
+            match Self::send(&request) {
+                Ok(response) => response_to_cache_state(response),
+                Err(()) => Err(()),
             }
         }
     }

--- a/src/contexts/status_cache/infrastructure/daemon_client.rs
+++ b/src/contexts/status_cache/infrastructure/daemon_client.rs
@@ -17,16 +17,21 @@ impl CachePort for DaemonClient {
         let cwd = std::env::current_dir()
             .map(|p| p.to_string_lossy().into_owned())
             .unwrap_or_default();
-        match Self::send(&Request::Query {
+        let request = Request::Query {
             repo_id: repo_id.to_owned(),
             cwd,
-        }) {
-            Ok(Response::Fresh { output }) => Ok(CacheState::Fresh(output)),
-            Ok(Response::Stale { output }) => Ok(CacheState::Stale(output)),
-            Ok(Response::Miss) => Ok(CacheState::Miss),
-            Ok(_) | Err(()) => {
+        };
+
+        match Self::send(&request) {
+            Ok(response) => response_to_cache_state(response),
+            Err(()) => {
                 Self::lazy_start();
-                Err(())
+                // Retry once without sleeping. This captures the case where another process
+                // has just started the daemon and the socket becomes available immediately.
+                match Self::send(&request) {
+                    Ok(response) => response_to_cache_state(response),
+                    Err(()) => Err(()),
+                }
             }
         }
     }
@@ -36,6 +41,15 @@ impl CachePort for DaemonClient {
             repo_id: repo_id.to_owned(),
             output: output.to_owned(),
         });
+    }
+}
+
+fn response_to_cache_state(response: Response) -> Result<CacheState, ()> {
+    match response {
+        Response::Fresh { output } => Ok(CacheState::Fresh(output)),
+        Response::Stale { output } => Ok(CacheState::Stale(output)),
+        Response::Miss => Ok(CacheState::Miss),
+        _ => Err(()),
     }
 }
 
@@ -79,12 +93,16 @@ impl DaemonClient {
         let Ok(exe) = std::env::current_exe() else {
             return;
         };
+        // `daemon start` is a bounded blocking call:
+        // the CLI waits until the inner daemon prints "ready\n" or times out.
+        // This avoids the startup race where an immediate query hits before
+        // the socket is available.
         let _ = std::process::Command::new(&exe)
             .args(["daemon", "start"])
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null())
-            .spawn();
+            .status();
     }
 }
 

--- a/src/contexts/status_cache/infrastructure/daemon_server.rs
+++ b/src/contexts/status_cache/infrastructure/daemon_server.rs
@@ -204,41 +204,15 @@ fn process(request: &Request, state: &Arc<Mutex<DaemonState>>) -> ActionResult {
                     let stored_cwd = entry.cwd.clone();
                     let need_refresh = !entry.refreshing;
                     let refreshing_now = entry.refreshing;
-
-                    // no-PR cache is a valid empty output. Keep returning empty output while
-                    // scheduling background refresh, but still show loading for initial
-                    // placeholder entries that are currently being refreshed.
-                    if output.is_empty() {
-                        if refreshing_now && !has_fetched {
-                            return ActionResult {
-                                response: Response::Miss,
-                                refresh_repo_id: None,
-                                refresh_cwd: None,
-                                stop: false,
-                            };
-                        }
-                        if need_refresh {
-                            mark_refreshing(s.entries.get_mut(repo_id).expect("entry exists"));
-                        }
-                        return ActionResult {
-                            response: Response::Fresh {
-                                output: String::new(),
-                            },
-                            refresh_repo_id: need_refresh.then(|| repo_id.clone()),
-                            refresh_cwd: need_refresh.then_some(stored_cwd),
-                            stop: false,
-                        };
-                    }
-
-                    if need_refresh {
-                        mark_refreshing(s.entries.get_mut(repo_id).expect("entry exists"));
-                    }
-                    ActionResult {
-                        response: Response::Stale { output },
-                        refresh_repo_id: need_refresh.then(|| repo_id.clone()),
-                        refresh_cwd: need_refresh.then_some(stored_cwd),
-                        stop: false,
-                    }
+                    process_stale_query(
+                        repo_id,
+                        output,
+                        has_fetched,
+                        stored_cwd,
+                        need_refresh,
+                        refreshing_now,
+                        &mut s.entries,
+                    )
                 }
                 None => {
                     let past = Instant::now()
@@ -264,33 +238,7 @@ fn process(request: &Request, state: &Arc<Mutex<DaemonState>>) -> ActionResult {
                 }
             }
         }
-        Request::Update { repo_id, output } => {
-            if let Some(entry) = s.entries.get_mut(repo_id) {
-                entry.output.clone_from(output);
-                entry.has_fetched = true;
-                entry.fetched_at = Instant::now();
-                entry.refreshing = false;
-                entry.refresh_started_at = None;
-            } else {
-                s.entries.insert(
-                    repo_id.clone(),
-                    CacheEntry {
-                        output: output.clone(),
-                        has_fetched: true,
-                        fetched_at: Instant::now(),
-                        refreshing: false,
-                        refresh_started_at: None,
-                        cwd: PathBuf::new(),
-                    },
-                );
-            }
-            ActionResult {
-                response: Response::Ok,
-                refresh_repo_id: None,
-                refresh_cwd: None,
-                stop: false,
-            }
-        }
+        Request::Update { repo_id, output } => process_update(repo_id, output, &mut s.entries),
         Request::Stop => ActionResult {
             response: Response::Ok,
             refresh_repo_id: None,
@@ -352,6 +300,50 @@ fn mark_refreshing(entry: &mut CacheEntry) {
     entry.refresh_started_at = Some(Instant::now());
 }
 
+// no-PR cache is a valid empty output. Keep returning empty output while scheduling background
+// refresh, but still show loading for initial placeholder entries that are currently being refreshed.
+fn process_stale_query(
+    repo_id: &str,
+    output: String,
+    has_fetched: bool,
+    stored_cwd: PathBuf,
+    need_refresh: bool,
+    refreshing_now: bool,
+    entries: &mut HashMap<String, CacheEntry>,
+) -> ActionResult {
+    if output.is_empty() {
+        if refreshing_now && !has_fetched {
+            return ActionResult {
+                response: Response::Miss,
+                refresh_repo_id: None,
+                refresh_cwd: None,
+                stop: false,
+            };
+        }
+        if need_refresh {
+            mark_refreshing(entries.get_mut(repo_id).expect("entry exists"));
+        }
+        return ActionResult {
+            response: Response::Fresh {
+                output: String::new(),
+            },
+            refresh_repo_id: need_refresh.then(|| repo_id.to_owned()),
+            refresh_cwd: need_refresh.then_some(stored_cwd),
+            stop: false,
+        };
+    }
+
+    if need_refresh {
+        mark_refreshing(entries.get_mut(repo_id).expect("entry exists"));
+    }
+    ActionResult {
+        response: Response::Stale { output },
+        refresh_repo_id: need_refresh.then(|| repo_id.to_owned()),
+        refresh_cwd: need_refresh.then_some(stored_cwd),
+        stop: false,
+    }
+}
+
 fn is_active_entry(entry: &CacheEntry) -> bool {
     // no-PR entries are intentionally treated as inactive so they do not keep
     // the daemon alive forever. They can be re-created on the next prompt.
@@ -362,6 +354,38 @@ fn refresh_lock_expired(entry: &CacheEntry) -> bool {
     entry
         .refresh_started_at
         .is_some_and(|started| started.elapsed().as_secs() >= refresh_lock_timeout_secs())
+}
+
+fn process_update(
+    repo_id: &str,
+    output: &str,
+    entries: &mut HashMap<String, CacheEntry>,
+) -> ActionResult {
+    if let Some(entry) = entries.get_mut(repo_id) {
+        entry.output.clone_from(&output.to_owned());
+        entry.has_fetched = true;
+        entry.fetched_at = Instant::now();
+        entry.refreshing = false;
+        entry.refresh_started_at = None;
+    } else {
+        entries.insert(
+            repo_id.to_owned(),
+            CacheEntry {
+                output: output.to_owned(),
+                has_fetched: true,
+                fetched_at: Instant::now(),
+                refreshing: false,
+                refresh_started_at: None,
+                cwd: PathBuf::new(),
+            },
+        );
+    }
+    ActionResult {
+        response: Response::Ok,
+        refresh_repo_id: None,
+        refresh_cwd: None,
+        stop: false,
+    }
 }
 
 fn collect_background_refresh_targets(

--- a/src/contexts/status_cache/infrastructure/daemon_server.rs
+++ b/src/contexts/status_cache/infrastructure/daemon_server.rs
@@ -16,6 +16,7 @@ const DEFAULT_REFRESH_LOCK_TIMEOUT_SECS: u64 = 120;
 
 struct CacheEntry {
     output: String,
+    has_fetched: bool,
     fetched_at: Instant,
     refreshing: bool,
     refresh_started_at: Option<Instant>,
@@ -199,8 +200,36 @@ fn process(request: &Request, state: &Arc<Mutex<DaemonState>>) -> ActionResult {
                 },
                 Some(entry) => {
                     let output = entry.output.clone();
+                    let has_fetched = entry.has_fetched;
                     let stored_cwd = entry.cwd.clone();
                     let need_refresh = !entry.refreshing;
+                    let refreshing_now = entry.refreshing;
+
+                    // no-PR cache is a valid empty output. Keep returning empty output while
+                    // scheduling background refresh, but still show loading for initial
+                    // placeholder entries that are currently being refreshed.
+                    if output.is_empty() {
+                        if refreshing_now && !has_fetched {
+                            return ActionResult {
+                                response: Response::Miss,
+                                refresh_repo_id: None,
+                                refresh_cwd: None,
+                                stop: false,
+                            };
+                        }
+                        if need_refresh {
+                            mark_refreshing(s.entries.get_mut(repo_id).expect("entry exists"));
+                        }
+                        return ActionResult {
+                            response: Response::Fresh {
+                                output: String::new(),
+                            },
+                            refresh_repo_id: need_refresh.then(|| repo_id.clone()),
+                            refresh_cwd: need_refresh.then_some(stored_cwd),
+                            stop: false,
+                        };
+                    }
+
                     if need_refresh {
                         mark_refreshing(s.entries.get_mut(repo_id).expect("entry exists"));
                     }
@@ -219,6 +248,7 @@ fn process(request: &Request, state: &Arc<Mutex<DaemonState>>) -> ActionResult {
                         repo_id.clone(),
                         CacheEntry {
                             output: String::new(),
+                            has_fetched: false,
                             fetched_at: past,
                             refreshing: true,
                             refresh_started_at: Some(Instant::now()),
@@ -237,6 +267,7 @@ fn process(request: &Request, state: &Arc<Mutex<DaemonState>>) -> ActionResult {
         Request::Update { repo_id, output } => {
             if let Some(entry) = s.entries.get_mut(repo_id) {
                 entry.output.clone_from(output);
+                entry.has_fetched = true;
                 entry.fetched_at = Instant::now();
                 entry.refreshing = false;
                 entry.refresh_started_at = None;
@@ -245,6 +276,7 @@ fn process(request: &Request, state: &Arc<Mutex<DaemonState>>) -> ActionResult {
                     repo_id.clone(),
                     CacheEntry {
                         output: output.clone(),
+                        has_fetched: true,
                         fetched_at: Instant::now(),
                         refreshing: false,
                         refresh_started_at: None,
@@ -321,6 +353,8 @@ fn mark_refreshing(entry: &mut CacheEntry) {
 }
 
 fn is_active_entry(entry: &CacheEntry) -> bool {
+    // no-PR entries are intentionally treated as inactive so they do not keep
+    // the daemon alive forever. They can be re-created on the next prompt.
     !entry.output.is_empty()
 }
 

--- a/tests/e2e/cache.rs
+++ b/tests/e2e/cache.rs
@@ -133,6 +133,44 @@ fn test_daemon_no_pr_shows_nothing_after_refresh() {
     cmd.assert().success().stdout(predicate::str::is_empty());
 }
 
+/// no-PR の stale リフレッシュ中でも `? loading` に戻らず空出力を維持する。
+///
+/// 回帰シナリオ:
+/// - キャッシュ済み空文字（no-PR）で TTL=0 により stale 化
+/// - 1回目の stale クエリで daemon refresh を開始
+/// - refresh 実行中の 2回目 stale クエリでも空出力を返すべき
+#[test]
+fn test_daemon_no_pr_stale_while_refreshing_keeps_empty_output() {
+    // Give enough refresh delay to reliably keep the daemon in refreshing state
+    // while we issue multiple stale queries below.
+    let env = TestEnv::with_no_pr_delay_ms(1000);
+    let _daemon = DaemonHandle::start_with_env(&env, &[("MERGE_READY_STALE_TTL", "0")]);
+
+    // 初回クエリ: キャッシュミス -> loading
+    let mut cmd = Command::cargo_bin(BIN).unwrap();
+    env.apply_with_cache(&mut cmd);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::diff("? loading"));
+
+    // 初回リフレッシュ完了で空キャッシュ確定
+    DaemonHandle::wait_for_cache(&env, 5000);
+
+    // stale 1回目: リフレッシュ開始しつつ空出力
+    let mut cmd = Command::cargo_bin(BIN).unwrap();
+    env.apply_with_cache(&mut cmd);
+    cmd.assert().success().stdout(predicate::str::is_empty());
+
+    // stale 2回目以降（refresh実行中を狙う）: loading に戻らず空出力を維持
+    // 1回だけだと refresh 完了後でも偽陽性になりうるため、短間隔で複数回検証する。
+    for _ in 0..5 {
+        let mut cmd = Command::cargo_bin(BIN).unwrap();
+        env.apply_with_cache(&mut cmd);
+        cmd.assert().success().stdout(predicate::str::is_empty());
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
 // ── git リポジトリ外 ────────────────────────────────────────────────────
 
 /// git リポジトリでない場合、何も出力しない

--- a/tests/e2e/helpers.rs
+++ b/tests/e2e/helpers.rs
@@ -241,6 +241,26 @@ impl TestEnv {
         }
     }
 
+    /// PRなしシナリオ（遅延付き）:
+    /// `gh pr view` が指定時間待機後に "no pull requests found" で exit 1 を返す。
+    ///
+    /// stale refresh 中の挙動を再現するため、refresh 処理を意図的に長引かせる。
+    pub fn with_no_pr_delay_ms(delay_ms: u64) -> Self {
+        let (bin_dir, home_dir, repo_dir) = Self::setup_with_git();
+        let secs = delay_ms / 1000;
+        let millis = delay_ms % 1000;
+        let sleep_arg = format!("{secs}.{millis:03}");
+        let script = format!(
+            "#!/bin/sh\nsleep {sleep_arg}\nprintf 'no pull requests found' >&2\nexit 1\n"
+        );
+        write_executable(bin_dir.path().join("gh"), &script);
+        Self {
+            bin_dir,
+            home_dir,
+            repo_dir,
+        }
+    }
+
     /// git リポジトリ外シナリオ（`.git` のない空ディレクトリで実行）
     pub fn without_git_remote() -> Self {
         let (bin_dir, home_dir, repo_dir) = Self::setup_without_git();

--- a/tests/e2e/helpers.rs
+++ b/tests/e2e/helpers.rs
@@ -250,9 +250,8 @@ impl TestEnv {
         let secs = delay_ms / 1000;
         let millis = delay_ms % 1000;
         let sleep_arg = format!("{secs}.{millis:03}");
-        let script = format!(
-            "#!/bin/sh\nsleep {sleep_arg}\nprintf 'no pull requests found' >&2\nexit 1\n"
-        );
+        let script =
+            format!("#!/bin/sh\nsleep {sleep_arg}\nprintf 'no pull requests found' >&2\nexit 1\n");
         write_executable(bin_dir.path().join("gh"), &script);
         Self {
             bin_dir,


### PR DESCRIPTION
Closes #95

## 問題

no-PR ブランチのキャッシュが Stale 化した後、バックグラウンドリフレッシュ中に再び `? loading` が表示される回帰バグ。

`Stale("")` が「初回プレースホルダー（未取得）」か「取得済みの有効空キャッシュ（no-PR）」かを区別できなかったことが原因。

## 変更内容

**daemon_server**: `CacheEntry` に `has_fetched: bool` フラグを追加し、空出力の stale クエリを文脈で判別。

- `refreshing == true && !has_fetched`（初回プレースホルダー）→ `Response::Miss` を返し `? loading` を維持
- それ以外の空キャッシュ（取得済み no-PR）→ `Response::Fresh { output: "" }` を返し無表示

**daemon_client**: デーモン起動直後の race を軽減するため、接続失敗時に `lazy_start()` 後ノースリープでリトライを 1 回実施。あわせて `lazy_start()` を `.spawn()` から `.status()` に変更し、ソケットが確実に用意できた後にリトライするよう改善。

## テスト

新規 E2E テスト `test_daemon_no_pr_stale_while_refreshing_keeps_empty_output`（回帰テスト）を追加。遅延付き no-PR スタブ（`TestEnv::with_no_pr_delay_ms`）でリフレッシュ中の状態を再現し、2 回目の stale クエリでも `? loading` に戻らないことを検証。

## Test plan
- [x] `cargo test -q test_daemon_no_pr_stale_while_refreshing_keeps_empty_output --test e2e`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo fmt --check --all`