### PR TITLE
docs: contexts.rs から削除済み config モジュールへの broken リンクを除去

### DIFF
--- a/src/contexts.rs
+++ b/src/contexts.rs
@@ -2,7 +2,6 @@
 //!
 //! This module exposes three contexts, each separated by responsibility.
 //!
-//! - [`config`] - manages display and behavior settings
 //! - [`evaluation`] - evaluates pull request merge readiness
 //! - [`daemon`] - provides low-latency responses via daemon/cache
 //!
@@ -12,7 +11,6 @@
 //! merge-ready-prompt (lightweight bin)
 //!   -> daemon (serve quickly from daemon/cache)
 //!   -> evaluation (fetch + evaluate merge readiness)
-//!   -> config (presentation and behavior settings)
 //! ```
 
 pub mod daemon;

--- a/src/contexts/evaluation.rs
+++ b/src/contexts/evaluation.rs
@@ -7,8 +7,8 @@
 //!
 //! ## Main responsibilities
 //!
-//! - PR lifecycle state evaluation (`domain::pr_state`)
-//! - Conversion to output tokens (`application`)
+//! - PR lifecycle state evaluation ([`domain::pr_state`])
+//! - Conversion to output tokens ([`application`])
 
 pub mod application;
 pub mod domain;

--- a/src/contexts/evaluation.rs
+++ b/src/contexts/evaluation.rs
@@ -8,10 +8,6 @@
 //! ## Main responsibilities
 //!
 //! - PR lifecycle state evaluation (`domain::pr_state`)
-//! - Branch sync state evaluation (`domain::branch_sync`)
-//! - CI check aggregation (`domain::ci_checks`)
-//! - Review status evaluation (`domain::review`)
-//! - Final readiness policy evaluation (`domain::policy`, `domain::merge_ready`)
 //! - Conversion to output tokens (`application`)
 
 pub mod application;


### PR DESCRIPTION
## Summary

- `src/contexts.rs`: `config` コンテキストは #162 で削除済みだったが、[`config`] への broken intra-doc link とダイアグラムの記述が残っていたため除去
- `src/contexts/evaluation.rs`: 存在しないサブモジュール（`branch_sync`・`ci_checks`・`review` 等）へのコメント参照を削除し、実際の構造に合わせて整理
- `src/contexts/evaluation.rs`: バッククォートのみの参照（`` `domain::pr_state` ``）を intra-doc link 構文（[`domain::pr_state`]）に変換し、将来の削除・リネーム時に rustdoc が警告で検知できるようにした

## Test plan

- [ ] `cargo build` で `rustdoc::broken_intra_doc_links` warning が出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)