### PR TITLE
fix(test): stale_delay_ms の初回 gh 呼び出しを即時化してフレーキーを解消

### DIFF
--- a/tests/e2e/helpers/env.rs
+++ b/tests/e2e/helpers/env.rs
@@ -260,14 +260,28 @@ impl TestEnv {
         }
     }
 
-    /// PR なしシナリオ（遅延付き）: stale refresh 中の挙動を再現するため gh を長引かせる。
-    pub fn with_no_pr_delay_ms(delay_ms: u64) -> Self {
+    /// PR なしシナリオ（遅延付き）: stale refresh 中の挙動を再現するため、初回呼び出しは即座に返し、
+    /// 2回目以降（stale refresh）のみ `delay_ms` 遅延させる。
+    ///
+    /// これにより `wait_for_cache` が初回リフレッシュ完了を確実に待てる一方で、
+    /// stale refresh 中の挙動（空出力を維持）を検証できる。
+    pub fn with_no_pr_stale_delay_ms(delay_ms: u64) -> Self {
         let (bin_dir, home_dir, repo_dir) = Self::setup_with_git();
         let secs = delay_ms / 1000;
         let millis = delay_ms % 1000;
         let sleep_arg = format!("{secs}.{millis:03}");
-        let script =
-            format!("#!/bin/sh\nsleep {sleep_arg}\nprintf 'no pull requests found' >&2\nexit 1\n");
+        let count_path = home_dir.path().join(".gh_call_count").display().to_string();
+        let script = format!(
+            "#!/bin/sh\n\
+             count=$(cat \"{count_path}\" 2>/dev/null || printf '0')\n\
+             count=$((count + 1))\n\
+             printf '%d' \"$count\" > \"{count_path}\"\n\
+             if [ \"$count\" -gt 1 ]; then\n\
+                 sleep {sleep_arg}\n\
+             fi\n\
+             printf 'no pull requests found' >&2\n\
+             exit 1\n"
+        );
         write_executable(bin_dir.path().join("gh"), &script);
         Self {
             bin_dir,

--- a/tests/e2e/scenarios/no_pr.rs
+++ b/tests/e2e/scenarios/no_pr.rs
@@ -35,7 +35,7 @@ fn test_daemon_no_pr_shows_nothing_after_refresh() {
 /// #5: no-PR の stale リフレッシュ中でも `? loading` に戻らず空出力を維持する
 #[test]
 fn test_daemon_no_pr_stale_while_refreshing_keeps_empty_output() {
-    let env = TestEnv::with_no_pr_delay_ms(1000);
+    let env = TestEnv::with_no_pr_stale_delay_ms(1000);
     let _daemon = DaemonHandle::start_with_env(&env, &[("MERGE_READY_STALE_TTL", "0")]);
 
     // 初回クエリ: キャッシュミス → loading


### PR DESCRIPTION
Closes #151

## Summary

- `with_no_pr_delay_ms` を `with_no_pr_stale_delay_ms` に置き換え
- 初回 `gh` 呼び出しは即座に返し、2回目以降（stale refresh）のみ遅延させる
- カウンターファイル（`$HOME/.gh_call_count`）で呼び出し回数をシェルスクリプト側が管理

**フレーキーの原因**: 旧実装は全 `gh` 呼び出しに遅延を入れていたため、並列実行による高負荷下で初回リフレッシュが `wait_for_cache` のタイムアウト 5000ms を超えることがあった。タイムアウトを伸ばすのではなく、そもそも初回リフレッシュのタイミング依存を排除した。

## Test plan

- [ ] `cargo test --test e2e "no_pr"` がパスすること
- [ ] `cargo test --workspace` を複数回実行してもフレーキーが再現しないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)