### PR TITLE
docs: README.md にサンプルコンフィグと設定ファイルの説明を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,69 @@ style = "bold yellow"
 
 If your environment sets `STARSHIP_SHELL` to a slower shell (for example `fish`), custom modules can be noticeably slower due to shell startup cost. Pinning `shell = ["/bin/zsh"]` (or another lightweight shell on your system) keeps prompt latency low.
 
+## Configuration
+
+The configuration file is read from `$XDG_CONFIG_HOME/merge-ready.toml` (or `~/.config/merge-ready.toml` if `XDG_CONFIG_HOME` is not set).
+
+Open the file in your editor:
+
+```bash
+merge-ready config
+```
+
+All fields are optional. Below is the full default configuration:
+
+```toml
+[merge_ready]
+symbol = "✓"
+label = "merge-ready"
+# format = "$symbol $label"
+
+[conflict]
+symbol = "✗"
+label = "conflict"
+
+[update_branch]
+symbol = "✗"
+label = "update-branch"
+
+[sync_unknown]
+symbol = "?"
+label = "sync-unknown"
+
+[ci_fail]
+symbol = "✗"
+label = "ci-fail"
+
+[ci_action]
+symbol = "⚠"
+label = "ci-action"
+
+[review]
+symbol = "⚠"
+label = "review"
+
+[error.auth_required]
+symbol = "!"
+label = "gh auth login"
+
+[error.rate_limited]
+symbol = "✗"
+label = "rate-limited"
+
+[error.api_error]
+symbol = "✗"
+label = "api-error"
+```
+
+Each token supports three optional fields:
+
+| Field | Description | Default |
+|-------|-------------|---------|
+| `symbol` | Leading symbol | see above |
+| `label` | Status text | see above |
+| `format` | Output template | `"$symbol $label"` |
+
 ## Requirements
 
 - `gh` CLI installed and authenticated

--- a/README.md
+++ b/README.md
@@ -114,38 +114,47 @@ label = "merge-ready"
 [conflict]
 symbol = "✗"
 label = "conflict"
+# format = "$symbol $label"
 
 [update_branch]
 symbol = "✗"
 label = "update-branch"
+# format = "$symbol $label"
 
 [sync_unknown]
 symbol = "?"
 label = "sync-unknown"
+# format = "$symbol $label"
 
 [ci_fail]
 symbol = "✗"
 label = "ci-fail"
+# format = "$symbol $label"
 
 [ci_action]
 symbol = "⚠"
 label = "ci-action"
+# format = "$symbol $label"
 
 [review]
 symbol = "⚠"
 label = "review"
+# format = "$symbol $label"
 
 [error.auth_required]
 symbol = "!"
 label = "gh auth login"
+# format = "$symbol $label"
 
 [error.rate_limited]
 symbol = "✗"
 label = "rate-limited"
+# format = "$symbol $label"
 
 [error.api_error]
 symbol = "✗"
 label = "api-error"
+# format = "$symbol $label"
 ```
 
 Each token supports three optional fields:

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Open the file in your editor:
 merge-ready config
 ```
 
-All fields are optional. Below is the full default configuration:
+All fields are optional — omitting any field falls back to the default shown below.
 
 ```toml
 [merge_ready]


### PR DESCRIPTION
## Summary

- `## Configuration` セクションを追加
- 設定ファイルのパス（`$XDG_CONFIG_HOME/merge-ready.toml` / `~/.config/merge-ready.toml`）と編集コマンドを明記
- 全トークンのデフォルト値を TOML サンプルとして掲載
- `symbol` / `label` / `format` フィールドの説明テーブルを追加

## Background

Issue #141 で `config update` サブコマンドを廃止した際、ユーザーへの代替案として「README.md にサンプルコンフィグを提示する」方針となっていたが未実施だった。

Closes #143

## Test plan

- [ ] README.md を目視確認（TOML サンプルのデフォルト値が `config.rs` の `fill_defaults()` と一致すること）
- [ ] `merge-ready config` で生成されるデフォルトコンフィグと README のサンプルが一致すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)