### PR TITLE
fix: restart daemon when prompt detects version mismatch

### DIFF
--- a/src/contexts/status_cache/domain/daemon.rs
+++ b/src/contexts/status_cache/domain/daemon.rs
@@ -3,6 +3,7 @@ pub struct DaemonStatus {
     pub pid: u32,
     pub entries: usize,
     pub uptime_secs: u64,
+    pub version: String,
 }
 
 /// デーモンのライフサイクル管理ポート

--- a/src/contexts/status_cache/infrastructure/daemon_client.rs
+++ b/src/contexts/status_cache/infrastructure/daemon_client.rs
@@ -14,6 +14,10 @@ pub struct DaemonClient;
 
 impl CachePort for DaemonClient {
     fn query(&self, repo_id: &str) -> Result<CacheState, ()> {
+        // We pay one extra status round-trip per prompt call to guarantee protocol
+        // compatibility during upgrades. The mismatch case is bounded to upgrade
+        // windows (old daemon still alive right after binary update), while steady
+        // state keeps matching versions and returns quickly.
         Self::restart_if_version_mismatched();
         let cwd = std::env::current_dir()
             .map(|p| p.to_string_lossy().into_owned())

--- a/src/contexts/status_cache/infrastructure/daemon_client.rs
+++ b/src/contexts/status_cache/infrastructure/daemon_client.rs
@@ -14,6 +14,7 @@ pub struct DaemonClient;
 
 impl CachePort for DaemonClient {
     fn query(&self, repo_id: &str) -> Result<CacheState, ()> {
+        Self::restart_if_version_mismatched();
         let cwd = std::env::current_dir()
             .map(|p| p.to_string_lossy().into_owned())
             .unwrap_or_default();
@@ -53,19 +54,33 @@ fn response_to_cache_state(response: Response) -> Result<CacheState, ()> {
 }
 
 impl DaemonClient {
+    const CLIENT_VERSION: &'static str = env!("CARGO_PKG_VERSION");
+
     pub(super) fn stop() -> bool {
         Self::send(&Request::Stop).is_ok()
     }
 
-    pub(super) fn status_raw() -> Option<(u32, usize, u64)> {
+    pub(super) fn status_raw() -> Option<(u32, usize, u64, String)> {
         match Self::send(&Request::Status) {
             Ok(Response::Status {
                 pid,
                 entries,
                 uptime_secs,
-            }) => Some((pid, entries, uptime_secs)),
+                version,
+            }) => Some((pid, entries, uptime_secs, version)),
             _ => None,
         }
+    }
+
+    fn restart_if_version_mismatched() {
+        let Some((_pid, _entries, _uptime_secs, daemon_version)) = Self::status_raw() else {
+            return;
+        };
+        if daemon_version == Self::CLIENT_VERSION {
+            return;
+        }
+        let _ = Self::stop();
+        Self::lazy_start();
     }
 
     fn send(request: &Request) -> Result<Response, ()> {

--- a/src/contexts/status_cache/infrastructure/daemon_lifecycle.rs
+++ b/src/contexts/status_cache/infrastructure/daemon_lifecycle.rs
@@ -49,10 +49,11 @@ impl DaemonLifecyclePort for DaemonLifecycle {
     }
 
     fn get_status(&self) -> Option<DaemonStatus> {
-        DaemonClient::status_raw().map(|(pid, entries, uptime_secs)| DaemonStatus {
+        DaemonClient::status_raw().map(|(pid, entries, uptime_secs, version)| DaemonStatus {
             pid,
             entries,
             uptime_secs,
+            version,
         })
     }
 }

--- a/src/contexts/status_cache/infrastructure/daemon_server.rs
+++ b/src/contexts/status_cache/infrastructure/daemon_server.rs
@@ -253,7 +253,7 @@ fn process(request: &Request, state: &Arc<Mutex<DaemonState>>) -> ActionResult {
                     pid: std::process::id(),
                     entries,
                     uptime_secs,
-                    version: daemon_version(),
+                    version: env!("CARGO_PKG_VERSION").to_owned(),
                 },
                 refresh_repo_id: None,
                 refresh_cwd: None,
@@ -421,10 +421,4 @@ fn collect_background_refresh_targets(
         s.last_activity = Instant::now();
     }
     targets
-}
-
-fn daemon_version() -> String {
-    // Test-only override to emulate an older daemon binary.
-    std::env::var("MERGE_READY_DAEMON_VERSION_OVERRIDE")
-        .unwrap_or_else(|_| env!("CARGO_PKG_VERSION").to_owned())
 }

--- a/src/contexts/status_cache/infrastructure/daemon_server.rs
+++ b/src/contexts/status_cache/infrastructure/daemon_server.rs
@@ -253,6 +253,7 @@ fn process(request: &Request, state: &Arc<Mutex<DaemonState>>) -> ActionResult {
                     pid: std::process::id(),
                     entries,
                     uptime_secs,
+                    version: daemon_version(),
                 },
                 refresh_repo_id: None,
                 refresh_cwd: None,
@@ -420,4 +421,10 @@ fn collect_background_refresh_targets(
         s.last_activity = Instant::now();
     }
     targets
+}
+
+fn daemon_version() -> String {
+    // Test-only override to emulate an older daemon binary.
+    std::env::var("MERGE_READY_DAEMON_VERSION_OVERRIDE")
+        .unwrap_or_else(|_| env!("CARGO_PKG_VERSION").to_owned())
 }

--- a/src/contexts/status_cache/infrastructure/protocol.rs
+++ b/src/contexts/status_cache/infrastructure/protocol.rs
@@ -26,5 +26,6 @@ pub enum Response {
         pid: u32,
         entries: usize,
         uptime_secs: u64,
+        version: String,
     },
 }

--- a/src/contexts/status_cache/interface/cli/daemon.rs
+++ b/src/contexts/status_cache/interface/cli/daemon.rs
@@ -121,8 +121,11 @@ fn status(port: &impl Port) {
     match lifecycle::get_status(port) {
         Some(s) => {
             println!(
-                "running  pid={}  entries={}  uptime={}s",
-                s.pid, s.entries, s.uptime_secs
+                "running  pid={}  entries={}  uptime={}s  version={}",
+                s.pid,
+                s.entries,
+                s.uptime_secs,
+                s.version
             );
         }
         None => println!("not running"),

--- a/src/contexts/status_cache/interface/cli/daemon.rs
+++ b/src/contexts/status_cache/interface/cli/daemon.rs
@@ -122,10 +122,7 @@ fn status(port: &impl Port) {
         Some(s) => {
             println!(
                 "running  pid={}  entries={}  uptime={}s  version={}",
-                s.pid,
-                s.entries,
-                s.uptime_secs,
-                s.version
+                s.pid, s.entries, s.uptime_secs, s.version
             );
         }
         None => println!("not running"),

--- a/tests/e2e/cache.rs
+++ b/tests/e2e/cache.rs
@@ -215,3 +215,38 @@ fn test_daemon_multi_repo_isolation() {
     );
     assert_ne!(out_a, out_b, "repos must not share cached output");
 }
+
+/// daemon version が不一致のとき、prompt 実行で自動再起動される。
+#[test]
+fn test_prompt_restarts_daemon_on_version_mismatch() {
+    let env = TestEnv::new(OPEN_PR_VIEW_JSON, Some(CI_PASS_JSON));
+    let _old =
+        DaemonHandle::start_with_env(&env, &[("MERGE_READY_DAEMON_VERSION_OVERRIDE", "0.0.0")]);
+
+    // 古い daemon が応答することを確認
+    let mut before = Command::cargo_bin(BIN).unwrap();
+    env.apply(&mut before);
+    before
+        .args(["daemon", "status"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("version=0.0.0"));
+
+    // prompt 実行で version mismatch を検知し、自動再起動する
+    let mut prompt = Command::cargo_bin(BIN).unwrap();
+    env.apply_with_cache(&mut prompt);
+    prompt.assert().success();
+
+    // 再起動後は実バージョンが返る
+    let mut after = Command::cargo_bin(BIN).unwrap();
+    env.apply(&mut after);
+    after
+        .args(["daemon", "status"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "version={}",
+            env!("CARGO_PKG_VERSION")
+        )))
+        .stdout(predicate::str::contains("version=0.0.0").not());
+}

--- a/tests/e2e/cache.rs
+++ b/tests/e2e/cache.rs
@@ -6,7 +6,7 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
 
-use super::helpers::{DaemonHandle, MultiRepoEnv, TestEnv};
+use super::helpers::{DaemonHandle, FakeDaemonHandle, MultiRepoEnv, TestEnv};
 
 /// merge-ready のバイナリ名
 const BIN: &str = "merge-ready";
@@ -220,8 +220,7 @@ fn test_daemon_multi_repo_isolation() {
 #[test]
 fn test_prompt_restarts_daemon_on_version_mismatch() {
     let env = TestEnv::new(OPEN_PR_VIEW_JSON, Some(CI_PASS_JSON));
-    let _old =
-        DaemonHandle::start_with_env(&env, &[("MERGE_READY_DAEMON_VERSION_OVERRIDE", "0.0.0")]);
+    let _old = FakeDaemonHandle::start_versioned(&env, "0.0.0");
 
     // 古い daemon が応答することを確認
     let mut before = Command::cargo_bin(BIN).unwrap();

--- a/tests/e2e/daemon.rs
+++ b/tests/e2e/daemon.rs
@@ -65,6 +65,23 @@ fn test_daemon_status_shows_running() {
         .stdout(predicate::str::contains("running"));
 }
 
+/// daemon status が version を出力する
+#[test]
+fn test_daemon_status_includes_version() {
+    let env = TestEnv::new(
+        r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}"#,
+        Some(r#"[{"bucket":"pass","state":"SUCCESS","name":"ci","link":""}]"#),
+    );
+    let _daemon = DaemonHandle::start(&env);
+
+    let mut cmd = Command::cargo_bin(BIN).unwrap();
+    env.apply(&mut cmd);
+    cmd.args(["daemon", "status"]);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains(env!("CARGO_PKG_VERSION")));
+}
+
 /// daemon stop 後 → status が "not running"
 #[test]
 fn test_daemon_stop_terminates() {

--- a/tests/e2e/helpers.rs
+++ b/tests/e2e/helpers.rs
@@ -7,6 +7,8 @@
 //! バイナリの実行ディレクトリを `repo_dir` に設定することで再現性を確保する。
 
 use std::fs;
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::UnixListener;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use tempfile::{TempDir, tempdir};
@@ -469,6 +471,75 @@ impl Drop for DaemonHandle {
             .env("TMPDIR", &self.tmpdir)
             .output();
         let _ = self.process.kill();
+    }
+}
+
+/// version 不一致を再現するための簡易 fake daemon。
+///
+/// `Status` には指定 version を返し、`Stop` 受信で終了する。
+pub struct FakeDaemonHandle {
+    join: Option<std::thread::JoinHandle<()>>,
+    socket_path: std::path::PathBuf,
+}
+
+impl FakeDaemonHandle {
+    #[must_use]
+    pub fn start_versioned(env: &TestEnv, version: &str) -> Self {
+        let socket_path = env.home().join(daemon_dir_name()).join("daemon.sock");
+        if let Some(parent) = socket_path.parent() {
+            fs::create_dir_all(parent).expect("create fake daemon dir");
+        }
+        let _ = fs::remove_file(&socket_path);
+
+        let listener = UnixListener::bind(&socket_path).expect("bind fake daemon socket");
+        let version = version.to_owned();
+        let socket_path_for_thread = socket_path.clone();
+        let join = std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(mut stream) = stream else {
+                    continue;
+                };
+                let mut line = String::new();
+                {
+                    let mut reader = BufReader::new(&stream);
+                    if reader.read_line(&mut line).is_err() {
+                        continue;
+                    }
+                }
+                if line.contains("\"action\":\"status\"") {
+                    let _ = stream.write_all(
+                        format!(
+                            "{{\"tag\":\"status\",\"pid\":1,\"entries\":0,\"uptime_secs\":0,\"version\":\"{version}\"}}\n"
+                        )
+                        .as_bytes(),
+                    );
+                } else if line.contains("\"action\":\"stop\"") {
+                    let _ = stream.write_all(b"{\"tag\":\"ok\"}\n");
+                    break;
+                } else {
+                    let _ = stream.write_all(b"{\"tag\":\"miss\"}\n");
+                }
+            }
+            let _ = fs::remove_file(&socket_path_for_thread);
+        });
+
+        Self {
+            join: Some(join),
+            socket_path,
+        }
+    }
+}
+
+impl Drop for FakeDaemonHandle {
+    fn drop(&mut self) {
+        // Ensure the fake server thread is not left behind if a test fails early.
+        let _ = std::os::unix::net::UnixStream::connect(&self.socket_path).and_then(|mut stream| {
+            stream.write_all(b"{\"action\":\"stop\"}\n")
+        });
+        if let Some(join) = self.join.take() {
+            let _ = join.join();
+        }
+        let _ = fs::remove_file(&self.socket_path);
     }
 }
 

--- a/tests/e2e/helpers.rs
+++ b/tests/e2e/helpers.rs
@@ -8,8 +8,8 @@
 
 use std::fs;
 use std::io::{BufRead, BufReader, Write};
-use std::os::unix::net::UnixListener;
 use std::os::unix::fs::PermissionsExt;
+use std::os::unix::net::UnixListener;
 use std::path::Path;
 use tempfile::{TempDir, tempdir};
 
@@ -533,9 +533,8 @@ impl FakeDaemonHandle {
 impl Drop for FakeDaemonHandle {
     fn drop(&mut self) {
         // Ensure the fake server thread is not left behind if a test fails early.
-        let _ = std::os::unix::net::UnixStream::connect(&self.socket_path).and_then(|mut stream| {
-            stream.write_all(b"{\"action\":\"stop\"}\n")
-        });
+        let _ = std::os::unix::net::UnixStream::connect(&self.socket_path)
+            .and_then(|mut stream| stream.write_all(b"{\"action\":\"stop\"}\n"));
         if let Some(join) = self.join.take() {
             let _ = join.join();
         }


### PR DESCRIPTION
## Why
After upgrading `merge-ready`, an old daemon process can remain running and continue serving stale behavior/protocol assumptions. This mismatch can lead to cache inconsistencies and unreliable prompt output.

## What
- add daemon `version` to the status protocol/response path
- expose daemon version in `daemon status` output for observability
- add prompt-side compatibility check in `DaemonClient::query`
- auto-restart daemon on version mismatch (`stop -> start`) before querying cache
- document why the per-query version check latency is acceptable (upgrade-window-only mismatch risk)
- add E2E tests for:
  - daemon status includes current version
  - prompt detects mismatch and recovers by restarting daemon
- simulate old-daemon mismatch in E2E via a fake daemon test helper (no test-only runtime env var in production path)

## Test plan
- [x] `cargo test --workspace daemon_status_includes_version`
- [x] `cargo test --workspace prompt_restarts_daemon_on_version_mismatch`
- [x] `cargo test --workspace`

Closes #104