### PR TITLE
feat!: config update サブコマンドと version フィールドの廃止、config edit → config への統合

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4,7 +4,6 @@ use clap::CommandFactory;
 
 use crate::adapters::ConfigAdapter;
 use crate::cli::{Cli, Command};
-use crate::contexts::config::infrastructure::toml_loader::TomlConfigRepository;
 use crate::contexts::daemon::application::cache as daemon_cache_app;
 use crate::contexts::daemon::infrastructure::daemon_client::{self as daemon_client, DaemonClient};
 use crate::contexts::prompt::infrastructure::{gh::GhClient, logger::Logger};
@@ -25,11 +24,7 @@ pub fn run(cli: Cli) -> ExitCode {
         }
         Some(Command::Config(args)) => {
             let config_path = crate::contexts::config::infrastructure::toml_loader::config_path();
-            crate::contexts::config::interface::cli::run(
-                &args,
-                &TomlConfigRepository,
-                config_path.as_deref(),
-            )
+            crate::contexts::config::interface::cli::run(&args, config_path.as_deref())
         }
         Some(Command::Daemon(args)) => {
             crate::contexts::prompt::infrastructure::logger::init();

--- a/src/app.rs
+++ b/src/app.rs
@@ -22,9 +22,9 @@ pub fn run(cli: Cli) -> ExitCode {
             );
             ExitCode::SUCCESS
         }
