### PR TITLE
refactor: reduce cargo-modules synthetic cycle hotspots

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -8,7 +8,7 @@ use crate::contexts::configuration::infrastructure::toml_loader::TomlConfigRepos
 use crate::contexts::merge_readiness::application::{
     OutputToken,
     errors::ErrorToken,
-    prompt::{ExecutionMode, RepoIdPort},
+    prompt::ExecutionMode,
 };
 use crate::contexts::merge_readiness::infrastructure::{gh::GhClient, logger::Logger};
 use crate::contexts::merge_readiness::interface::{
@@ -19,14 +19,6 @@ use crate::contexts::status_cache::application::cache as status_cache_app;
 use crate::contexts::status_cache::infrastructure::daemon_client::{
     self as daemon_client, DaemonClient,
 };
-
-struct InfraRepoIdPort;
-
-impl RepoIdPort for InfraRepoIdPort {
-    fn get(&self) -> Option<String> {
-        crate::contexts::merge_readiness::infrastructure::repo_id::get()
-    }
-}
 
 impl crate::contexts::merge_readiness::application::errors::ErrorLogger for Logger {
     fn log(&self, msg: &str) {
@@ -65,7 +57,6 @@ impl PresentationConfigPort for ConfigAdapter {
 }
 
 pub fn run(cli: Cli) -> ExitCode {
-    let repo_id_port = InfraRepoIdPort;
     match cli.command {
         Some(Command::Prompt(args)) => match prompt::resolve_mode(&args) {
             ExecutionMode::Direct => {
@@ -77,7 +68,10 @@ pub fn run(cli: Cli) -> ExitCode {
                 ExitCode::SUCCESS
             }
             ExecutionMode::Cached => {
-                prompt::cached::run(&repo_id_port, daemon_client::query_via_daemon);
+                prompt::cached::run(
+                    crate::contexts::merge_readiness::infrastructure::repo_id::get,
+                    daemon_client::query_via_daemon,
+                );
                 ExitCode::SUCCESS
             }
         },

--- a/src/app.rs
+++ b/src/app.rs
@@ -6,9 +6,7 @@ use crate::cli::{Cli, Command};
 use crate::contexts::configuration::application::config_service::ConfigService;
 use crate::contexts::configuration::infrastructure::toml_loader::TomlConfigRepository;
 use crate::contexts::merge_readiness::application::{
-    OutputToken,
-    errors::ErrorToken,
-    prompt::ExecutionMode,
+    OutputToken, errors::ErrorToken, prompt::ExecutionMode,
 };
 use crate::contexts::merge_readiness::infrastructure::{gh::GhClient, logger::Logger};
 use crate::contexts::merge_readiness::interface::{

--- a/src/contexts/configuration/application/config_service.rs
+++ b/src/contexts/configuration/application/config_service.rs
@@ -1,4 +1,4 @@
-use super::super::domain::config::{Config, TokenConfig};
+use super::super::domain::config::{Config, TokenConfig, render_token};
 use super::super::domain::repository::ConfigRepository;
 
 pub struct ConfigService(Config);
@@ -9,89 +9,102 @@ impl ConfigService {
     }
 
     pub fn render_merge_ready(&self) -> String {
-        self.0
-            .merge_ready
-            .as_ref()
-            .unwrap_or(&default_token())
-            .render("✓", "merge-ready")
+        render_token(
+            self.0.merge_ready.as_ref().unwrap_or(&default_token()),
+            "✓",
+            "merge-ready",
+        )
     }
 
     pub fn render_conflict(&self) -> String {
-        self.0
-            .conflict
-            .as_ref()
-            .unwrap_or(&default_token())
-            .render("✗", "conflict")
+        render_token(
+            self.0.conflict.as_ref().unwrap_or(&default_token()),
+            "✗",
+            "conflict",
+        )
     }
 
     pub fn render_update_branch(&self) -> String {
-        self.0
-            .update_branch
-            .as_ref()
-            .unwrap_or(&default_token())
-            .render("✗", "update-branch")
+        render_token(
+            self.0.update_branch.as_ref().unwrap_or(&default_token()),
+            "✗",
+            "update-branch",
+        )
     }
 
     pub fn render_sync_unknown(&self) -> String {
-        self.0
-            .sync_unknown
-            .as_ref()
-            .unwrap_or(&default_token())
-            .render("?", "sync-unknown")
+        render_token(
+            self.0.sync_unknown.as_ref().unwrap_or(&default_token()),
+            "?",
+            "sync-unknown",
+        )
     }
 
     pub fn render_ci_fail(&self) -> String {
-        self.0
-            .ci_fail
-            .as_ref()
-            .unwrap_or(&default_token())
-            .render("✗", "ci-fail")
+        render_token(
+            self.0.ci_fail.as_ref().unwrap_or(&default_token()),
+            "✗",
+            "ci-fail",
+        )
     }
 
     pub fn render_ci_action(&self) -> String {
-        self.0
-            .ci_action
-            .as_ref()
-            .unwrap_or(&default_token())
-            .render("⚠", "ci-action")
+        render_token(
+            self.0.ci_action.as_ref().unwrap_or(&default_token()),
+            "⚠",
+            "ci-action",
+        )
     }
 
     pub fn render_review(&self) -> String {
-        self.0
-            .review
-            .as_ref()
-            .unwrap_or(&default_token())
-            .render("⚠", "review")
+        render_token(
+            self.0.review.as_ref().unwrap_or(&default_token()),
+            "⚠",
+            "review",
+        )
     }
 
     pub fn render_auth_required(&self) -> String {
-        self.0
-            .error
-            .as_ref()
-            .and_then(|ec| ec.auth_required.as_ref())
-            .unwrap_or(&default_token())
-            .render("!", "gh auth login")
+        render_token(
+            self.0
+                .error
+                .as_ref()
+                .and_then(|ec| ec.auth_required.as_ref())
+                .unwrap_or(&default_token()),
+            "!",
+            "gh auth login",
+        )
     }
 
     pub fn render_rate_limited(&self) -> String {
-        self.0
-            .error
-            .as_ref()
-            .and_then(|ec| ec.rate_limited.as_ref())
-            .unwrap_or(&default_token())
-            .render("✗", "rate-limited")
+        render_token(
+            self.0
+                .error
+                .as_ref()
+                .and_then(|ec| ec.rate_limited.as_ref())
+                .unwrap_or(&default_token()),
+            "✗",
+            "rate-limited",
+        )
     }
 
     pub fn render_api_error(&self) -> String {
-        self.0
-            .error
-            .as_ref()
-            .and_then(|ec| ec.api_error.as_ref())
-            .unwrap_or(&default_token())
-            .render("✗", "api-error")
+        render_token(
+            self.0
+                .error
+                .as_ref()
+                .and_then(|ec| ec.api_error.as_ref())
+                .unwrap_or(&default_token()),
+            "✗",
+            "api-error",
+        )
     }
 }
 
 fn default_token() -> TokenConfig {
-    TokenConfig::default()
+    TokenConfig {
+        symbol: None,
+        label: None,
+        format: None,
+    }
 }

--- a/src/contexts/configuration/domain/config.rs
+++ b/src/contexts/configuration/domain/config.rs
@@ -35,7 +35,7 @@ impl Config {
         self.ci_fail.get_or_insert_with(|| tok("✗", "ci-fail"));
         self.ci_action.get_or_insert_with(|| tok("⚠", "ci-action"));
         self.review.get_or_insert_with(|| tok("⚠", "review"));
-        let error = self.error.get_or_insert_with(ErrorConfig::default);
+        let error = self.error.get_or_insert_with(ErrorConfig::empty);
         error
             .auth_required
             .get_or_insert_with(|| tok("!", "gh auth login"));
@@ -46,26 +46,34 @@ impl Config {
     }
 }
 
-#[derive(Deserialize, Serialize, Default)]
+#[derive(Deserialize, Serialize)]
 pub struct TokenConfig {
     pub symbol: Option<String>,
     pub label: Option<String>,
     pub format: Option<String>,
 }
 
-impl TokenConfig {
-    #[must_use]
-    pub fn render(&self, default_symbol: &str, default_label: &str) -> String {
-        let symbol = self.symbol.as_deref().unwrap_or(default_symbol);
-        let label = self.label.as_deref().unwrap_or(default_label);
-        let fmt = self.format.as_deref().unwrap_or(DEFAULT_FORMAT);
-        fmt.replace("$symbol", symbol).replace("$label", label)
-    }
+#[must_use]
+pub fn render_token(token: &TokenConfig, default_symbol: &str, default_label: &str) -> String {
+    let symbol = token.symbol.as_deref().unwrap_or(default_symbol);
+    let label = token.label.as_deref().unwrap_or(default_label);
+    let fmt = token.format.as_deref().unwrap_or(DEFAULT_FORMAT);
+    fmt.replace("$symbol", symbol).replace("$label", label)
 }
 
-#[derive(Deserialize, Serialize, Default)]
+#[derive(Deserialize, Serialize)]
 pub struct ErrorConfig {
     pub auth_required: Option<TokenConfig>,
     pub rate_limited: Option<TokenConfig>,
     pub api_error: Option<TokenConfig>,
+}
+
+impl ErrorConfig {
+    fn empty() -> Self {
+        Self {
+            auth_required: None,
+            rate_limited: None,
+            api_error: None,
+        }
+    }
 }

--- a/src/contexts/merge_readiness/application/prompt.rs
+++ b/src/contexts/merge_readiness/application/prompt.rs
@@ -7,11 +7,6 @@ use crate::contexts::merge_readiness::domain::{
     merge_ready::MergeReadinessRepository, pr_state::PrStateRepository, review::ReviewRepository,
 };
 
-/// git リポジトリ ID を取得するポート
-pub trait RepoIdPort {
-    fn get(&self) -> Option<String>;
-}
-
 /// プロンプト表示の実行モード
 pub enum ExecutionMode {
     /// キャッシュを使わず gh を直接呼ぶ

--- a/src/contexts/merge_readiness/interface/cli/prompt/cached.rs
+++ b/src/contexts/merge_readiness/interface/cli/prompt/cached.rs
@@ -1,7 +1,5 @@
-use crate::contexts::merge_readiness::application::prompt::RepoIdPort;
-
-pub fn run(repo_id_port: &impl RepoIdPort, query: impl Fn(&str) -> Option<String>) {
-    let Some(id) = repo_id_port.get() else { return };
+pub fn run(repo_id: impl Fn() -> Option<String>, query: impl Fn(&str) -> Option<String>) {
+    let Some(id) = repo_id() else { return };
     run_with_writer(&id, query, &mut std::io::stdout());
 }
 
@@ -16,13 +14,6 @@ fn run_with_writer(id: &str, query: impl Fn(&str) -> Option<String>, w: &mut imp
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    struct FixedRepoId(Option<String>);
-    impl RepoIdPort for FixedRepoId {
-        fn get(&self) -> Option<String> {
-            self.0.clone()
-        }
-    }
 
     fn run_capture(id: &str, query: impl Fn(&str) -> Option<String>) -> String {
         let mut buf = Vec::new();


### PR DESCRIPTION
## Summary
- Replace `RepoIdPort` trait-object wiring in the prompt cached path with function injection to remove the `InfraRepoIdPort`/`::get` synthetic cycle.
- Move `TokenConfig::render` to a free function and remove `Default`-derived usage at call sites to avoid additional method-derived cycle nodes.
- Keep behavior unchanged while making `cargo modules dependencies --acyclic` advance beyond the originally reported failure.

## Test plan
- [x] `cargo test`
- [x] `cargo modules dependencies --acyclic`

Made with [Cursor](https://cursor.com)