### PR TITLE
fix: migrate app-id to client-id in release-prepare workflow

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
## Summary

- `release-prepare.yml` の `actions/create-github-app-token@v3.1.1` で非推奨となった `app-id` パラメータを `client-id` へ移行する
- シークレット名 `APP_ID` は変更なし、入力パラメータ名のみの変更

Closes #129

## Test plan

- [ ] ワークフローを手動実行し、`Input 'app-id' has been deprecated` 警告が消えていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)