### PR TITLE
feat: PR 未作成時に  を表示する

### DIFF
--- a/src/contexts/evaluation/application.rs
+++ b/src/contexts/evaluation/application.rs
@@ -20,6 +20,7 @@ pub enum OutputToken {
     CiAction,
     ReviewRequested,
     MergeReady,
+    NoPullRequest,
 }
 
 fn map_blocked_to_tokens(blocked: BlockedState) -> Vec<OutputToken> {
@@ -49,11 +50,25 @@ pub(crate) fn map_pr_state_to_tokens(state: PrState) -> Vec<OutputToken> {
     match state {
         PrState::Blocked(blocked) => map_blocked_to_tokens(blocked),
         PrState::Unblocked(UnblockedState::MergeReady) => vec![OutputToken::MergeReady],
-        // Draft (#154)、NoPr (#156) は後続 Issue で実装
+        PrState::NoPr => vec![OutputToken::NoPullRequest],
+        // Draft (#154) は後続 Issue で実装
         // NotApplicable / Unknown は何も表示しない
         PrState::Unblocked(UnblockedState::Draft)
-        | PrState::NoPr
         | PrState::NotApplicable(_)
-        | PrState::Unknown => vec![],
+        | PrState::Unknown => {
+            vec![]
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_pr_maps_to_no_pull_request_token() {
+        let tokens = map_pr_state_to_tokens(PrState::NoPr);
+        assert_eq!(tokens.len(), 1);
+        assert!(matches!(tokens[0], OutputToken::NoPullRequest));
     }
 }

--- a/src/contexts/evaluation/application/config_service.rs
+++ b/src/contexts/evaluation/application/config_service.rs
@@ -33,6 +33,11 @@ fn render_token(config: &DisplayConfig, token: &OutputToken) -> String {
             "✓",
             "merge-ready",
         ),
+        OutputToken::NoPullRequest => apply_format(
+            config.no_pull_request.as_ref().unwrap_or(&empty()),
+            "+",
+            "create-pr",
+        ),
         OutputToken::Conflict => apply_format(
             config.conflict.as_ref().unwrap_or(&empty()),
             "✗",
@@ -89,5 +94,23 @@ fn empty() -> TokenConfig {
         symbol: None,
         label: None,
         format: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct DefaultRepo;
+    impl DisplayConfigRepository for DefaultRepo {
+        fn load(&self) -> DisplayConfig {
+            default_display_config()
+        }
+    }
+
+    #[test]
+    fn no_pull_request_renders_with_default_config() {
+        let result = render_output(&[OutputToken::NoPullRequest], None, &DefaultRepo);
+        assert_eq!(result, "+ create-pr");
     }
 }

--- a/src/contexts/evaluation/domain/display_config.rs
+++ b/src/contexts/evaluation/domain/display_config.rs
@@ -5,6 +5,7 @@ const DEFAULT_FORMAT: &str = "$symbol $label";
 #[derive(Deserialize, Serialize, Default)]
 pub struct DisplayConfig {
     pub merge_ready: Option<TokenConfig>,
+    pub no_pull_request: Option<TokenConfig>,
     pub conflict: Option<TokenConfig>,
     pub update_branch: Option<TokenConfig>,
     pub sync_unknown: Option<TokenConfig>,
@@ -23,6 +24,8 @@ impl DisplayConfig {
         };
         self.merge_ready
             .get_or_insert_with(|| tok("✓", "merge-ready"));
+        self.no_pull_request
+            .get_or_insert_with(|| tok("+", "create-pr"));
         self.conflict.get_or_insert_with(|| tok("✗", "conflict"));
         self.update_branch
             .get_or_insert_with(|| tok("✗", "update-branch"));
@@ -75,5 +78,19 @@ impl ErrorConfig {
             rate_limited: None,
             api_error: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fill_defaults_sets_no_pull_request() {
+        let mut config = DisplayConfig::default();
+        config.fill_defaults();
+        let tok = config.no_pull_request.as_ref().unwrap();
+        assert_eq!(tok.symbol.as_deref(), Some("+"));
+        assert_eq!(tok.label.as_deref(), Some("create-pr"));
     }
 }

--- a/tests/e2e/prompt/pr_state.rs
+++ b/tests/e2e/prompt/pr_state.rs
@@ -1,11 +1,12 @@
 //! PR ライフサイクル状態の E2E テスト（シナリオ #31–33）
 //!
-//! `OPEN` 以外の PR 状態、および PR が存在しない場合は何も出力しない。
+//! `OPEN` 以外の PR 状態は何も出力しない。PR が存在しない場合は `+ create-pr` を出力する。
 //! 実行フローは daemon 経由（`merge-ready prompt`）に統一する。
 
 const PROMPT_BIN: &str = "merge-ready-prompt";
 
 use assert_cmd::Command;
+use predicates::prelude::*;
 use rstest::rstest;
 
 use super::super::helpers::{DaemonHandle, TestEnv};
@@ -24,14 +25,22 @@ fn assert_prompt_empty(env: &TestEnv) {
 
 // ── #31: PR なし ──────────────────────────────────────────────────────────────
 
-/// #31: ブランチに PR が存在しない → 空文字（`exit 0`）
+/// #31: ブランチに PR が存在しない → `+ create-pr`（`exit 0`）
 #[test]
 fn test_no_pr() {
     let env = TestEnv::with_error(
         r#"no pull requests found for branch "feat/1-e2e-red-tests""#,
         1,
     );
-    assert_prompt_empty(&env);
+    let _daemon = DaemonHandle::start(&env);
+    DaemonHandle::wait_for_cache(&env, 5000);
+
+    let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
+    env.apply_with_cache(&mut cmd);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::diff("+ create-pr"))
+        .stderr("");
 }
 
 // ── #32–33: CLOSED / MERGED ───────────────────────────────────────────────────

--- a/tests/e2e/scenarios/no_pr.rs
+++ b/tests/e2e/scenarios/no_pr.rs
@@ -1,7 +1,7 @@
 //! キャッシュライフサイクル シナリオ #4, #5: PR なし
 //!
-//! #4: PR なしブランチ → loading → キャッシュ確定後に空出力（`? loading` が永続しない）
-//! #5: PR なし + TTL=0 + リフレッシュ遅延 → stale 中も `? loading` に戻らず空出力維持
+//! #4: PR なしブランチ → loading → キャッシュ確定後に `+ create-pr`（`? loading` が永続しない）
+//! #5: PR なし + TTL=0 + リフレッシュ遅延 → stale 中も `? loading` に戻らず `+ create-pr` 維持
 
 const PROMPT_BIN: &str = "merge-ready-prompt";
 
@@ -10,7 +10,7 @@ use predicates::prelude::*;
 
 use super::super::helpers::{DaemonHandle, TestEnv};
 
-/// #4: PR なしブランチで daemon 経由: リフレッシュ完了後に `? loading` が消える
+/// #4: PR なしブランチで daemon 経由: リフレッシュ完了後に `+ create-pr` が表示される
 #[test]
 fn test_daemon_no_pr_shows_nothing_after_refresh() {
     let env = TestEnv::with_no_pr();
@@ -26,10 +26,12 @@ fn test_daemon_no_pr_shows_nothing_after_refresh() {
     // daemon リフレッシュ完了を待つ
     DaemonHandle::wait_for_cache(&env, 5000);
 
-    // キャッシュ確定後は何も出力しない（? loading が永続しないことを確認）
+    // キャッシュ確定後は + create-pr を出力する（? loading が永続しないことを確認）
     let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
     env.apply_with_cache(&mut cmd);
-    cmd.assert().success().stdout(predicate::str::is_empty());
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::diff("+ create-pr"));
 }
 
 /// #5: no-PR の stale リフレッシュ中でも `? loading` に戻らず空出力を維持する
@@ -45,19 +47,23 @@ fn test_daemon_no_pr_stale_while_refreshing_keeps_empty_output() {
         .success()
         .stdout(predicate::str::diff("? loading"));
 
-    // 初回リフレッシュ完了で空キャッシュ確定
+    // 初回リフレッシュ完了で + create-pr キャッシュ確定
     DaemonHandle::wait_for_cache(&env, 5000);
 
-    // stale 1回目: リフレッシュ開始しつつ空出力
+    // stale 1回目: リフレッシュ開始しつつ + create-pr 出力
     let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
     env.apply_with_cache(&mut cmd);
-    cmd.assert().success().stdout(predicate::str::is_empty());
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::diff("+ create-pr"));
 
-    // stale 2回目以降（refresh 実行中を狙う）: loading に戻らず空出力を維持
+    // stale 2回目以降（refresh 実行中を狙う）: loading に戻らず + create-pr を維持
     for _ in 0..5 {
         let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
         env.apply_with_cache(&mut cmd);
-        cmd.assert().success().stdout(predicate::str::is_empty());
+        cmd.assert()
+            .success()
+            .stdout(predicate::str::diff("+ create-pr"));
         std::thread::sleep(std::time::Duration::from_millis(50));
     }
 }


### PR DESCRIPTION
## Summary

- `OutputToken::NoPullRequest` を追加し、`PrState::NoPr` をこのトークンにマップ
- `DisplayConfig` に `no_pull_request: Option<TokenConfig>` フィールドを追加し、`fill_defaults()` でデフォルト値 `("+", "create-pr")` を設定
- `config_service::render_token` に `NoPullRequest` のレンダリングを追加
- 既存の e2e テスト（`test_no_pr` / no-PR シナリオ #4, #5）を新しい期待値 `+ create-pr` に更新

Closes #156

## Test plan

- [x] `cargo test --workspace` — 93 件全件 pass（新規ユニットテスト 3 件追加）
- [x] `cargo clippy --workspace -- -D warnings` — 警告なし
- [x] `cargo fmt --check --all` — 差分なし
- [x] `bash scripts/check-layer-deps.sh` — DDD レイヤー依存ルール OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)