### PR TITLE
test: strengthen repo_id worktree separation checks (#98)

### DIFF
--- a/src/contexts/merge_readiness/infrastructure/repo_id.rs
+++ b/src/contexts/merge_readiness/infrastructure/repo_id.rs
@@ -71,10 +71,10 @@ mod tests {
         dir
     }
 
-    // worktree: main_repo/.git/worktrees/feat/HEAD + worktree/.git (file)
+    // worktree: main_repo/.git/worktrees/<branch>/HEAD + worktree/.git (file)
     fn make_worktree(branch: &str) -> (TempDir, TempDir) {
         let main_repo = TempDir::new().unwrap();
-        let worktree_meta = main_repo.path().join(".git/worktrees/feat");
+        let worktree_meta = main_repo.path().join(format!(".git/worktrees/{branch}"));
         fs::create_dir_all(&worktree_meta).unwrap();
         fs::write(
             worktree_meta.join("HEAD"),
@@ -144,10 +144,33 @@ mod tests {
 
     #[test]
     fn worktree_head_returns_branch_name() {
-        let (main_repo, _worktree) = make_worktree("feat");
-        let git_dir = main_repo.path().join(".git/worktrees/feat");
+        let (_main_repo, worktree) = make_worktree("feat");
+        let (_, git_dir) = find_git_dir(worktree.path()).unwrap();
         let branch = read_head(&git_dir).unwrap();
         assert_eq!(branch, "feat");
+    }
+
+    #[test]
+    fn worktree_repo_id_differs_from_main_repo_id() {
+        let main_repo = make_normal_repo("main");
+        let (_worktree_main_repo, worktree) = make_worktree("feat");
+
+        let (main_toplevel, main_git_dir) = find_git_dir(main_repo.path()).unwrap();
+        let (worktree_toplevel, worktree_git_dir) = find_git_dir(worktree.path()).unwrap();
+
+        let main_branch = read_head(&main_git_dir).unwrap_or_default();
+        let worktree_branch = read_head(&worktree_git_dir).unwrap_or_default();
+        assert_eq!(main_branch, "main");
+        assert_eq!(worktree_branch, "feat");
+
+        let main_id = path_to_id(&format!("{}\0{}", main_toplevel.display(), main_branch));
+        let worktree_id = path_to_id(&format!(
+            "{}\0{}",
+            worktree_toplevel.display(),
+            worktree_branch
+        ));
+
+        assert_ne!(main_id, worktree_id);
     }
 
     // ── path_to_id ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add a dedicated regression test in `repo_id.rs` to verify that a repo_id resolved from a worktree path is different from the main repository repo_id.
- Fix the worktree test fixture so `make_worktree(branch)` actually creates metadata under `.git/worktrees/<branch>` instead of a hardcoded `feat` path.
- Update `worktree_head_returns_branch_name` to use the real returned worktree path and resolve `git_dir` through `find_git_dir`, ensuring the test validates actual worktree behavior.
- Keep temporary main-repo handles alive in tests to prevent accidental deletion of worktree backing metadata during execution.
- Add explicit branch assertions (`main` / `feat`) in the new test so the computed IDs are validated against expected branch sources before collision checks.

## Why this change
Issue #98 identified that existing tests only checked branch name parsing from worktree metadata, but did not prove `repo_id` uniqueness between main repo and worktrees. This could allow silent collisions in cache keys. The new test closes that gap by asserting the expected non-collision invariant.

## Test plan
- [x] `cargo test repo_id::tests::worktree_`

Made with [Cursor](https://cursor.com)