### PR TITLE
fix: write error logs to merge-ready cache directory

### DIFF
--- a/src/contexts/merge_readiness/infrastructure/logger.rs
+++ b/src/contexts/merge_readiness/infrastructure/logger.rs
@@ -3,7 +3,7 @@ use std::io::Write as _;
 
 pub struct Logger;
 
-/// `$HOME/.cache/ci-status/error.log` にエラーメッセージを追記する。
+/// `$HOME/.cache/merge-ready/error.log` にエラーメッセージを追記する。
 ///
 /// ディレクトリが存在しない場合は自動的に作成する。
 /// 書き込み失敗は静かに握り潰す（`stderr` には何も出力しない）。
@@ -11,7 +11,7 @@ pub fn append_error(message: &str) {
     let Some(home) = std::env::var_os("HOME") else {
         return;
     };
-    let log_dir = std::path::Path::new(&home).join(".cache/ci-status");
+    let log_dir = std::path::Path::new(&home).join(".cache/merge-ready");
     let _ = fs::create_dir_all(&log_dir);
     let log_path = log_dir.join("error.log");
     let Ok(mut file) = OpenOptions::new().create(true).append(true).open(log_path) else {

--- a/tests/e2e/merge_readiness/errors.rs
+++ b/tests/e2e/merge_readiness/errors.rs
@@ -10,7 +10,7 @@
 //!   - `exit 1` + その他                → `✗ api-error`
 //!
 //! 各テストは独立した `TestEnv`（`bin_dir` + `home_dir`）を持つため、
-//! 並列実行時に `~/.cache/ci-status/error.log` が競合しない。
+//! 並列実行時に `~/.cache/merge-ready/error.log` が競合しない。
 
 use super::super::helpers::TestEnv;
 use assert_cmd::Command;
@@ -130,12 +130,12 @@ fn test_gh_timeout() {
 
 // ─── エラーログ ───────────────────────────────────────────────────────────
 
-/// API エラー発生時に `$HOME/.cache/ci-status/error.log` へ追記されること。
+/// API エラー発生時に `$HOME/.cache/merge-ready/error.log` へ追記されること。
 /// `TestEnv` の `home_dir` を `HOME` に設定しているため実際の `~` には書き込まれない。
 #[test]
 fn test_error_log_written() {
     let env = TestEnv::with_error("HTTP 500: Internal Server Error", 1);
-    let log_path = env.home().join(".cache/ci-status/error.log");
+    let log_path = env.home().join(".cache/merge-ready/error.log");
 
     let mut cmd = Command::cargo_bin("merge-ready").unwrap();
     env.apply(&mut cmd);


### PR DESCRIPTION
## Summary
- Replace legacy error log path from `~/.cache/ci-status/error.log` to `~/.cache/merge-ready/error.log`.
- Update E2E error tests and documentation comments to match the corrected cache directory.
- Keep scope limited to the bugfix only.

## Test plan
- [x] `cargo test --test e2e merge_readiness::errors::test_error_log_written -- --exact`
- [x] `cargo test --test e2e merge_readiness::errors -- --nocapture`

Made with [Cursor](https://cursor.com)