### PR TITLE
refactor: ReviewStatus・PrLifecycle の状態語彙を拡張し粒度を上げる

### DIFF
--- a/src/contexts/prompt/domain/policy.rs
+++ b/src/contexts/prompt/domain/policy.rs
@@ -47,7 +47,7 @@ mod tests {
         let signals = PromptDecisionPolicy::evaluate(&PromptEvaluation {
             branch_sync: &BranchSync::new(super::super::branch_sync::BranchSyncStatus::Clean),
             ci_checks: &CiChecks::new(vec![super::super::ci_checks::CheckBucket::Other]),
-            review: &Review::new(super::super::review::ReviewStatus::Other),
+            review: &Review::new(super::super::review::ReviewStatus::Approved),
             readiness: &MergeReadiness {
                 is_draft: false,
                 is_protected: true,

--- a/src/contexts/prompt/domain/pr_state.rs
+++ b/src/contexts/prompt/domain/pr_state.rs
@@ -3,7 +3,8 @@ use super::error::RepositoryError;
 /// PR のライフサイクル状態（外部コマンドの文字列表現に非依存）
 pub enum PrLifecycle {
     Open,
-    NotOpen,
+    Merged,
+    Closed,
 }
 
 #[must_use]

--- a/src/contexts/prompt/domain/review/model.rs
+++ b/src/contexts/prompt/domain/review/model.rs
@@ -16,7 +16,9 @@ impl Review {
     pub fn signal(&self) -> Option<PromptSignal> {
         match self.status {
             ReviewStatus::ChangesRequested => Some(PromptSignal::ReviewRequested),
-            ReviewStatus::Other => None,
+            ReviewStatus::Approved | ReviewStatus::ReviewRequired | ReviewStatus::NoDecision => {
+                None
+            }
         }
     }
 }

--- a/src/contexts/prompt/domain/review/status.rs
+++ b/src/contexts/prompt/domain/review/status.rs
@@ -1,5 +1,7 @@
 /// レビュー決定状態
 pub enum ReviewStatus {
     ChangesRequested,
-    Other,
+    Approved,
+    ReviewRequired,
+    NoDecision,
 }

--- a/src/contexts/prompt/infrastructure/gh.rs
+++ b/src/contexts/prompt/infrastructure/gh.rs
@@ -160,10 +160,10 @@ impl MergeReadinessRepository for GhClient {
 // ── 翻訳関数（gh 固有文字列 → domain enum）──────────────────────────────────
 
 fn translate_lifecycle(state: &str) -> PrLifecycle {
-    if state == "OPEN" {
-        PrLifecycle::Open
-    } else {
-        PrLifecycle::NotOpen
+    match state {
+        "OPEN" => PrLifecycle::Open,
+        "MERGED" => PrLifecycle::Merged,
+        _ => PrLifecycle::Closed,
     }
 }
 
@@ -207,10 +207,11 @@ fn fetch_behind_by(base_ref: &str, head_ref: &str, cwd: Option<&std::path::Path>
 }
 
 fn translate_review(decision: Option<&str>) -> ReviewStatus {
-    if decision == Some("CHANGES_REQUESTED") {
-        ReviewStatus::ChangesRequested
-    } else {
-        ReviewStatus::Other
+    match decision {
+        Some("CHANGES_REQUESTED") => ReviewStatus::ChangesRequested,
+        Some("APPROVED") => ReviewStatus::Approved,
+        Some("REVIEW_REQUIRED") => ReviewStatus::ReviewRequired,
+        _ => ReviewStatus::NoDecision,
     }
 }
 


### PR DESCRIPTION
closes #78

## Summary

- `ReviewStatus::Other` を `Approved` / `ReviewRequired` / `NoDecision` に分解
- `PrLifecycle::NotOpen` を `Merged` / `Closed` に分解
- インフラ層の翻訳関数（`translate_review` / `translate_lifecycle`）を GitHub API の実値に対応する具体的なマッピングに更新
- 既存の merge-ready 判定挙動は互換保持（`ChangesRequested` のみ `ReviewRequested` シグナルを返す）

## Test plan

- [ ] `cargo test --workspace` — 95 テストすべてパス
- [ ] `cargo clippy --workspace -- -D warnings` — 警告なし
- [ ] `cargo fmt --check --all` — フォーマット差分なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)