### PR TITLE
spike: stdout vs stderr のエラー出力 UX 検証

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -46,7 +46,7 @@ impl PresentationConfigPort for ConfigAdapter {
         match token {
             ErrorToken::AuthRequired => self.0.render_auth_required(),
             ErrorToken::RateLimited => self.0.render_rate_limited(),
-            ErrorToken::ApiError => self.0.render_api_error(),
+            ErrorToken::ApiError(msg) => msg,
         }
     }
 }

--- a/src/contexts/prompt/application/errors.rs
+++ b/src/contexts/prompt/application/errors.rs
@@ -7,14 +7,14 @@ pub trait ErrorLogger {
 /// エラー時に表示するトークンの意味オブジェクト
 ///
 /// 文字列表現への変換は presentation 層が担う。
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub enum ErrorToken {
     /// 認証が必要（ツール未インストール含む）
     AuthRequired,
     /// レート制限によりアクセス不可
     RateLimited,
-    /// 予期しない API エラー
-    ApiError,
+    /// 予期しない API エラー（raw メッセージを保持）
+    ApiError(String),
 }
 
 /// エラーをユーザーに表示するポート
@@ -39,7 +39,7 @@ pub fn handle(
         }
         RepositoryError::Unexpected(msg) => {
             err_logger.log(&msg);
-            err_presenter.show_error(ErrorToken::ApiError);
+            err_presenter.show_error(ErrorToken::ApiError(msg));
         }
     }
 }

--- a/src/contexts/prompt/interface/cli/prompt/cached.rs
+++ b/src/contexts/prompt/interface/cli/prompt/cached.rs
@@ -5,8 +5,8 @@ pub fn run(repo_id: impl Fn() -> Option<String>, query: impl Fn(&str) -> Option<
 
 fn run_with_writer(id: &str, query: impl Fn(&str) -> Option<String>, w: &mut impl std::io::Write) {
     // SPIKE: stdout と stderr 両方にエラーメッセージを出して見え方を比較する
-    write!(w, "HTTP 500: Internal Server Error").unwrap();
-    eprint!("HTTP 500: Internal Server Error");
+    write!(w, "[stdout] HTTP 500: Internal Server Error").unwrap();
+    eprint!("[stderr] HTTP 500: Internal Server Error");
     let _ = (id, query);
 }
 

--- a/src/contexts/prompt/interface/cli/prompt/cached.rs
+++ b/src/contexts/prompt/interface/cli/prompt/cached.rs
@@ -4,11 +4,9 @@ pub fn run(repo_id: impl Fn() -> Option<String>, query: impl Fn(&str) -> Option<
 }
 
 fn run_with_writer(id: &str, query: impl Fn(&str) -> Option<String>, w: &mut impl std::io::Write) {
-    match query(id) {
-        Some(s) if !s.is_empty() => write!(w, "{s}").unwrap(),
-        Some(_) => {}
-        None => write!(w, "? loading").unwrap(),
-    }
+    // SPIKE: 常に stdout にエラーメッセージを出してプロンプトへの見え方を確認する
+    write!(w, "HTTP 500: Internal Server Error").unwrap();
+    let _ = (id, query);
 }
 
 #[cfg(test)]

--- a/src/contexts/prompt/interface/cli/prompt/cached.rs
+++ b/src/contexts/prompt/interface/cli/prompt/cached.rs
@@ -4,8 +4,9 @@ pub fn run(repo_id: impl Fn() -> Option<String>, query: impl Fn(&str) -> Option<
 }
 
 fn run_with_writer(id: &str, query: impl Fn(&str) -> Option<String>, w: &mut impl std::io::Write) {
-    // SPIKE: 常に stdout にエラーメッセージを出してプロンプトへの見え方を確認する
+    // SPIKE: stdout と stderr 両方にエラーメッセージを出して見え方を比較する
     write!(w, "HTTP 500: Internal Server Error").unwrap();
+    eprint!("HTTP 500: Internal Server Error");
     let _ = (id, query);
 }
 


### PR DESCRIPTION
## 目的

Issue #100 の設計判断として、エラーメッセージを stdout / stderr のどちらに出力すべきかを Starship 環境で検証するスパイク。

> **このPRはマージしない。検証結果の記録が目的。**

## 検証内容

`merge-ready prompt` 実行時に stdout・stderr の両方に識別可能なメッセージを出力し、Starship プロンプトへの表示挙動を確認した。

```rust
write!(w, "[stdout] HTTP 500: Internal Server Error").unwrap();
eprint!("[stderr] HTTP 500: Internal Server Error");
```

## 検証結果

| 出力先 | Starship プロンプト | ターミナル直接実行 |
|---|---|---|
| stdout | **表示される** | 表示される |
| stderr | **表示されない** | 表示される |

Starship はコマンドの stderr を握り潰す。

## 結論

- **検知パス（エラートークン → Prompt 表示）は stdout 一択**
- 「stderr に出力して stdout を汚さない」選択肢は Starship 環境では機能しない
- ログファイルへの書き込みは引き続きファイル I/O で行う（stderr ではない）

## 関連

- Issue #100 にコメントとして記録済み: #issuecomment-4312673245