### PR TITLE
feat: Draft PR のとき ✎ ready-for-review を表示する

### DIFF
--- a/src/contexts/evaluation/application.rs
+++ b/src/contexts/evaluation/application.rs
@@ -21,6 +21,7 @@ pub enum OutputToken {
     ReviewRequested,
     MergeReady,
     NoPullRequest,
+    Draft,
 }
 
 fn map_blocked_to_tokens(blocked: BlockedState) -> Vec<OutputToken> {
@@ -50,14 +51,10 @@ pub(crate) fn map_pr_state_to_tokens(state: PrState) -> Vec<OutputToken> {
     match state {
         PrState::Blocked(blocked) => map_blocked_to_tokens(blocked),
         PrState::Unblocked(UnblockedState::MergeReady) => vec![OutputToken::MergeReady],
+        PrState::Unblocked(UnblockedState::Draft) => vec![OutputToken::Draft],
         PrState::NoPr => vec![OutputToken::NoPullRequest],
-        // Draft (#154) は後続 Issue で実装
         // NotApplicable / Unknown は何も表示しない
-        PrState::Unblocked(UnblockedState::Draft)
-        | PrState::NotApplicable(_)
-        | PrState::Unknown => {
-            vec![]
-        }
+        PrState::NotApplicable(_) | PrState::Unknown => vec![],
     }
 }
 
@@ -70,5 +67,12 @@ mod tests {
         let tokens = map_pr_state_to_tokens(PrState::NoPr);
         assert_eq!(tokens.len(), 1);
         assert!(matches!(tokens[0], OutputToken::NoPullRequest));
+    }
+
+    #[test]
+    fn draft_pr_maps_to_draft_token() {
+        let tokens = map_pr_state_to_tokens(PrState::Unblocked(UnblockedState::Draft));
+        assert_eq!(tokens.len(), 1);
+        assert!(matches!(tokens[0], OutputToken::Draft));
     }
 }

--- a/src/contexts/evaluation/application/config_service.rs
+++ b/src/contexts/evaluation/application/config_service.rs
@@ -64,6 +64,11 @@ fn render_token(config: &DisplayConfig, token: &OutputToken) -> String {
         OutputToken::ReviewRequested => {
             apply_format(config.review.as_ref().unwrap_or(&empty()), "⚠", "review")
         }
+        OutputToken::Draft => apply_format(
+            config.draft.as_ref().unwrap_or(&empty()),
+            "✎",
+            "ready-for-review",
+        ),
     }
 }
 
@@ -112,5 +117,11 @@ mod tests {
     fn no_pull_request_renders_with_default_config() {
         let result = render_output(&[OutputToken::NoPullRequest], None, &DefaultRepo);
         assert_eq!(result, "+ create-pr");
+    }
+
+    #[test]
+    fn draft_renders_with_default_config() {
+        let result = render_output(&[OutputToken::Draft], None, &DefaultRepo);
+        assert_eq!(result, "✎ ready-for-review");
     }
 }

--- a/src/contexts/evaluation/domain/display_config.rs
+++ b/src/contexts/evaluation/domain/display_config.rs
@@ -12,6 +12,7 @@ pub struct DisplayConfig {
     pub ci_fail: Option<TokenConfig>,
     pub ci_action: Option<TokenConfig>,
     pub review: Option<TokenConfig>,
+    pub draft: Option<TokenConfig>,
     pub error: Option<ErrorConfig>,
 }
 
@@ -34,6 +35,8 @@ impl DisplayConfig {
         self.ci_fail.get_or_insert_with(|| tok("✗", "ci-fail"));
         self.ci_action.get_or_insert_with(|| tok("⚠", "ci-action"));
         self.review.get_or_insert_with(|| tok("⚠", "review"));
+        self.draft
+            .get_or_insert_with(|| tok("✎", "ready-for-review"));
         let error = self.error.get_or_insert_with(ErrorConfig::empty);
         error
             .auth_required
@@ -92,5 +95,14 @@ mod tests {
         let tok = config.no_pull_request.as_ref().unwrap();
         assert_eq!(tok.symbol.as_deref(), Some("+"));
         assert_eq!(tok.label.as_deref(), Some("create-pr"));
+    }
+
+    #[test]
+    fn fill_defaults_sets_draft() {
+        let mut config = DisplayConfig::default();
+        config.fill_defaults();
+        let tok = config.draft.as_ref().unwrap();
+        assert_eq!(tok.symbol.as_deref(), Some("✎"));
+        assert_eq!(tok.label.as_deref(), Some("ready-for-review"));
     }
 }

--- a/tests/e2e/prompt/pr_state.rs
+++ b/tests/e2e/prompt/pr_state.rs
@@ -13,6 +13,19 @@ use super::super::helpers::{DaemonHandle, TestEnv};
 
 const CLOSED_PR: &str = r#"{"state":"CLOSED","isDraft":false,"mergeable":"UNKNOWN","mergeStateStatus":"UNKNOWN","reviewDecision":null}"#;
 const MERGED_PR: &str = r#"{"state":"MERGED","isDraft":false,"mergeable":"UNKNOWN","mergeStateStatus":"UNKNOWN","reviewDecision":null}"#;
+const DRAFT_PR: &str = r#"{"state":"OPEN","isDraft":true,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}"#;
+
+fn assert_prompt(env: &TestEnv, expected: &str) {
+    let _daemon = DaemonHandle::start(env);
+    DaemonHandle::wait_for_cache(env, 5000);
+
+    let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
+    env.apply_with_cache(&mut cmd);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::diff(expected.to_owned()))
+        .stderr("");
+}
 
 fn assert_prompt_empty(env: &TestEnv) {
     let _daemon = DaemonHandle::start(env);
@@ -41,6 +54,17 @@ fn test_no_pr() {
         .success()
         .stdout(predicate::str::diff("+ create-pr"))
         .stderr("");
+}
+
+// ── #32–33: CLOSED / MERGED ───────────────────────────────────────────────────
+
+// ── #34: Draft PR ────────────────────────────────────────────────────────────
+
+/// #34: Draft PR → `✎ ready-for-review`
+#[test]
+fn test_draft_pr_shows_ready_for_review() {
+    let env = TestEnv::new(DRAFT_PR, Some(r#"[]"#));
+    assert_prompt(&env, "✎ ready-for-review");
 }
 
 // ── #32–33: CLOSED / MERGED ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `OutputToken::Draft` を追加し、`PrState::Unblocked(Draft)` を `vec![OutputToken::Draft]` にマッピング
- `DisplayConfig` に `draft: Option<TokenConfig>` フィールドを追加し、`fill_defaults()` でデフォルト値（`✎ ready-for-review`）を設定
- `render_token()` に `OutputToken::Draft` アームを追加

## Test plan

- [x] ユニットテスト: `draft_pr_maps_to_draft_token()` — Draft state → Draft token のマッピング
- [x] ユニットテスト: `fill_defaults_sets_draft()` — デフォルト symbol/label の確認
- [x] ユニットテスト: `draft_renders_with_default_config()` — `✎ ready-for-review` の描画
- [x] E2E テスト: `test_draft_pr_shows_ready_for_review()` — `isDraft=true` の PR で `✎ ready-for-review` が出力されることを確認
- [x] `cargo test --workspace` 全 97 件 Pass
- [x] `cargo clippy --workspace -- -D warnings` / `cargo fmt --check --all` 通過

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)