### PR TITLE
feat: PR が closed/merged になったらリフレッシュを停止する

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -6,6 +6,7 @@ use crate::adapters::ConfigAdapter;
 use crate::cli::{Cli, Command};
 use crate::contexts::daemon::application::cache as daemon_cache_app;
 use crate::contexts::daemon::infrastructure::daemon_client::DaemonClient;
+use crate::contexts::evaluation::domain::pr_state::PrStateRepository;
 use crate::contexts::evaluation::infrastructure::{gh::GhClient, logger::Logger};
 use crate::contexts::evaluation::interface::presentation::{PresentationConfigPort, Presenter};
 
@@ -22,10 +23,10 @@ pub fn run(cli: Cli) -> ExitCode {
                 crate::contexts::daemon::infrastructure::daemon_lifecycle::DaemonLifecycle::new(
                     |repo_id: &str, cwd: &std::path::Path| {
                         let repo_id = repo_id.to_owned();
+                        let client = GhClient::new_in(cwd.to_path_buf());
                         let (tokens, error) =
                             crate::contexts::evaluation::application::prompt::fetch_output(
-                                &GhClient::new_in(cwd.to_path_buf()),
-                                &Logger,
+                                &client, &Logger,
                             );
                         let config = ConfigAdapter::load();
                         let output = if let Some(err) = error {
@@ -33,7 +34,12 @@ pub fn run(cli: Cli) -> ExitCode {
                         } else {
                             Presenter::new(config).render_to_string(&tokens)
                         };
-                        daemon_cache_app::update(&DaemonClient, &repo_id, &output);
+                        // エラー時は is_terminal = false（再試行が必要なため）
+                        // OnceLock キャッシュ済みの fetch_lifecycle を呼び出すため追加 API 呼び出しなし
+                        let is_terminal = error.is_none()
+                            && tokens.is_empty()
+                            && client.fetch_lifecycle().is_ok_and(|l| l.is_terminal());
+                        daemon_cache_app::update(&DaemonClient, &repo_id, &output, is_terminal);
                     },
                 );
             crate::contexts::daemon::interface::cli::daemon::run(args.subcommand, &lifecycle)

--- a/src/contexts/daemon/application/cache.rs
+++ b/src/contexts/daemon/application/cache.rs
@@ -1,6 +1,6 @@
 use crate::contexts::daemon::domain::cache::CachePort;
 
 /// キャッシュを更新するユースケース
-pub fn update(port: &impl CachePort, repo_id: &str, output: &str) {
-    port.update(repo_id, output);
+pub fn update(port: &impl CachePort, repo_id: &str, output: &str, is_terminal: bool) {
+    port.update(repo_id, output, is_terminal);
 }

--- a/src/contexts/daemon/domain/cache.rs
+++ b/src/contexts/daemon/domain/cache.rs
@@ -1,5 +1,5 @@
 /// キャッシュの更新ポート
 pub trait CachePort {
     /// キャッシュを更新する。失敗は静かに無視する。
-    fn update(&self, repo_id: &str, output: &str);
+    fn update(&self, repo_id: &str, output: &str, is_terminal: bool);
 }

--- a/src/contexts/daemon/infrastructure/daemon_client.rs
+++ b/src/contexts/daemon/infrastructure/daemon_client.rs
@@ -12,10 +12,11 @@ const READ_TIMEOUT_MS: u64 = 500;
 pub struct DaemonClient;
 
 impl CachePort for DaemonClient {
-    fn update(&self, repo_id: &str, output: &str) {
+    fn update(&self, repo_id: &str, output: &str, is_terminal: bool) {
         let _ = Self::send(&Request::Update {
             repo_id: repo_id.to_owned(),
             output: output.to_owned(),
+            is_terminal,
         });
     }
 }

--- a/src/contexts/daemon/infrastructure/daemon_server.rs
+++ b/src/contexts/daemon/infrastructure/daemon_server.rs
@@ -30,6 +30,8 @@ struct CacheEntry {
     refreshing: bool,
     refresh_started_at: Option<Instant>,
     cwd: PathBuf,
+    /// PR が closed / merged 確認済みかどうか。true の場合バックグラウンドリフレッシュを停止する。
+    is_terminal: bool,
 }
 
 struct DaemonState {
@@ -293,7 +295,11 @@ fn process(request: &Request, state: &Arc<Mutex<DaemonState>>) -> ActionResult {
             let cwd_path = PathBuf::from(cwd);
             process_query(&repo_id, cwd_path, ttl, version_mismatch, &mut s.entries)
         }
-        Request::Update { repo_id, output } => process_update(repo_id, output, &mut s.entries),
+        Request::Update {
+            repo_id,
+            output,
+            is_terminal,
+        } => process_update(repo_id, output, *is_terminal, &mut s.entries),
         Request::Stop => ActionResult {
             response: Response::Ok,
             refresh_repo_id: None,
@@ -320,6 +326,14 @@ fn process(request: &Request, state: &Arc<Mutex<DaemonState>>) -> ActionResult {
     }
 }
 
+fn effective_ttl(entry: &CacheEntry, base_ttl: u64) -> u64 {
+    if entry.is_terminal {
+        background_refresh_secs()
+    } else {
+        base_ttl
+    }
+}
+
 fn process_query(
     repo_id: &str,
     cwd_path: PathBuf,
@@ -328,8 +342,8 @@ fn process_query(
     entries: &mut HashMap<String, CacheEntry>,
 ) -> ActionResult {
     match entries.get(repo_id) {
-        Some(entry) if entry.fetched_at.elapsed().as_secs() <= ttl => {
-            // Fresh キャッシュ
+        Some(entry) if entry.fetched_at.elapsed().as_secs() <= effective_ttl(entry, ttl) => {
+            // Fresh キャッシュ（terminal エントリは background_refresh_secs を TTL として使用）
             ActionResult {
                 response: Response::Output {
                     output: entry.output.clone(),
@@ -347,6 +361,7 @@ fn process_query(
             let stored_cwd = entry.cwd.clone();
             let need_refresh = !entry.refreshing;
             let refreshing_now = entry.refreshing;
+            let is_terminal = entry.is_terminal;
             process_stale_query(
                 repo_id,
                 StaleQueryParams {
@@ -356,6 +371,7 @@ fn process_query(
                     need_refresh,
                     refreshing_now,
                     restart_after_response,
+                    is_terminal,
                 },
                 entries,
             )
@@ -374,6 +390,7 @@ fn process_query(
                     refreshing: true,
                     refresh_started_at: Some(Instant::now()),
                     cwd: cwd_path.clone(),
+                    is_terminal: false,
                 },
             );
             ActionResult {
@@ -435,6 +452,7 @@ struct StaleQueryParams {
     need_refresh: bool,
     refreshing_now: bool,
     restart_after_response: bool,
+    is_terminal: bool,
 }
 
 // no-PR cache is a valid empty output. Keep returning empty output while scheduling background
@@ -451,7 +469,18 @@ fn process_stale_query(
         need_refresh,
         refreshing_now,
         restart_after_response,
+        is_terminal,
     } = params;
+
+    // terminal エントリが stale になったら is_terminal をリセットして再アクティブ化する。
+    // 再取得後に依然 closed / merged なら process_update が is_terminal = true を再設定する。
+    if let Some(entry) = entries.get_mut(repo_id)
+        && is_terminal
+        && need_refresh
+    {
+        entry.is_terminal = false;
+    }
+
     if output.is_empty() {
         if refreshing_now && !has_fetched {
             return ActionResult {
@@ -491,7 +520,9 @@ fn process_stale_query(
 }
 
 fn is_active_entry(entry: &CacheEntry) -> bool {
-    !entry.output.is_empty()
+    // no-PR entries and terminal (closed/merged) entries are treated as inactive so they do not
+    // keep the daemon alive forever. They can be re-created on the next prompt.
+    !entry.output.is_empty() && !entry.is_terminal
 }
 
 fn refresh_lock_expired(entry: &CacheEntry) -> bool {
@@ -503,6 +534,7 @@ fn refresh_lock_expired(entry: &CacheEntry) -> bool {
 fn process_update(
     repo_id: &str,
     output: &str,
+    is_terminal: bool,
     entries: &mut HashMap<String, CacheEntry>,
 ) -> ActionResult {
     if let Some(entry) = entries.get_mut(repo_id) {
@@ -511,6 +543,7 @@ fn process_update(
         entry.fetched_at = Instant::now();
         entry.refreshing = false;
         entry.refresh_started_at = None;
+        entry.is_terminal = is_terminal;
     } else {
         entries.insert(
             repo_id.to_owned(),
@@ -521,6 +554,7 @@ fn process_update(
                 refreshing: false,
                 refresh_started_at: None,
                 cwd: PathBuf::new(),
+                is_terminal,
             },
         );
     }
@@ -565,4 +599,143 @@ fn collect_background_refresh_targets(
         s.last_activity = Instant::now();
     }
     targets
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_entry(output: &str, is_terminal: bool) -> CacheEntry {
+        CacheEntry {
+            output: output.to_owned(),
+            has_fetched: true,
+            fetched_at: Instant::now(),
+            refreshing: false,
+            refresh_started_at: None,
+            cwd: PathBuf::new(),
+            is_terminal,
+        }
+    }
+
+    // ── is_active_entry ────────────────────────────────────────────────────────
+
+    #[test]
+    fn active_when_non_empty_output_and_not_terminal() {
+        assert!(is_active_entry(&make_entry("✓ merge-ready", false)));
+    }
+
+    #[test]
+    fn inactive_when_empty_output() {
+        assert!(!is_active_entry(&make_entry("", false)));
+    }
+
+    #[test]
+    fn inactive_when_terminal_with_empty_output() {
+        assert!(!is_active_entry(&make_entry("", true)));
+    }
+
+    #[test]
+    fn inactive_when_terminal_even_with_non_empty_output() {
+        assert!(!is_active_entry(&make_entry("✓ merge-ready", true)));
+    }
+
+    // ── process_update ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn process_update_sets_is_terminal_true() {
+        let mut entries = HashMap::new();
+        entries.insert("repo".to_owned(), make_entry("✓ merge-ready", false));
+        process_update("repo", "", true, &mut entries);
+        assert!(entries["repo"].is_terminal);
+    }
+
+    #[test]
+    fn process_update_clears_is_terminal_when_pr_reopens() {
+        let mut entries = HashMap::new();
+        entries.insert("repo".to_owned(), make_entry("", true));
+        process_update("repo", "✓ merge-ready", false, &mut entries);
+        assert!(!entries["repo"].is_terminal);
+    }
+
+    // ── collect_background_refresh_targets ─────────────────────────────────────
+
+    #[test]
+    fn background_refresh_skips_terminal_entry() {
+        let state = Arc::new(Mutex::new(DaemonState::new()));
+        {
+            let mut s = state.lock().unwrap();
+            // terminal エントリ（stale）
+            let mut entry = make_entry("✓ merge-ready", true);
+            entry.fetched_at = Instant::now()
+                .checked_sub(Duration::from_secs(9999))
+                .unwrap();
+            s.entries.insert("repo".to_owned(), entry);
+        }
+        let targets = collect_background_refresh_targets(&state, 1);
+        assert!(
+            targets.is_empty(),
+            "terminal エントリはバックグラウンドリフレッシュ対象外のはず"
+        );
+    }
+
+    #[test]
+    fn background_refresh_includes_active_entry() {
+        let state = Arc::new(Mutex::new(DaemonState::new()));
+        {
+            let mut s = state.lock().unwrap();
+            let mut entry = make_entry("✓ merge-ready", false);
+            entry.fetched_at = Instant::now()
+                .checked_sub(Duration::from_secs(9999))
+                .unwrap();
+            entry.cwd = PathBuf::from("/some/repo");
+            s.entries.insert("repo".to_owned(), entry);
+        }
+        let targets = collect_background_refresh_targets(&state, 1);
+        assert_eq!(targets.len(), 1);
+    }
+
+    // ── effective_ttl ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn terminal_entry_uses_background_refresh_secs_as_ttl() {
+        let entry = make_entry("", true);
+        assert_eq!(effective_ttl(&entry, 5), background_refresh_secs());
+    }
+
+    #[test]
+    fn non_terminal_entry_uses_base_ttl() {
+        let entry = make_entry("✓ merge-ready", false);
+        assert_eq!(effective_ttl(&entry, 5), 5);
+    }
+
+    // ── process_stale_query: 再アクティブ化 ────────────────────────────────────
+
+    #[test]
+    fn stale_terminal_entry_resets_is_terminal_on_reactivation() {
+        let mut entries = HashMap::new();
+        let mut entry = make_entry("", true);
+        entry.fetched_at = Instant::now()
+            .checked_sub(Duration::from_secs(9999))
+            .unwrap();
+        entries.insert("repo".to_owned(), entry);
+
+        process_stale_query(
+            "repo",
+            StaleQueryParams {
+                output: String::new(),
+                has_fetched: true,
+                stored_cwd: PathBuf::new(),
+                need_refresh: true,
+                refreshing_now: false,
+                restart_after_response: false,
+                is_terminal: true,
+            },
+            &mut entries,
+        );
+
+        assert!(
+            !entries["repo"].is_terminal,
+            "stale terminal エントリは is_terminal がリセットされるはず"
+        );
+    }
 }

--- a/src/contexts/daemon/infrastructure/protocol.rs
+++ b/src/contexts/daemon/infrastructure/protocol.rs
@@ -14,8 +14,7 @@ pub enum Request {
     Update {
         repo_id: String,
         output: String,
-        /// PR が closed / merged 状態かどうか。旧バイナリ互換のためデフォルト false。
-        #[serde(default)]
+        /// PR が closed / merged 状態かどうか。
         is_terminal: bool,
     },
     Stop,

--- a/src/contexts/daemon/infrastructure/protocol.rs
+++ b/src/contexts/daemon/infrastructure/protocol.rs
@@ -14,6 +14,9 @@ pub enum Request {
     Update {
         repo_id: String,
         output: String,
+        /// PR が closed / merged 状態かどうか。旧バイナリ互換のためデフォルト false。
+        #[serde(default)]
+        is_terminal: bool,
     },
     Stop,
     Status,

--- a/src/contexts/evaluation/domain/pr_state.rs
+++ b/src/contexts/evaluation/domain/pr_state.rs
@@ -17,3 +17,31 @@ pub enum PrLifecycle {
 pub fn is_open(lifecycle: &PrLifecycle) -> bool {
     matches!(lifecycle, PrLifecycle::Open)
 }
+
+impl PrLifecycle {
+    /// クローズ / マージ済みで追跡不要な状態かどうかを返す。
+    #[must_use]
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, PrLifecycle::Merged | PrLifecycle::Closed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_is_not_terminal() {
+        assert!(!PrLifecycle::Open.is_terminal());
+    }
+
+    #[test]
+    fn merged_is_terminal() {
+        assert!(PrLifecycle::Merged.is_terminal());
+    }
+
+    #[test]
+    fn closed_is_terminal() {
+        assert!(PrLifecycle::Closed.is_terminal());
+    }
+}

--- a/tests/e2e/helpers/env.rs
+++ b/tests/e2e/helpers/env.rs
@@ -214,6 +214,40 @@ impl TestEnv {
         }
     }
 
+    /// terminal PR シナリオ（呼び出しカウンタ付き）
+    ///
+    /// `gh pr view` が closed / merged JSON を返す。カウンタログファイルのパスを返す。
+    pub fn with_terminal_pr_call_log(state: &str) -> (Self, std::path::PathBuf) {
+        let (bin_dir, home_dir, repo_dir) = Self::setup_with_git();
+        let log_path = home_dir.path().join("gh_calls.log");
+        let log = log_path.display().to_string();
+        let pr_view_json = format!(
+            r#"{{"state":"{state}","isDraft":false,"mergeable":"UNKNOWN","mergeStateStatus":"UNKNOWN","reviewDecision":null}}"#
+        );
+        let script = format!(
+            "#!/bin/sh\n\
+             printf '1' >> \"{log}\"\n\
+             case \"$*\" in\n\
+               *'pr view'*)\n\
+                 printf '%s' '{pr_view_json}'\n\
+                 ;;\n\
+               *)\n\
+                 printf 'unexpected gh call: %s' \"$*\" >&2\n\
+                 exit 127\n\
+                 ;;\n\
+             esac\n"
+        );
+        write_executable(bin_dir.path().join("gh"), &script);
+        (
+            Self {
+                bin_dir,
+                home_dir,
+                repo_dir,
+            },
+            log_path,
+        )
+    }
+
     /// PR なしシナリオ: `gh pr view` が "no pull requests found" で exit 1 を返す。
     pub fn with_no_pr() -> Self {
         let (bin_dir, home_dir, repo_dir) = Self::setup_with_git();

--- a/tests/e2e/scenarios/mod.rs
+++ b/tests/e2e/scenarios/mod.rs
@@ -4,3 +4,4 @@ mod multi_repo;
 mod no_pr;
 mod no_repo;
 mod stale;
+mod terminal_pr;

--- a/tests/e2e/scenarios/terminal_pr.rs
+++ b/tests/e2e/scenarios/terminal_pr.rs
@@ -1,0 +1,75 @@
+//! terminal PR シナリオ: PR が closed / merged になったらリフレッシュを停止する（シナリオ #50, #51）
+//!
+//! #50: closed PR → キャッシュ確定後に TTL=0 で連続クエリ → gh は1回しか呼ばれない
+//! #51: merged PR → 同上
+
+const PROMPT_BIN: &str = "merge-ready-prompt";
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+use super::super::helpers::{DaemonHandle, TestEnv};
+
+/// #50: closed PR はキャッシュ確定後に再フェッチされない
+#[test]
+fn test_closed_pr_stops_refreshing_after_terminal_state() {
+    let (env, log_path) = TestEnv::with_terminal_pr_call_log("CLOSED");
+    let _daemon = DaemonHandle::start_with_env(&env, &[("MERGE_READY_STALE_TTL", "0")]);
+
+    // 初回クエリ: キャッシュミス → ? loading
+    let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
+    env.apply_with_cache(&mut cmd);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::diff("? loading"));
+
+    // キャッシュ確定（closed PR → output=""、is_terminal=true）を待つ
+    DaemonHandle::wait_for_cache(&env, 5000);
+
+    // TTL=0 でも terminal エントリは background_refresh_secs TTL を使うため
+    // 連続クエリで gh が再度呼ばれないことを確認
+    for _ in 0..5 {
+        let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
+        env.apply_with_cache(&mut cmd);
+        cmd.assert().success().stdout(predicate::str::is_empty());
+    }
+
+    // gh 呼び出し回数 = 1（初回リフレッシュのみ）
+    let call_log = std::fs::read_to_string(&log_path).unwrap_or_default();
+    assert_eq!(
+        call_log.len(),
+        1,
+        "terminal closed PR は初回リフレッシュ後に gh を呼ばないはず（呼び出し回数: {}）",
+        call_log.len()
+    );
+}
+
+/// #51: merged PR はキャッシュ確定後に再フェッチされない
+#[test]
+fn test_merged_pr_stops_refreshing_after_terminal_state() {
+    let (env, log_path) = TestEnv::with_terminal_pr_call_log("MERGED");
+    let _daemon = DaemonHandle::start_with_env(&env, &[("MERGE_READY_STALE_TTL", "0")]);
+
+    // 初回クエリ: ? loading
+    let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
+    env.apply_with_cache(&mut cmd);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::diff("? loading"));
+
+    DaemonHandle::wait_for_cache(&env, 5000);
+
+    for _ in 0..5 {
+        let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
+        env.apply_with_cache(&mut cmd);
+        cmd.assert().success().stdout(predicate::str::is_empty());
+    }
+
+    let call_log = std::fs::read_to_string(&log_path).unwrap_or_default();
+    assert_eq!(
+        call_log.len(),
+        1,
+        "terminal merged PR は初回リフレッシュ後に gh を呼ばないはず（呼び出し回数: {}）",
+        call_log.len()
+    );
+}


### PR DESCRIPTION
Closes #146

## 概要

PR が closed / merged になった後も Daemon が継続的に GitHub API を叩き続ける問題を修正。

### 根本原因

`process_stale_query` は `output = ""` かつ `has_fetched = true` の場合でも `need_refresh = true` なら `gh pr view` を再呼び出ししていた（stale TTL = 5s ごとに繰り返し）。`output = ""` が「PR なし」と「closed/merged 確認済み」を区別していないのが原因。

### 解決策

`CacheEntry` に `is_terminal: bool` フラグを追加し、closed / merged PR を確認したエントリに設定。Terminal エントリには `background_refresh_secs`（デフォルト 180s）を有効 TTL として適用し、再フェッチを大幅に抑制する。

## 変更内容

| ファイル | 変更 |
|---------|------|
| `evaluation/domain/pr_state.rs` | `PrLifecycle::is_terminal()` 追加 |
| `daemon/domain/cache.rs` | `CachePort::update` に `is_terminal: bool` 追加 |
| `daemon/application/cache.rs` | 同上 |
| `daemon/infrastructure/protocol.rs` | `Update` に `is_terminal: bool` 追加 |
| `daemon/infrastructure/daemon_client.rs` | `CachePort` 実装更新 |
| `daemon/infrastructure/daemon_server.rs` | コアロジック変更（後述） |
| `app.rs` | `is_terminal` 判定と伝播（`OnceLock` キャッシュ再利用で追加 API 呼び出しなし） |
| `tests/e2e/helpers/env.rs` | `TestEnv::with_terminal_pr_call_log()` 追加 |
| `tests/e2e/scenarios/terminal_pr.rs` | E2E テスト2件（closed / merged） |

### `daemon_server.rs` の主な変更

- `CacheEntry.is_terminal: bool` 追加
- `is_active_entry`: `!output.is_empty() && !is_terminal`（terminal エントリをバックグラウンドリフレッシュ対象外・アイドルタイムアウト inactive 扱いに）
- `effective_ttl`: terminal エントリは `background_refresh_secs()`（180s）を TTL として使用
- `process_stale_query`: terminal エントリが stale になったら `is_terminal = false` にリセットして再アクティブ化（lazy re-activation）
- `process_update`: `is_terminal` フラグをキャッシュエントリに反映

## 検証結果（PR #149 を使用）

`MERGE_READY_STALE_TTL=0`（強制 stale）+ gh 呼び出しカウンタで検証。

```
全 gh 呼び出しログ（gh wrapper 経由）:
1  10:44:22 gh pr view ...    ← 初回リフレッシュ (PR OPEN)
2  10:44:23 gh repo view ...
3  10:44:23 gh pr checks ...
4  10:44:23 gh api .../compare/...
5  10:44:33 gh pr view ...    ← 2回目リフレッシュ (TTL=1s 超過, PR まだ OPEN)
6  10:44:34 gh pr checks ...
7  10:44:34 gh repo view ...
8  10:44:34 gh api .../compare/...
9  10:45:17 gh pr view ...    ← CLOSED 検知リフレッシュ (state=CLOSED → 早期リターン)
   ← 以降 10 回連続 prompt → 追加呼び出し 0 回 ✓
```

| フェーズ | 追加 gh 呼び出し |
|---------|----------------|
| PR OPEN 中（TTL=0 で連続 prompt） | あり（TTL 超過ごと）|
| PR CLOSED 検知後（TTL=0 で 10 回連続 prompt） | **0 回** ✓ |

## チェックリスト

- [x] `cargo test --workspace` 全 90 テスト通過
- [x] `cargo clippy --workspace -- -D warnings` 警告なし
- [x] `cargo fmt --check --all` 差分なし
- [x] `bash scripts/check-layer-deps.sh` DDD レイヤー依存ルール OK
- [x] 単体テスト: `is_active_entry`（4ケース）、`process_update`、`collect_background_refresh_targets`、`effective_ttl`、`process_stale_query` 再アクティブ化
- [x] E2E テスト: closed / merged PR がキャッシュ確定後に再フェッチされないことを検証