### PR TITLE
docs: add README docs for each context

### DIFF
--- a/src/contexts/README.md
+++ b/src/contexts/README.md
@@ -12,32 +12,6 @@
 
 ## 関係図（責務のつながり）
 
-```text
-                         reads/writes settings
-                    +-----------------------------+
-                    |        configuration        |
-                    |  token style, user config   |
-                    +-----------------------------+
-                              ^
-                              | uses presentation settings
-                              |
-+-----------------------------+-----------------------------+
-|                        merge_readiness                    |
-|  fetch PR state -> evaluate policy -> output tokens       |
-+-----------------------------+-----------------------------+
-                              ^
-                              | computes and returns tokens
-                              |
-                    +-----------------------------+
-                    |         status_cache        |
-                    | daemon lifecycle + cache    |
-                    +-----------------------------+
-                              ^
-                              | serves prompt command quickly
-                              |
-                           CLI (`merge-ready prompt`)
-```
-
 ```mermaid
 flowchart TD
     CLI["CLI (`merge-ready prompt`)"] -->|serves prompt command quickly| SC["status_cache<br/>daemon lifecycle + cache"]

--- a/src/contexts/README.md
+++ b/src/contexts/README.md
@@ -1,0 +1,53 @@
+# contexts
+
+`merge-ready` は責務ごとに 3 つのコンテキストへ分割されています。
+各コンテキストは `domain / application / infrastructure / interface` のレイヤーで構成され、
+関心事を分離した設計になっています。
+
+## コンテキスト一覧
+
+- `configuration`: 設定の取得・更新を担当
+- `merge_readiness`: PR のマージ可否判定を担当
+- `status_cache`: デーモンとキャッシュによる低遅延応答を担当
+
+## 関係図（責務のつながり）
+
+```text
+                         reads/writes settings
+                    +-----------------------------+
+                    |        configuration        |
+                    |  token style, user config   |
+                    +-----------------------------+
+                              ^
+                              | uses presentation settings
+                              |
++-----------------------------+-----------------------------+
+|                        merge_readiness                    |
+|  fetch PR state -> evaluate policy -> output tokens       |
++-----------------------------+-----------------------------+
+                              ^
+                              | computes and returns tokens
+                              |
+                    +-----------------------------+
+                    |         status_cache        |
+                    | daemon lifecycle + cache    |
+                    +-----------------------------+
+                              ^
+                              | serves prompt command quickly
+                              |
+                           CLI (`merge-ready prompt`)
+```
+
+```mermaid
+flowchart TD
+    CLI["CLI (`merge-ready prompt`)"] -->|serves prompt command quickly| SC["status_cache<br/>daemon lifecycle + cache"]
+    SC -->|computes and returns tokens| MR["merge_readiness<br/>fetch PR state -> evaluate policy -> output tokens"]
+    MR -->|uses presentation settings| CFG["configuration<br/>token style, user config"]
+    CFG -->|reads/writes settings| CFG
+```
+
+## 補足
+
+- `merge_readiness` は判定ロジックの中核で、表示用トークンを生成します。
+- `status_cache` はその結果をキャッシュして、プロンプト呼び出しを高速化します。
+- `configuration` はトークン表示や挙動に関わる設定を提供し、他コンテキストから参照されます。

--- a/src/contexts/configuration/README.md
+++ b/src/contexts/configuration/README.md
@@ -1,0 +1,21 @@
+# configuration context
+
+## 役割
+
+`configuration` コンテキストは、`merge-ready` の表示設定やトークン設定を扱うコンテキストです。
+ユーザー設定の読み込みと更新を、ドメインに依存しない形で提供します。
+
+## 提供する機能
+
+- 設定値を取得するためのサービス (`application/config_service.rs`)
+- 設定値を更新するためのユースケース (`application/config_updater.rs`)
+- 設定オブジェクトとリポジトリ境界 (`domain/config.rs`, `domain/repository.rs`)
+- TOML ベースの永続化実装 (`infrastructure/toml_loader.rs`)
+- CLI からの操作入口 (`interface/cli/`)
+
+## レイヤー構成
+
+- `domain/`: 設定モデルと抽象リポジトリ
+- `application/`: 設定取得・更新のユースケース
+- `infrastructure/`: TOML 読み書きなどの外部 I/O 実装
+- `interface/`: CLI コマンドの受け口

--- a/src/contexts/merge_readiness/README.md
+++ b/src/contexts/merge_readiness/README.md
@@ -1,0 +1,28 @@
+# merge_readiness context
+
+## 役割
+
+`merge_readiness` コンテキストは、現在のブランチに紐づく Pull Request が
+マージ可能かどうかを判定する中核コンテキストです。
+GitHub から取得した状態をポリシーで評価し、プロンプト表示用のトークンに変換します。
+
+## 提供する機能
+
+- PR の状態取得 (`pr_state`)
+- ブランチ同期状態の判定 (`branch_sync`)
+- CI チェック結果の集約 (`ci_checks`)
+- レビュー状態の判定 (`review`)
+- 最終的なマージ可否評価 (`merge_ready`, `policy`)
+- トークンの表示責務 (`interface/presentation.rs`)
+
+## レイヤー構成
+
+- `domain/`: 判定ロジック、ポリシー、状態モデル
+- `application/`: ユースケース実行と出力トークン生成
+- `infrastructure/`: `gh` 呼び出しやロギング実装
+- `interface/`: CLI 入力と表示変換
+
+## 補足
+
+`application::run` では、独立した取得処理を並列実行して待ち時間を短縮しつつ、
+評価結果を `OutputToken` に正規化して上位層へ返します。

--- a/src/contexts/status_cache/README.md
+++ b/src/contexts/status_cache/README.md
@@ -1,0 +1,22 @@
+# status_cache context
+
+## 役割
+
+`status_cache` コンテキストは、`merge-ready prompt` の低遅延応答のために
+バックグラウンドデーモンとキャッシュを管理するコンテキストです。
+マージ判定結果をキャッシュし、CLI からは軽量に取得できるようにします。
+
+## 提供する機能
+
+- キャッシュモデルと更新ロジック (`domain/cache.rs`, `application/cache.rs`)
+- デーモン稼働状態の管理 (`domain/daemon.rs`, `application/lifecycle.rs`)
+- デーモンサーバー/クライアント実装 (`infrastructure/daemon_server.rs`, `infrastructure/daemon_client.rs`)
+- デーモンの PID・ソケット・パス管理 (`infrastructure/pid.rs`, `infrastructure/paths.rs`)
+- CLI からの `daemon` サブコマンド (`interface/cli/daemon.rs`)
+
+## レイヤー構成
+
+- `domain/`: キャッシュとデーモンの状態モデル
+- `application/`: キャッシュ運用・ライフサイクル制御
+- `infrastructure/`: IPC プロトコルとプロセス実装
+- `interface/`: CLI コマンド処理


### PR DESCRIPTION
## Summary
- add `README.md` under each context directory (`configuration`, `merge_readiness`, `status_cache`) to explain responsibilities and layer structure
- add `src/contexts/README.md` as an index with cross-context responsibility flow
- include a Mermaid diagram to visualize context relationships (removed duplicate ASCII diagram)

## Test plan
- [x] Verify new README files exist under `src/contexts/*`
- [x] Confirm Mermaid diagram block is present and renders on GitHub
- [ ] Run full CI test suite (not required for docs-only change)

Made with [Cursor](https://cursor.com)