-        Some(Command::Config(args)) => {
+        Some(Command::Config) => {
             let config_path = crate::contexts::config::infrastructure::toml_loader::config_path();
-            crate::contexts::config::interface::cli::run(&args, config_path.as_deref())
+            crate::contexts::config::interface::cli::run(config_path.as_deref())
         }
         Some(Command::Daemon(args)) => {
             crate::contexts::prompt::infrastructure::logger::init();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,5 @@
 use clap::{Parser, Subcommand};
 
-use crate::contexts::config::interface::cli::ConfigArgs;
 use crate::contexts::daemon::interface::cli::DaemonArgs;
 use crate::contexts::prompt::interface::cli::prompt::{AFTER_HELP, PromptArgs};
 
@@ -20,8 +19,8 @@ pub enum Command {
     /// Show PR merge status for your shell prompt
     #[command(after_help = AFTER_HELP)]
     Prompt(PromptArgs),
-    /// Manage the configuration file
-    Config(ConfigArgs),
+    /// Open the configuration file in an editor (creates it with defaults if absent)
+    Config,
     /// Manage the background cache daemon
     Daemon(DaemonArgs),
 }

--- a/src/contexts/config/application.rs
+++ b/src/contexts/config/application.rs
@@ -1,3 +1,2 @@
 pub mod config_service;
 pub mod config_updater;
-pub mod port;

--- a/src/contexts/config/application/config_updater.rs
+++ b/src/contexts/config/application/config_updater.rs
@@ -1,21 +1,7 @@
-use super::super::domain::config::{CURRENT_VERSION, Config};
-use super::super::domain::repository::ConfigRepository;
-
-pub fn run(repo: &impl ConfigRepository) -> Result<(), std::io::Error> {
-    let mut config = repo.load();
-    if config.version == CURRENT_VERSION {
-        return Ok(());
-    }
-    config.version = CURRENT_VERSION;
-    config.fill_defaults();
-    repo.save(&config)
-}
+use super::super::domain::config::Config;
 
 pub fn default_config() -> Config {
-    let mut config = Config {
-        version: CURRENT_VERSION,
-        ..Config::default()
-    };
+    let mut config = Config::default();
     config.fill_defaults();
     config
 }

--- a/src/contexts/config/application/port.rs
+++ b/src/contexts/config/application/port.rs
@@ -1,5 +1,0 @@
-use super::super::domain::repository::ConfigRepository;
-
-/// 設定更新ユースケース向けポート（interface 層が domain 型を直接参照しないための facade）。
-pub trait UpdateConfigPort: ConfigRepository {}
-impl<T: ConfigRepository> UpdateConfigPort for T {}

--- a/src/contexts/config/domain/config.rs
+++ b/src/contexts/config/domain/config.rs
@@ -2,12 +2,8 @@ use serde::{Deserialize, Serialize};
 
 const DEFAULT_FORMAT: &str = "$symbol $label";
 
-pub const CURRENT_VERSION: u32 = 1;
-
 #[derive(Deserialize, Serialize, Default)]
 pub struct Config {
-    #[serde(default)]
-    pub version: u32,
     pub merge_ready: Option<TokenConfig>,
     pub conflict: Option<TokenConfig>,
     pub update_branch: Option<TokenConfig>,

--- a/src/contexts/config/domain/repository.rs
+++ b/src/contexts/config/domain/repository.rs
@@ -2,8 +2,4 @@ use super::config::Config;
 
 pub trait ConfigRepository {
     fn load(&self) -> Config;
-
-    /// # Errors
-    /// Returns `io::Error` when the config path is unavailable or write fails.
-    fn save(&self, config: &Config) -> Result<(), std::io::Error>;
 }

--- a/src/contexts/config/infrastructure/toml_loader.rs
+++ b/src/contexts/config/infrastructure/toml_loader.rs
@@ -16,20 +16,6 @@ impl ConfigRepository for TomlConfigRepository {
         };
         toml::from_str(&content).unwrap_or_default()
     }
-
-    /// # Errors
-    /// Returns `io::Error` when the config path is unavailable or write fails.
-    fn save(&self, config: &Config) -> Result<(), std::io::Error> {
-        let path = config_path().ok_or_else(|| {
-            std::io::Error::new(std::io::ErrorKind::NotFound, "config path not found")
-        })?;
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-        let content = toml::to_string_pretty(config)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-        std::fs::write(path, content)
-    }
 }
 
 // XDG_CONFIG_HOME が設定されていればそちらを優先し、なければ $HOME/.config にフォールバックする。

--- a/src/contexts/config/interface/cli.rs
+++ b/src/contexts/config/interface/cli.rs
@@ -1,3 +1,3 @@
 pub mod config;
 
-pub use config::{ConfigArgs, run};
+pub use config::run;

--- a/src/contexts/config/interface/cli/config.rs
+++ b/src/contexts/config/interface/cli/config.rs
@@ -3,10 +3,7 @@ use std::process::ExitCode;
 
 use clap::{Args, Subcommand};
 
-use crate::contexts::config::application::port::UpdateConfigPort;
-
 pub mod edit;
-pub mod update;
 
 #[derive(Args)]
 pub struct ConfigArgs {
@@ -18,15 +15,9 @@ pub struct ConfigArgs {
 pub enum ConfigCommand {
     /// Open the configuration file in an editor (creates it with defaults if absent)
     Edit,
-    /// Update the configuration file to the latest schema (preserves valid keys, removes obsolete ones, adds missing ones with defaults)
-    Update,
 }
 
-pub fn run(
-    args: &ConfigArgs,
-    port: &impl UpdateConfigPort,
-    config_path: Option<&Path>,
-) -> ExitCode {
+pub fn run(args: &ConfigArgs, config_path: Option<&Path>) -> ExitCode {
     match args.subcommand {
         ConfigCommand::Edit => {
             let Some(path) = config_path else {
@@ -37,13 +28,6 @@ pub fn run(
             };
             if let Err(e) = edit::run(path) {
                 eprintln!("failed to edit config: {e}");
-                return ExitCode::FAILURE;
-            }
-            ExitCode::SUCCESS
-        }
-        ConfigCommand::Update => {
-            if let Err(e) = update::run(port) {
-                eprintln!("failed to update config: {e}");
                 return ExitCode::FAILURE;
             }
             ExitCode::SUCCESS

--- a/src/contexts/config/interface/cli/config.rs
+++ b/src/contexts/config/interface/cli/config.rs
@@ -1,36 +1,18 @@
 use std::path::Path;
 use std::process::ExitCode;
 
-use clap::{Args, Subcommand};
-
 pub mod edit;
 
-#[derive(Args)]
-pub struct ConfigArgs {
-    #[command(subcommand)]
-    pub subcommand: ConfigCommand,
-}
-
-#[derive(Subcommand)]
-pub enum ConfigCommand {
-    /// Open the configuration file in an editor (creates it with defaults if absent)
-    Edit,
-}
-
-pub fn run(args: &ConfigArgs, config_path: Option<&Path>) -> ExitCode {
-    match args.subcommand {
-        ConfigCommand::Edit => {
-            let Some(path) = config_path else {
-                eprintln!(
-                    "failed to edit config: could not determine config path (HOME or XDG_CONFIG_HOME required)"
-                );
-                return ExitCode::FAILURE;
-            };
-            if let Err(e) = edit::run(path) {
-                eprintln!("failed to edit config: {e}");
-                return ExitCode::FAILURE;
-            }
-            ExitCode::SUCCESS
-        }
+pub fn run(config_path: Option<&Path>) -> ExitCode {
+    let Some(path) = config_path else {
+        eprintln!(
+            "failed to edit config: could not determine config path (HOME or XDG_CONFIG_HOME required)"
+        );
+        return ExitCode::FAILURE;
+    };
+    if let Err(e) = edit::run(path) {
+        eprintln!("failed to edit config: {e}");
+        return ExitCode::FAILURE;
     }
+    ExitCode::SUCCESS
 }

--- a/src/contexts/config/interface/cli/config/update.rs
+++ b/src/contexts/config/interface/cli/config/update.rs
@@ -1,5 +1,0 @@
-use crate::contexts::config::application::{config_updater, port::UpdateConfigPort};
-
-pub fn run(port: &impl UpdateConfigPort) -> Result<(), std::io::Error> {
-    config_updater::run(port)
-}

--- a/tests/e2e/config/config.rs
+++ b/tests/e2e/config/config.rs
@@ -1,9 +1,8 @@
-//! 設定ファイル（`~/.config/merge-ready.toml`）の E2E テスト（シナリオ #42–63）
+//! 設定ファイル（`~/.config/merge-ready.toml`）の E2E テスト（シナリオ #42–59）
 //!
 //! - #42–50: symbol / label / format のカスタマイズ、XDG_CONFIG_HOME の優先度
 //!   → prompt テストは daemon 経由フローで検証する
-//! - #51–58: `config edit` サブコマンド
-//! - #59–63: `config update` サブコマンド
+//! - #51–59: `config` サブコマンド（エディタ起動）
 
 use assert_cmd::Command;
 use predicates::prelude::*;
@@ -153,7 +152,7 @@ fn test_xdg_config_home_takes_precedence_over_home() {
     drop(child);
 }
 
-// ── #51–58: config edit ───────────────────────────────────────────────────────
+// ── #51–58: config ────────────────────────────────────────────────────────────
 
 /// #51: `$VISUAL` が設定されている場合、`$VISUAL` がファイルパスを引数として呼ばれる
 #[test]
@@ -166,7 +165,7 @@ fn test_config_edit_uses_visual() {
     env.apply(&mut c);
     c.env("VISUAL", &editor_path);
     c.env_remove("EDITOR");
-    c.args(["config", "edit"]);
+    c.args(["config"]);
     c.assert().success().stderr("");
 
     let called_path = std::fs::read_to_string(&log_path).expect("editor was not called");
@@ -187,7 +186,7 @@ fn test_config_edit_uses_editor_when_visual_unset() {
     env.apply(&mut c);
     c.env_remove("VISUAL");
     c.env("EDITOR", &editor_path);
-    c.args(["config", "edit"]);
+    c.args(["config"]);
     c.assert().success().stderr("");
 
     let called_path = std::fs::read_to_string(&log_path).expect("editor was not called");
@@ -208,7 +207,7 @@ fn test_config_edit_falls_back_to_vi() {
     env.apply(&mut c);
     c.env_remove("VISUAL");
     c.env_remove("EDITOR");
-    c.args(["config", "edit"]);
+    c.args(["config"]);
     c.assert().success().stderr("");
 
     let called_path = std::fs::read_to_string(&log_path).expect("vi was not called");
@@ -227,7 +226,7 @@ fn test_config_edit_creates_default_when_absent() {
     let mut c = Command::cargo_bin(BIN).unwrap();
     env.apply(&mut c);
     c.env("VISUAL", &editor_path);
-    c.args(["config", "edit"]);
+    c.args(["config"]);
     c.assert().success().stderr("");
 
     let called_path = std::fs::read_to_string(&log_path).expect("editor was not called");
@@ -256,7 +255,7 @@ fn test_config_edit_creates_dir_and_file_when_both_absent() {
     c.env("XDG_CONFIG_HOME", &xdg_dir);
     c.current_dir(env.repo_dir.path());
     c.env("VISUAL", &editor_path);
-    c.args(["config", "edit"]);
+    c.args(["config"]);
     c.assert().success().stderr("");
 
     let called_path = std::fs::read_to_string(&log_path).expect("editor was not called");
@@ -282,7 +281,7 @@ fn test_config_edit_exits_nonzero_when_editor_fails() {
     let mut c = Command::cargo_bin(BIN).unwrap();
     env.apply(&mut c);
     c.env("VISUAL", &editor_path);
-    c.args(["config", "edit"]);
+    c.args(["config"]);
     c.assert()
         .failure()
         .stderr(predicates::str::contains("failed to edit config"));
@@ -300,7 +299,7 @@ fn test_config_edit_exits_nonzero_without_config_path() {
     c.env_remove("XDG_CONFIG_HOME");
     c.current_dir(env.repo_dir.path());
     c.env("VISUAL", &editor_path);
-    c.args(["config", "edit"]);
+    c.args(["config"]);
     c.assert()
         .failure()
         .stderr(predicates::str::contains("failed to edit config"));
@@ -315,7 +314,7 @@ fn test_config_edit_default_contains_sections() {
     let mut c = Command::cargo_bin(BIN).unwrap();
     env.apply(&mut c);
     c.env("VISUAL", &editor_path);
-    c.args(["config", "edit"]);
+    c.args(["config"]);
     c.assert().success().stderr("");
 
     let config_path = env.home_dir.path().join(".config").join("merge-ready.toml");

--- a/tests/e2e/config/config.rs
+++ b/tests/e2e/config/config.rs
@@ -1,8 +1,8 @@
-//! 設定ファイル（`~/.config/merge-ready.toml`）の E2E テスト（シナリオ #42–59）
+//! 設定ファイル（`~/.config/merge-ready.toml`）の E2E テスト（シナリオ #42–58）
 //!
 //! - #42–50: symbol / label / format のカスタマイズ、XDG_CONFIG_HOME の優先度
 //!   → prompt テストは daemon 経由フローで検証する
-//! - #51–59: `config` サブコマンド（エディタ起動）
+//! - #51–58: `config` コマンド（エディタ起動）
 
 use assert_cmd::Command;
 use predicates::prelude::*;
@@ -327,16 +327,4 @@ fn test_config_edit_default_contains_sections() {
         content.contains("conflict"),
         "config should contain conflict section, got:\n{content}"
     );
-}
-
-// ── #59: config update（廃止済み）────────────────────────────────────────────
-
-/// #59: config update は廃止済み → unknown subcommand エラー
-#[test]
-fn test_config_update_is_removed() {
-    let env = TestEnv::without_gh();
-    let mut c = Command::cargo_bin(BIN).unwrap();
-    env.apply(&mut c);
-    c.args(["config", "update"]);
-    c.assert().failure();
 }

--- a/tests/e2e/config/config.rs
+++ b/tests/e2e/config/config.rs
@@ -330,106 +330,14 @@ fn test_config_edit_default_contains_sections() {
     );
 }
 
-// ── #59–63: config update ─────────────────────────────────────────────────────
+// ── #59: config update（廃止済み）────────────────────────────────────────────
 
-/// #59: 設定ファイル不在 → デフォルト設定ファイルが新規作成される
+/// #59: config update は廃止済み → unknown subcommand エラー
 #[test]
-fn test_config_update_creates_default_when_absent() {
+fn test_config_update_is_removed() {
     let env = TestEnv::without_gh();
-
     let mut c = Command::cargo_bin(BIN).unwrap();
     env.apply(&mut c);
     c.args(["config", "update"]);
-    c.assert().success().stderr("");
-
-    let config_path = env.home_dir.path().join(".config").join("merge-ready.toml");
-    assert!(config_path.exists(), "config file was not created");
-    let content = std::fs::read_to_string(&config_path).unwrap();
-    assert!(!content.is_empty(), "config file is empty");
-}
-
-/// #60: バージョンが最新と一致 → ファイルが変更されない
-#[test]
-fn test_config_update_no_change_when_latest_version() {
-    let env = TestEnv::without_gh();
-    let original = "version = 1\n\n[merge_ready]\nsymbol = \"★\"\n";
-    env.write_config(original);
-
-    let mut c = Command::cargo_bin(BIN).unwrap();
-    env.apply(&mut c);
-    c.args(["config", "update"]);
-    c.assert().success().stderr("");
-
-    let config_path = env.home_dir.path().join(".config").join("merge-ready.toml");
-    let content = std::fs::read_to_string(&config_path).unwrap();
-    assert_eq!(content, original, "file should not be modified");
-}
-
-/// #61: 旧バージョン・有効なキーあり → 既存の値が保持される
-#[test]
-fn test_config_update_preserves_valid_keys() {
-    let env = TestEnv::without_gh();
-    env.write_config("[merge_ready]\nsymbol = \"★\"\n");
-
-    let mut c = Command::cargo_bin(BIN).unwrap();
-    env.apply(&mut c);
-    c.args(["config", "update"]);
-    c.assert().success().stderr("");
-
-    let config_path = env.home_dir.path().join(".config").join("merge-ready.toml");
-    let content = std::fs::read_to_string(&config_path).unwrap();
-    assert!(
-        content.contains("★"),
-        "symbol should be preserved, got:\n{content}"
-    );
-    assert!(
-        content.contains("version = 1"),
-        "version should be updated, got:\n{content}"
-    );
-}
-
-/// #62: 旧バージョン・廃止キーあり → 廃止キーが削除される
-#[test]
-fn test_config_update_removes_obsolete_keys() {
-    let env = TestEnv::without_gh();
-    env.write_config("[merge_ready]\nsymbol = \"★\"\n\n[obsolete_section]\nsome_key = \"value\"\n");
-
-    let mut c = Command::cargo_bin(BIN).unwrap();
-    env.apply(&mut c);
-    c.args(["config", "update"]);
-    c.assert().success().stderr("");
-
-    let config_path = env.home_dir.path().join(".config").join("merge-ready.toml");
-    let content = std::fs::read_to_string(&config_path).unwrap();
-    assert!(
-        !content.contains("obsolete_section"),
-        "obsolete_section should be removed, got:\n{content}"
-    );
-    assert!(
-        !content.contains("some_key"),
-        "some_key should be removed, got:\n{content}"
-    );
-}
-
-/// #63: 旧バージョン・不足キーあり → デフォルト値で不足キーが追加される
-#[test]
-fn test_config_update_adds_missing_sections_with_defaults() {
-    let env = TestEnv::without_gh();
-    env.write_config("[merge_ready]\nsymbol = \"★\"\n");
-
-    let mut c = Command::cargo_bin(BIN).unwrap();
-    env.apply(&mut c);
-    c.args(["config", "update"]);
-    c.assert().success().stderr("");
-
-    let config_path = env.home_dir.path().join(".config").join("merge-ready.toml");
-    let content = std::fs::read_to_string(&config_path).unwrap();
-    assert!(
-        content.contains("★"),
-        "symbol should be preserved, got:\n{content}"
-    );
-    assert!(
-        content.contains("conflict"),
-        "conflict section should be added with defaults, got:\n{content}"
-    );
+    c.assert().failure();
 }


### PR DESCRIPTION
Closes #141

## Summary

- `merge-ready config update` サブコマンドを廃止（コンフィグのマイグレーション管理はユーザーに委ねる）
- `Config::version` フィールド・`CURRENT_VERSION` 定数を削除
- `ConfigRepository::save()` メソッドを削除（update 専用だったため）
- `merge-ready config edit` を `merge-ready config` に統合（サブコマンド層を撤廃）

## Breaking Changes

- `config update` サブコマンドが存在しなくなる
- コンフィグファイルの `version` キーは無視される（serde unknown field として読み捨て）
- `config edit` の代わりに `config` を使う

## Test plan

- [ ] `cargo test --workspace` — 全 91 テスト通過
- [ ] `cargo clippy --workspace -- -D warnings` — 警告なし
- [ ] `cargo fmt --check --all` — フォーマット OK
- [ ] `bash scripts/check-layer-deps.sh` — DDD 層依存 OK
- [ ] `merge-ready config` でエディタが起動すること
- [ ] `merge-ready config update` が unknown subcommand エラーになること
- [ ] `merge-ready config edit` が unknown subcommand エラーになること

🤖 Generated with [Claude Code](https://claude.com/claude-code)