### PR TITLE
refactor: cache daemon error outputs and unify fetch flow

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -11,9 +11,10 @@ use crate::contexts::prompt::application::{
     OutputToken, errors::ErrorToken, prompt::ExecutionMode,
 };
 use crate::contexts::prompt::infrastructure::{gh::GhClient, logger::Logger};
+use crate::contexts::prompt::interface::presentation::Presenter;
 use crate::contexts::prompt::interface::{
     cli::prompt::{self},
-    presentation::{PresentationConfigPort, Presenter},
+    presentation::PresentationConfigPort,
 };
 
 impl crate::contexts::prompt::application::errors::ErrorLogger for Logger {
@@ -84,15 +85,18 @@ pub fn run(cli: Cli) -> ExitCode {
                 crate::contexts::daemon::infrastructure::daemon_lifecycle::DaemonLifecycle::new(
                     |repo_id: &str, cwd: &std::path::Path| {
                         let repo_id = repo_id.to_owned();
-                        let tokens = crate::contexts::prompt::application::prompt::fetch_output(
-                            &GhClient::new_in(cwd.to_path_buf()),
-                            &Logger,
-                        );
-                        if let Some(tokens) = tokens {
-                            let output =
-                                Presenter::new(ConfigAdapter::load()).render_to_string(&tokens);
-                            daemon_cache_app::update(&DaemonClient, &repo_id, &output);
-                        }
+                        let (tokens, error) =
+                            crate::contexts::prompt::application::prompt::fetch_output(
+                                &GhClient::new_in(cwd.to_path_buf()),
+                                &Logger,
+                            );
+                        let config = ConfigAdapter::load();
+                        let output = if let Some(err) = error {
+                            config.render_error_token(err)
+                        } else {
+                            Presenter::new(config).render_to_string(&tokens)
+                        };
+                        daemon_cache_app::update(&DaemonClient, &repo_id, &output);
                     },
                 );
             crate::contexts::daemon::interface::cli::daemon::run(args.subcommand, &lifecycle);

--- a/src/contexts/prompt/application/prompt.rs
+++ b/src/contexts/prompt/application/prompt.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
 
 use super::OutputToken;
 use super::errors::{ErrorLogger, ErrorPresenter, ErrorToken};
@@ -15,10 +15,11 @@ pub enum ExecutionMode {
     Cached,
 }
 
-/// gh を呼んで出力トークンを返す。エラー発生時は `None` を返す（daemon 書き込み回避）。
+/// gh を呼んで出力トークンとエラートークンを返す。
 ///
-/// `daemon refresh` 処理用。エラーは stderr に出力せず内部追跡のみ行う。
-pub fn fetch_output<C, L>(client: &C, logger: &L) -> Option<Vec<OutputToken>>
+/// `daemon refresh` 処理用。エラーは stderr に出力せず内部で捕捉する。
+/// エラー発生時は `Option<ErrorToken>` に値が入り、daemon がキャッシュに書き込める。
+pub fn fetch_output<C, L>(client: &C, logger: &L) -> (Vec<OutputToken>, Option<ErrorToken>)
 where
     C: PrStateRepository
         + BranchSyncRepository
@@ -28,21 +29,24 @@ where
         + Sync,
     L: ErrorLogger + Sync,
 {
-    struct TrackingPresenter(AtomicBool);
+    struct CapturingPresenter(Mutex<Option<ErrorToken>>);
 
-    impl ErrorPresenter for TrackingPresenter {
-        fn show_error(&self, _token: ErrorToken) {
-            self.0
-                .update(Ordering::Relaxed, Ordering::Relaxed, |_| true);
+    impl ErrorPresenter for CapturingPresenter {
+        fn show_error(&self, token: ErrorToken) {
+            *self
+                .0
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(token);
         }
     }
 
-    let presenter = TrackingPresenter(AtomicBool::new(false));
+    let presenter = CapturingPresenter(Mutex::new(None));
     let tokens = super::run(client, logger, &presenter);
+    let error = presenter
+        .0
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .take();
 
-    if presenter.0.load(Ordering::Relaxed) {
-        None
-    } else {
-        Some(tokens)
-    }
+    (tokens, error)
 }

--- a/tests/e2e/prompt/errors.rs
+++ b/tests/e2e/prompt/errors.rs
@@ -1,21 +1,20 @@
 //! エラー系 E2E テスト（シナリオ #34–41）
 //!
 //! `gh` CLI の各エラーシナリオに対して正しい `stdout` が返ることを検証する。
-//! daemon はエラー状態をキャッシュしないため、Direct パス（`--no-cache`）で検証する。
+//! daemon がエラー状態をキャッシュするため、daemon 経由（キャッシュパス）で検証する。
 //! 各テストは独立した `TestEnv`（`bin_dir` + `home_dir`）を持つため、
 //! 並列実行時に `error.log` が競合しない。
 
 use assert_cmd::Command;
 use rstest::rstest;
 
-use super::super::helpers::TestEnv;
+use super::super::helpers::{DaemonHandle, TestEnv};
 
 const BIN: &str = "merge-ready";
 
 fn cmd(env: &TestEnv) -> Command {
     let mut c = Command::cargo_bin(BIN).unwrap();
-    env.apply(&mut c);
-    c.args(["prompt", "--no-cache"]);
+    env.apply_with_cache(&mut c);
     c
 }
 
@@ -25,6 +24,9 @@ fn cmd(env: &TestEnv) -> Command {
 #[test]
 fn test_gh_not_installed() {
     let env = TestEnv::without_gh();
+    let _daemon = DaemonHandle::start(&env);
+    DaemonHandle::wait_for_cache(&env, 5000);
+
     cmd(&env)
         .assert()
         .success()
@@ -61,6 +63,9 @@ fn test_gh_not_installed() {
 )]
 fn test_error_output(#[case] msg: &str, #[case] code: u8, #[case] expected: &str) {
     let env = TestEnv::with_error(msg, code);
+    let _daemon = DaemonHandle::start(&env);
+    DaemonHandle::wait_for_cache(&env, 5000);
+
     cmd(&env)
         .assert()
         .success()
@@ -74,12 +79,10 @@ fn test_error_output(#[case] msg: &str, #[case] code: u8, #[case] expected: &str
 #[test]
 fn test_gh_timeout() {
     let env = TestEnv::with_hanging_gh();
-    cmd(&env)
-        .env("MERGE_READY_GH_TIMEOUT_SECS", "2")
-        .timeout(std::time::Duration::from_secs(5))
-        .assert()
-        .success()
-        .stdout("✗ api-error");
+    let _daemon = DaemonHandle::start_with_env(&env, &[("MERGE_READY_GH_TIMEOUT_SECS", "2")]);
+    DaemonHandle::wait_for_cache(&env, 10000);
+
+    cmd(&env).assert().success().stdout("✗ api-error");
 }
 
 // ── #41: エラーログ ───────────────────────────────────────────────────────────
@@ -89,6 +92,8 @@ fn test_gh_timeout() {
 fn test_error_log_written() {
     let env = TestEnv::with_error("HTTP 500: Internal Server Error", 1);
     let log_path = env.home().join(".cache/merge-ready/error.log");
+    let _daemon = DaemonHandle::start(&env);
+    DaemonHandle::wait_for_cache(&env, 5000);
 
     cmd(&env).assert().success();
 


### PR DESCRIPTION
## 概要

Issue [#122](https://github.com/toshiki670/merge-ready/issues/122) の対応として、daemon 経由でもエラー出力をキャッシュできるように実装を見直しました。

これまでの実装では、`fetch_output()` がエラー時に `None` を返していたため、daemon 側で `update()` が呼ばれず、エラー系 E2E は `--no-cache`（Direct パス）でしか検証できませんでした。

本PRでは、以下の方針で修正しています。

- `fetch_output()` の返り値を `Option<Vec<OutputToken>>` から `(Vec<OutputToken>, Option<ErrorToken>)` に変更
  - 正常系トークンとエラー種別を同時に扱えるようにし、エラー時も daemon 更新フローに乗せる
- `fetch_output()` 内の `TrackingPresenter`（エラー有無の bool 追跡）を、`ErrorToken` を保持する `CapturingPresenter`（ローカル構造体）へ変更
  - presentation 層への依存を増やさず、application 層内で完結
- daemon の `on_refresh` コールバックを変更
  - 正常系: 既存どおりトークンをレンダリング
  - エラー系: `ErrorToken` をレンダリング
  - いずれも最終的に `daemon_cache_app::update()` を必ず呼ぶ

これにより、エラー時もキャッシュに値が入り、`prompt` のキャッシュパスからエラー状態を再現できるようになります。

あわせて、既存のエラー系 E2E（シナリオ #34〜#41）を daemon 経由に切り替えています。

- 対象: `tests/e2e/prompt/errors.rs`
- 変更点:
  - `--no-cache` を使う Direct 呼び出しを廃止
  - `DaemonHandle::start(...)` + `wait_for_cache(...)` を用いたキャッシュ経由検証へ移行

## 設計上の補足

`app.rs` にレンダリング責務が残っている点は、本PRではスコープ外として据え置き、別Issueで追跡しています。

- 関連Issue: [#123](https://github.com/toshiki670/merge-ready/issues/123)

## テスト計画

- [x] `cargo test --test e2e prompt::errors`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `bash scripts/check-layer-deps.sh`

## 期待される効果

- エラーシナリオを daemon 経由で E2E 検証できるようになる
- `--no-cache` 依存のテスト構成から段階的に脱却できる
- 実ユーザーの利用経路（daemon/cached path）に近い検証が可能になる