### PR TITLE
chore: mod.rs の使用を禁止する CI チェックを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,14 @@ jobs:
       - name: Check layer dependency rules
         run: bash scripts/check-layer-deps.sh
 
+  no-mod-rs:
+    name: no-mod-rs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Check no mod.rs files
+        run: bash scripts/check-no-mod-rs.sh
+
   deny:
     name: deny
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,18 @@ cargo clippy --workspace -- -D warnings  # lints (must pass)
 cargo fmt --check --all              # formatting check
 cargo deny check                     # dependency audit
 bash scripts/check-layer-deps.sh     # DDD layer dependency rules
+bash scripts/check-no-mod-rs.sh      # forbid mod.rs (use Rust 2018+ style)
+```
+
+## File Naming
+
+Use Rust 2018+ module naming: `foo.rs` instead of `foo/mod.rs`.
+CI will reject new `mod.rs` files (exception: `tests/e2e/` is allowed).
+
+To fix a violation:
+
+```
+foo/bar/mod.rs  →  rename to foo/bar.rs  (keep the content as-is)
 ```
 
 ## Commit Convention

--- a/scripts/check-no-mod-rs.sh
+++ b/scripts/check-no-mod-rs.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Forbid mod.rs files outside of allowed paths (use Rust 2018+ style instead).
+#
+# Allowed exceptions:
+#   tests/e2e/  — migration cost is too high; excluded from this check
+
+set -uo pipefail
+
+cd "${ROOT_DIR:-$(dirname "$0")/..}"
+
+hits=$(find . -name "mod.rs" \
+  -not -path "./.git/*" \
+  -not -path "./target/*" \
+  -not -path "./tests/e2e/*" \
+  | sort)
+
+if [ -n "$hits" ]; then
+  printf '%s\n' "$hits"
+  cat >&2 <<'MSG'
+
+ERROR: mod.rs files are forbidden. Use Rust 2018+ style instead.
+
+  How to fix:
+    foo/bar/mod.rs  →  rename to foo/bar.rs  (keep the content as-is)
+
+  Exception: tests/e2e/ is allowed.
+
+MSG
+  exit 1
+fi
+
+echo "No forbidden mod.rs files found. OK"


### PR DESCRIPTION
## Summary

- `scripts/check-no-mod-rs.sh` を追加 — Rust 2018+ スタイル (`foo.rs`) を強制し、`tests/e2e/` のみ除外
- CI に `no-mod-rs` ジョブを追加
- `CONTRIBUTING.md` に File Naming セクションを追記

違反を検出した場合、修正手順をエラーメッセージで案内する:

```
ERROR: mod.rs files are forbidden. Use Rust 2018+ style instead.

  How to fix:
    foo/bar/mod.rs  →  rename to foo/bar.rs  (keep the content as-is)

  Exception: tests/e2e/ is allowed.
```

Closes #164

## Test plan

- [ ] `bash scripts/check-no-mod-rs.sh` がローカルで `OK` を返すこと
- [ ] CI の `no-mod-rs` ジョブがパスすること
- [ ] `src/` 配下に `mod.rs` を仮置きしてスクリプトが違反を検出することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)