### PR TITLE
feat: ErrorCategory / LogRecord の導入と simplelog による構造化ロギング

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,6 +288,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,10 +530,12 @@ dependencies = [
  "assert_cmd",
  "clap",
  "criterion",
+ "log",
  "predicates",
  "rstest",
  "serde",
  "serde_json",
+ "simplelog",
  "tempfile",
  "toml",
 ]
@@ -536,12 +547,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -605,6 +631,12 @@ checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "predicates"
@@ -865,6 +897,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simplelog"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16257adbfaef1ee58b1363bdc0664c9b8e1e30aed86049635fb5f147d065a9c0"
+dependencies = [
+ "log",
+ "termcolor",
+ "time",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -901,10 +944,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinytemplate"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,10 @@ pedantic = "warn"
 
 [dependencies]
 clap = { version = "4.6.1", features = ["derive", "cargo"] }
+log = "0.4"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
+simplelog = "0.12"
 toml = "1.1.2"
 
 [[test]]

--- a/src/app.rs
+++ b/src/app.rs
@@ -15,12 +15,6 @@ use crate::contexts::prompt::interface::{
     presentation::PresentationConfigPort,
 };
 
-impl crate::contexts::prompt::application::errors::ErrorLogger for Logger {
-    fn log(&self, record: &crate::contexts::prompt::application::errors::LogRecord) {
-        crate::contexts::prompt::infrastructure::logger::append_log_record(record);
-    }
-}
-
 pub(crate) struct ConfigAdapter(ConfigService);
 
 impl ConfigAdapter {
@@ -69,6 +63,7 @@ pub fn run(cli: Cli) -> ExitCode {
             )
         }
         Some(Command::Daemon(args)) => {
+            crate::contexts::prompt::infrastructure::logger::init();
             let lifecycle =
                 crate::contexts::daemon::infrastructure::daemon_lifecycle::DaemonLifecycle::new(
                     |repo_id: &str, cwd: &std::path::Path| {

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,8 +16,8 @@ use crate::contexts::prompt::interface::{
 };
 
 impl crate::contexts::prompt::application::errors::ErrorLogger for Logger {
-    fn log(&self, msg: &str) {
-        crate::contexts::prompt::infrastructure::logger::append_error(msg);
+    fn log(&self, record: &crate::contexts::prompt::application::errors::LogRecord) {
+        crate::contexts::prompt::infrastructure::logger::append_log_record(record);
     }
 }
 

--- a/src/contexts/daemon/infrastructure/daemon_lifecycle.rs
+++ b/src/contexts/daemon/infrastructure/daemon_lifecycle.rs
@@ -22,6 +22,7 @@ impl DaemonLifecyclePort for DaemonLifecycle {
     fn start(&self) {
         if let Some(p) = pid::read() {
             if pid::is_alive(p) {
+                log::error!("daemon is already running (pid {p})");
                 eprintln!("merge-ready daemon is already running (pid {p})");
                 std::process::exit(1);
             }

--- a/src/contexts/daemon/infrastructure/daemon_server.rs
+++ b/src/contexts/daemon/infrastructure/daemon_server.rs
@@ -65,6 +65,7 @@ pub fn run(on_refresh: &RefreshFn) {
     let listener = match UnixListener::bind(&socket_path) {
         Ok(l) => l,
         Err(e) => {
+            log::error!("failed to bind socket: {e}");
             eprintln!("merge-ready daemon: failed to bind socket: {e}");
             std::process::exit(1);
         }
@@ -130,7 +131,10 @@ pub fn run(on_refresh: &RefreshFn) {
                 let on_refresh = Arc::clone(on_refresh);
                 std::thread::spawn(move || handle_client(s, &state, &on_refresh));
             }
-            Err(_) => break,
+            Err(e) => {
+                log::error!("listener error: {e}");
+                break;
+            }
         }
     }
 

--- a/src/contexts/prompt/application/errors.rs
+++ b/src/contexts/prompt/application/errors.rs
@@ -1,20 +1,4 @@
-use crate::contexts::prompt::domain::error::RepositoryError;
-
-/// ログ記録のためのエラーカテゴリ（原因調査パス）
-#[allow(dead_code)]
-pub enum ErrorCategory {
-    Auth,
-    RateLimit,
-    Timeout,
-    Unknown,
-}
-
-/// ログに記録する構造化エントリ（原因調査パス）
-pub struct LogRecord {
-    pub category: ErrorCategory,
-    /// `Unknown` 系のみ raw メッセージを保持する
-    pub detail: Option<String>,
-}
+use crate::contexts::prompt::domain::error::{ErrorCategory, LogRecord, RepositoryError};
 
 pub trait ErrorLogger {
     fn log(&self, record: &LogRecord);

--- a/src/contexts/prompt/application/errors.rs
+++ b/src/contexts/prompt/application/errors.rs
@@ -1,10 +1,26 @@
 use crate::contexts::prompt::domain::error::RepositoryError;
 
-pub trait ErrorLogger {
-    fn log(&self, msg: &str);
+/// ログ記録のためのエラーカテゴリ（原因調査パス）
+#[allow(dead_code)]
+pub enum ErrorCategory {
+    Auth,
+    RateLimit,
+    Timeout,
+    Unknown,
 }
 
-/// エラー時に表示するトークンの意味オブジェクト
+/// ログに記録する構造化エントリ（原因調査パス）
+pub struct LogRecord {
+    pub category: ErrorCategory,
+    /// `Unknown` 系のみ raw メッセージを保持する
+    pub detail: Option<String>,
+}
+
+pub trait ErrorLogger {
+    fn log(&self, record: &LogRecord);
+}
+
+/// エラー時に表示するトークンの意味オブジェクト（検知パス）
 ///
 /// 文字列表現への変換は presentation 層が担う。
 #[derive(Clone, Copy)]
@@ -34,11 +50,17 @@ pub fn handle(
         }
         RepositoryError::NotFound => {}
         RepositoryError::RateLimited => {
-            err_logger.log("rate limit");
+            err_logger.log(&LogRecord {
+                category: ErrorCategory::RateLimit,
+                detail: None,
+            });
             err_presenter.show_error(ErrorToken::RateLimited);
         }
         RepositoryError::Unexpected(msg) => {
-            err_logger.log(&msg);
+            err_logger.log(&LogRecord {
+                category: ErrorCategory::Unknown,
+                detail: Some(msg),
+            });
             err_presenter.show_error(ErrorToken::ApiError);
         }
     }

--- a/src/contexts/prompt/domain/error.rs
+++ b/src/contexts/prompt/domain/error.rs
@@ -11,3 +11,19 @@ pub enum RepositoryError {
     /// 上記に当てはまらない予期しないエラー
     Unexpected(String),
 }
+
+/// ログ記録のためのエラーカテゴリ（原因調査パス）
+#[allow(dead_code)]
+pub enum ErrorCategory {
+    Auth,
+    RateLimit,
+    Timeout,
+    Unknown,
+}
+
+/// ログに記録する構造化エントリ（原因調査パス）
+pub struct LogRecord {
+    pub category: ErrorCategory,
+    /// `Unknown` 系のみ raw メッセージを保持する
+    pub detail: Option<String>,
+}

--- a/src/contexts/prompt/infrastructure/logger.rs
+++ b/src/contexts/prompt/infrastructure/logger.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use simplelog::{Config, LevelFilter, WriteLogger};
 
-use crate::contexts::prompt::application::errors::{ErrorCategory, LogRecord};
+use crate::contexts::prompt::domain::error::{ErrorCategory, LogRecord};
 
 pub struct Logger;
 

--- a/src/contexts/prompt/infrastructure/logger.rs
+++ b/src/contexts/prompt/infrastructure/logger.rs
@@ -1,83 +1,41 @@
-use std::fs::{self, OpenOptions};
-use std::io::Write as _;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::fs::OpenOptions;
+use std::path::PathBuf;
+
+use simplelog::{Config, LevelFilter, WriteLogger};
 
 use crate::contexts::prompt::application::errors::{ErrorCategory, LogRecord};
 
 pub struct Logger;
 
-pub fn append_log_record(record: &LogRecord) {
-    let category = match record.category {
-        ErrorCategory::Auth => "Auth",
-        ErrorCategory::RateLimit => "RateLimit",
-        ErrorCategory::Timeout => "Timeout",
-        ErrorCategory::Unknown => "Unknown",
-    };
-    let message = match &record.detail {
-        Some(d) => format!("[{category}] {d}"),
-        None => format!("[{category}]"),
-    };
-    append_line(&message);
-}
-
-fn timestamp() -> String {
-    let secs = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_or(0, |d| d.as_secs());
-    // ISO 8601 相当の簡易フォーマット（外部クレートなし）
-    let (y, mo, d, h, mi, s) = secs_to_datetime(secs);
-    format!("{y:04}-{mo:02}-{d:02}T{h:02}:{mi:02}:{s:02}Z")
-}
-
-fn append_line(message: &str) {
-    let Some(home) = std::env::var_os("HOME") else {
+/// デーモン起動時に一度だけ呼ぶ。
+/// `$HOME/.cache/merge-ready/error.log` への追記ロガーを初期化する。
+/// 失敗は静かに無視する（ログが書けなくてもデーモンは止まらない）。
+pub fn init() {
+    let Some(path) = log_path() else { return };
+    let Ok(file) = OpenOptions::new().create(true).append(true).open(path) else {
         return;
     };
-    let log_dir = std::path::Path::new(&home).join(".cache/merge-ready");
-    let _ = fs::create_dir_all(&log_dir);
-    let log_path = log_dir.join("error.log");
-    let Ok(mut file) = OpenOptions::new().create(true).append(true).open(log_path) else {
-        return;
-    };
-    let _ = writeln!(file, "{} {message}", timestamp());
+    let _ = WriteLogger::init(LevelFilter::Error, Config::default(), file);
 }
 
-/// Unix タイムスタンプ（秒）を (year, month, day, hour, min, sec) に変換する。
-fn secs_to_datetime(secs: u64) -> (u64, u64, u64, u64, u64, u64) {
-    let sec = secs % 60;
-    let total_min = secs / 60;
-    let min = total_min % 60;
-    let total_hours = total_min / 60;
-    let hour = total_hours % 24;
-    let total_days = total_hours / 24;
-
-    // グレゴリオ暦への変換（ユリウス通日ベース）
-    let jdn = total_days + 719_468;
-    let era = jdn / 146_097;
-    let doe = jdn - era * 146_097;
-    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
-    let year = yoe + era * 400;
-    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-    let mp = (5 * doy + 2) / 153;
-    let day = doy - (153 * mp + 2) / 5 + 1;
-    let month = if mp < 10 { mp + 3 } else { mp - 9 };
-    let year = if month <= 2 { year + 1 } else { year };
-
-    (year, month, day, hour, min, sec)
+fn log_path() -> Option<PathBuf> {
+    let home = std::env::var_os("HOME")?;
+    let dir = std::path::Path::new(&home).join(".cache/merge-ready");
+    std::fs::create_dir_all(&dir).ok()?;
+    Some(dir.join("error.log"))
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn timestamp_epoch() {
-        assert_eq!(secs_to_datetime(0), (1970, 1, 1, 0, 0, 0));
-    }
-
-    #[test]
-    fn timestamp_known() {
-        // 2026-04-24T00:00:00Z = 1776988800
-        assert_eq!(secs_to_datetime(1_776_988_800), (2026, 4, 24, 0, 0, 0));
+impl crate::contexts::prompt::application::errors::ErrorLogger for Logger {
+    fn log(&self, record: &LogRecord) {
+        let category = match record.category {
+            ErrorCategory::Auth => "Auth",
+            ErrorCategory::RateLimit => "RateLimit",
+            ErrorCategory::Timeout => "Timeout",
+            ErrorCategory::Unknown => "Unknown",
+        };
+        match &record.detail {
+            Some(detail) => log::error!("[{category}] {detail}"),
+            None => log::error!("[{category}]"),
+        }
     }
 }

--- a/src/contexts/prompt/infrastructure/logger.rs
+++ b/src/contexts/prompt/infrastructure/logger.rs
@@ -1,13 +1,35 @@
 use std::fs::{self, OpenOptions};
 use std::io::Write as _;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::contexts::prompt::application::errors::{ErrorCategory, LogRecord};
 
 pub struct Logger;
 
-/// `$HOME/.cache/merge-ready/error.log` にエラーメッセージを追記する。
-///
-/// ディレクトリが存在しない場合は自動的に作成する。
-/// 書き込み失敗は静かに握り潰す（`stderr` には何も出力しない）。
-pub fn append_error(message: &str) {
+pub fn append_log_record(record: &LogRecord) {
+    let category = match record.category {
+        ErrorCategory::Auth => "Auth",
+        ErrorCategory::RateLimit => "RateLimit",
+        ErrorCategory::Timeout => "Timeout",
+        ErrorCategory::Unknown => "Unknown",
+    };
+    let message = match &record.detail {
+        Some(d) => format!("[{category}] {d}"),
+        None => format!("[{category}]"),
+    };
+    append_line(&message);
+}
+
+fn timestamp() -> String {
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs());
+    // ISO 8601 相当の簡易フォーマット（外部クレートなし）
+    let (y, mo, d, h, mi, s) = secs_to_datetime(secs);
+    format!("{y:04}-{mo:02}-{d:02}T{h:02}:{mi:02}:{s:02}Z")
+}
+
+fn append_line(message: &str) {
     let Some(home) = std::env::var_os("HOME") else {
         return;
     };
@@ -17,5 +39,45 @@ pub fn append_error(message: &str) {
     let Ok(mut file) = OpenOptions::new().create(true).append(true).open(log_path) else {
         return;
     };
-    let _ = writeln!(file, "{message}");
+    let _ = writeln!(file, "{} {message}", timestamp());
+}
+
+/// Unix タイムスタンプ（秒）を (year, month, day, hour, min, sec) に変換する。
+fn secs_to_datetime(secs: u64) -> (u64, u64, u64, u64, u64, u64) {
+    let sec = secs % 60;
+    let total_min = secs / 60;
+    let min = total_min % 60;
+    let total_hours = total_min / 60;
+    let hour = total_hours % 24;
+    let total_days = total_hours / 24;
+
+    // グレゴリオ暦への変換（ユリウス通日ベース）
+    let jdn = total_days + 719_468;
+    let era = jdn / 146_097;
+    let doe = jdn - era * 146_097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+    let year = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let day = doy - (153 * mp + 2) / 5 + 1;
+    let month = if mp < 10 { mp + 3 } else { mp - 9 };
+    let year = if month <= 2 { year + 1 } else { year };
+
+    (year, month, day, hour, min, sec)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timestamp_epoch() {
+        assert_eq!(secs_to_datetime(0), (1970, 1, 1, 0, 0, 0));
+    }
+
+    #[test]
+    fn timestamp_known() {
+        // 2026-04-24T00:00:00Z = 1776988800
+        assert_eq!(secs_to_datetime(1_776_988_800), (2026, 4, 24, 0, 0, 0));
+    }
 }


### PR DESCRIPTION
## 概要

Issue #100 の実装フェーズ。エラーの検知パス（Prompt 表示）と原因調査パス（ログ記録）を別々の型で表現し、`simplelog` を使った構造化ファイルロギングを導入する。

## 変更内容

### 1. ErrorCategory / LogRecord の新設

- `ErrorCategory`（`Auth / RateLimit / Timeout / Unknown`）を `domain::error` に新設
- `LogRecord { category, detail }` を `domain::error` に新設。`Unknown` 系のみ raw メッセージを保持
- `ErrorLogger::log` の引数を `&str` → `&LogRecord` に変更し、カテゴリ情報を構造として保持

### 2. simplelog の導入

- `log` + `simplelog` を依存に追加
- `logger::init()` を daemon 起動時に一度だけ呼ぶ設計
  - **prompt パスでは呼ばないため `log::error!()` は noop → ログ I/O コストゼロ**
- 手書きの日時変換・ファイル書き込みをすべて削除し simplelog に委譲

### 3. レイヤー依存違反の修正

`infrastructure → application` が禁止ルールに違反していたため、`ErrorCategory` と `LogRecord` を `domain::error` に移動。`application::errors` と `infrastructure::logger` の両方が `domain` 経由で参照する。

### 4. daemon server 内エラーのログ対応

daemon は double-spawn 構造で動作するため、起動後のバックグラウンドプロセス内の `eprintln!` はユーザー端末に届かない。該当箇所に `log::error!()` を追加してログファイルに記録されるようにした。

| 箇所 | エラー内容 | 対応 |
|---|---|---|
| `daemon_server.rs` | ソケットバインド失敗 | `log::error!()` 追加（`eprintln!` は outer プロセスへの中継として維持） |
| `daemon_server.rs` | `listener.incoming()` エラー | サイレント break から `log::error!()` 追加に変更 |
| `daemon_lifecycle.rs` | daemon 多重起動検知 | `log::error!()` 追加 |

## 設計上のポイント

```
検知パス: RepositoryError → ErrorToken → Prompt 表示（stdout）
調査パス: RepositoryError → LogRecord  → error.log（daemon のみ）
```

- `ErrorCategory::Auth` / `ErrorCategory::Timeout` は将来追加予定のため `#[allow(dead_code)]` で管理
- ログ初期化は daemon 起動時のみ。prompt サブコマンドは一切ログ I/O を行わない
- `process::exit()` の置き換えは別途 Issue #134 で対応

## 関連

Closes の一部 #100