### PR TITLE
feat: reviewDecision == "REVIEW_REQUIRED" のとき @ assign-reviewer を表示する

### DIFF
--- a/src/contexts/evaluation/application.rs
+++ b/src/contexts/evaluation/application.rs
@@ -19,6 +19,7 @@ pub enum OutputToken {
     CiFail,
     CiAction,
     ReviewRequested,
+    ReviewRequired,
     MergeReady,
     NoPullRequest,
     Draft,
@@ -42,6 +43,7 @@ fn map_blocked_to_tokens(blocked: BlockedState) -> Vec<OutputToken> {
     if let Some(r) = blocked.review {
         tokens.push(match r {
             ReviewState::ChangesRequested => OutputToken::ReviewRequested,
+            ReviewState::ReviewRequired => OutputToken::ReviewRequired,
         });
     }
     tokens
@@ -74,5 +76,18 @@ mod tests {
         let tokens = map_pr_state_to_tokens(PrState::Unblocked(UnblockedState::Draft));
         assert_eq!(tokens.len(), 1);
         assert!(matches!(tokens[0], OutputToken::Draft));
+    }
+
+    #[test]
+    fn review_required_maps_to_review_required_token() {
+        use crate::contexts::evaluation::domain::pr_state::blocked::BlockedState;
+        let blocked = BlockedState {
+            branch_sync: None,
+            ci: None,
+            review: Some(ReviewState::ReviewRequired),
+        };
+        let tokens = map_pr_state_to_tokens(PrState::Blocked(blocked));
+        assert_eq!(tokens.len(), 1);
+        assert!(matches!(tokens[0], OutputToken::ReviewRequired));
     }
 }

--- a/src/contexts/evaluation/application/config_service.rs
+++ b/src/contexts/evaluation/application/config_service.rs
@@ -64,6 +64,11 @@ fn render_token(config: &DisplayConfig, token: &OutputToken) -> String {
         OutputToken::ReviewRequested => {
             apply_format(config.review.as_ref().unwrap_or(&empty()), "⚠", "review")
         }
+        OutputToken::ReviewRequired => apply_format(
+            config.review_required.as_ref().unwrap_or(&empty()),
+            "@",
+            "assign-reviewer",
+        ),
         OutputToken::Draft => apply_format(
             config.draft.as_ref().unwrap_or(&empty()),
             "✎",
@@ -123,5 +128,11 @@ mod tests {
     fn draft_renders_with_default_config() {
         let result = render_output(&[OutputToken::Draft], None, &DefaultRepo);
         assert_eq!(result, "✎ ready-for-review");
+    }
+
+    #[test]
+    fn review_required_renders_with_default_config() {
+        let result = render_output(&[OutputToken::ReviewRequired], None, &DefaultRepo);
+        assert_eq!(result, "@ assign-reviewer");
     }
 }

--- a/src/contexts/evaluation/domain/display_config.rs
+++ b/src/contexts/evaluation/domain/display_config.rs
@@ -12,6 +12,7 @@ pub struct DisplayConfig {
     pub ci_fail: Option<TokenConfig>,
     pub ci_action: Option<TokenConfig>,
     pub review: Option<TokenConfig>,
+    pub review_required: Option<TokenConfig>,
     pub draft: Option<TokenConfig>,
     pub error: Option<ErrorConfig>,
 }
@@ -35,6 +36,8 @@ impl DisplayConfig {
         self.ci_fail.get_or_insert_with(|| tok("✗", "ci-fail"));
         self.ci_action.get_or_insert_with(|| tok("⚠", "ci-action"));
         self.review.get_or_insert_with(|| tok("⚠", "review"));
+        self.review_required
+            .get_or_insert_with(|| tok("@", "assign-reviewer"));
         self.draft
             .get_or_insert_with(|| tok("✎", "ready-for-review"));
         let error = self.error.get_or_insert_with(ErrorConfig::empty);
@@ -104,5 +107,14 @@ mod tests {
         let tok = config.draft.as_ref().unwrap();
         assert_eq!(tok.symbol.as_deref(), Some("✎"));
         assert_eq!(tok.label.as_deref(), Some("ready-for-review"));
+    }
+
+    #[test]
+    fn fill_defaults_sets_review_required() {
+        let mut config = DisplayConfig::default();
+        config.fill_defaults();
+        let tok = config.review_required.as_ref().unwrap();
+        assert_eq!(tok.symbol.as_deref(), Some("@"));
+        assert_eq!(tok.label.as_deref(), Some("assign-reviewer"));
     }
 }

--- a/src/contexts/evaluation/domain/pr_state/blocked/review.rs
+++ b/src/contexts/evaluation/domain/pr_state/blocked/review.rs
@@ -3,4 +3,6 @@
 pub enum ReviewState {
     /// レビュアーが変更を要求している
     ChangesRequested,
+    /// レビュアーがまだアサインされていない
+    ReviewRequired,
 }

--- a/src/contexts/evaluation/infrastructure/gh.rs
+++ b/src/contexts/evaluation/infrastructure/gh.rs
@@ -160,6 +160,7 @@ fn translate_sync(mergeable: &str, behind_by: Option<u64>) -> Option<BranchSyncS
 fn translate_review(decision: Option<&str>) -> Option<ReviewState> {
     match decision {
         Some("CHANGES_REQUESTED") => Some(ReviewState::ChangesRequested),
+        Some("REVIEW_REQUIRED") => Some(ReviewState::ReviewRequired),
         _ => None,
     }
 }

--- a/tests/e2e/prompt/review.rs
+++ b/tests/e2e/prompt/review.rs
@@ -1,6 +1,8 @@
-//! レビュー状態の E2E テスト（シナリオ #30）
+//! レビュー状態の E2E テスト（シナリオ #30, #31）
 //!
-//! 対象条件: `reviewDecision == CHANGES_REQUESTED` → `⚠ review`
+//! 対象条件:
+//!   #30: `reviewDecision == CHANGES_REQUESTED` → `⚠ review`
+//!   #31: `reviewDecision == REVIEW_REQUIRED`   → `@ assign-reviewer`
 //! 実行フローは daemon 経由（`merge-ready prompt`）に統一する。
 
 const PROMPT_BIN: &str = "merge-ready-prompt";
@@ -22,4 +24,22 @@ fn test_review_changes_requested() {
     let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
     env.apply_with_cache(&mut cmd);
     cmd.assert().success().stdout("⚠ review").stderr("");
+}
+
+/// #31: `reviewDecision == REVIEW_REQUIRED` → `@ assign-reviewer`
+#[test]
+fn test_review_required() {
+    let env = TestEnv::new(
+        r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"BLOCKED","reviewDecision":"REVIEW_REQUIRED"}"#,
+        Some(r#"[{"bucket":"pass","state":"SUCCESS"}]"#),
+    );
+    let _daemon = DaemonHandle::start(&env);
+    DaemonHandle::wait_for_cache(&env, 5000);
+
+    let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
+    env.apply_with_cache(&mut cmd);
+    cmd.assert()
+        .success()
+        .stdout("@ assign-reviewer")
+        .stderr("");
 }


### PR DESCRIPTION
## Summary

- `ReviewState::ReviewRequired` variant を追加
- `translate_review()` に `"REVIEW_REQUIRED"` → `ReviewState::ReviewRequired` のマッピングを追加
- `OutputToken::ReviewRequired` を追加し、表示文字 `@ assign-reviewer` を設定
- E2E テスト `test_review_required()` を追加

## Test plan

- [x] `cargo test --workspace` — 101 tests passed
- [x] `cargo clippy --workspace -- -D warnings` — no issues
- [x] `cargo fmt --check --all` — ok
- [x] `bash scripts/check-layer-deps.sh` — ok
- [x] `bash scripts/check-no-mod-rs.sh` — ok

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)