### PR TITLE
docs: remove --no-cache from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,6 @@ Show merge status tokens for prompt integration:
 merge-ready prompt
 ```
 
-Bypass the daemon cache and fetch fresh state directly from `gh`:
-
-```bash
-merge-ready prompt --no-cache
-```
-
 Example output:
 
 ```text


### PR DESCRIPTION
## Summary

- README.md から廃止済みの `--no-cache` オプションの説明を削除

#125 でオプション本体を削除済みだが、ドキュメントの更新が漏れていたため対応。

CHANGELOG.md の記述（実装時の変更履歴）は過去の記録として残す。

## Test plan

- [x] README.md に `--no-cache` の記述がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)