### PR TITLE
feat: CI チェック実行中（pending）のとき ⧖ wait-for-ci を表示する

### DIFF
--- a/src/contexts/evaluation/application.rs
+++ b/src/contexts/evaluation/application.rs
@@ -18,6 +18,7 @@ pub enum OutputToken {
     SyncUnknown,
     CiFail,
     CiAction,
+    CiPending,
     ReviewRequested,
     ReviewRequired,
     MergeReady,
@@ -38,6 +39,7 @@ fn map_blocked_to_tokens(blocked: BlockedState) -> Vec<OutputToken> {
         tokens.push(match c {
             CiState::Fail => OutputToken::CiFail,
             CiState::ActionRequired => OutputToken::CiAction,
+            CiState::Pending => OutputToken::CiPending,
         });
     }
     if let Some(r) = blocked.review {
@@ -89,5 +91,18 @@ mod tests {
         let tokens = map_pr_state_to_tokens(PrState::Blocked(blocked));
         assert_eq!(tokens.len(), 1);
         assert!(matches!(tokens[0], OutputToken::ReviewRequired));
+    }
+
+    #[test]
+    fn ci_pending_maps_to_ci_pending_token() {
+        use crate::contexts::evaluation::domain::pr_state::blocked::BlockedState;
+        let blocked = BlockedState {
+            branch_sync: None,
+            ci: Some(CiState::Pending),
+            review: None,
+        };
+        let tokens = map_pr_state_to_tokens(PrState::Blocked(blocked));
+        assert_eq!(tokens.len(), 1);
+        assert!(matches!(tokens[0], OutputToken::CiPending));
     }
 }

--- a/src/contexts/evaluation/application/config_service.rs
+++ b/src/contexts/evaluation/application/config_service.rs
@@ -61,6 +61,11 @@ fn render_token(config: &DisplayConfig, token: &OutputToken) -> String {
             "⚠",
             "ci-action",
         ),
+        OutputToken::CiPending => apply_format(
+            config.ci_pending.as_ref().unwrap_or(&empty()),
+            "⧖",
+            "wait-for-ci",
+        ),
         OutputToken::ReviewRequested => {
             apply_format(config.review.as_ref().unwrap_or(&empty()), "⚠", "review")
         }
@@ -134,5 +139,11 @@ mod tests {
     fn review_required_renders_with_default_config() {
         let result = render_output(&[OutputToken::ReviewRequired], None, &DefaultRepo);
         assert_eq!(result, "@ assign-reviewer");
+    }
+
+    #[test]
+    fn ci_pending_renders_with_default_config() {
+        let result = render_output(&[OutputToken::CiPending], None, &DefaultRepo);
+        assert_eq!(result, "⧖ wait-for-ci");
     }
 }

--- a/src/contexts/evaluation/domain/display_config.rs
+++ b/src/contexts/evaluation/domain/display_config.rs
@@ -36,7 +36,8 @@ impl DisplayConfig {
             .get_or_insert_with(|| tok("?", "sync-unknown"));
         self.ci_fail.get_or_insert_with(|| tok("✗", "ci-fail"));
         self.ci_action.get_or_insert_with(|| tok("⚠", "ci-action"));
-        self.ci_pending.get_or_insert_with(|| tok("⧖", "wait-for-ci"));
+        self.ci_pending
+            .get_or_insert_with(|| tok("⧖", "wait-for-ci"));
         self.review.get_or_insert_with(|| tok("⚠", "review"));
         self.review_required
             .get_or_insert_with(|| tok("@", "assign-reviewer"));

--- a/src/contexts/evaluation/domain/display_config.rs
+++ b/src/contexts/evaluation/domain/display_config.rs
@@ -11,6 +11,7 @@ pub struct DisplayConfig {
     pub sync_unknown: Option<TokenConfig>,
     pub ci_fail: Option<TokenConfig>,
     pub ci_action: Option<TokenConfig>,
+    pub ci_pending: Option<TokenConfig>,
     pub review: Option<TokenConfig>,
     pub review_required: Option<TokenConfig>,
     pub draft: Option<TokenConfig>,
@@ -35,6 +36,7 @@ impl DisplayConfig {
             .get_or_insert_with(|| tok("?", "sync-unknown"));
         self.ci_fail.get_or_insert_with(|| tok("✗", "ci-fail"));
         self.ci_action.get_or_insert_with(|| tok("⚠", "ci-action"));
+        self.ci_pending.get_or_insert_with(|| tok("⧖", "wait-for-ci"));
         self.review.get_or_insert_with(|| tok("⚠", "review"));
         self.review_required
             .get_or_insert_with(|| tok("@", "assign-reviewer"));
@@ -116,5 +118,14 @@ mod tests {
         let tok = config.review_required.as_ref().unwrap();
         assert_eq!(tok.symbol.as_deref(), Some("@"));
         assert_eq!(tok.label.as_deref(), Some("assign-reviewer"));
+    }
+
+    #[test]
+    fn fill_defaults_sets_ci_pending() {
+        let mut config = DisplayConfig::default();
+        config.fill_defaults();
+        let tok = config.ci_pending.as_ref().unwrap();
+        assert_eq!(tok.symbol.as_deref(), Some("⧖"));
+        assert_eq!(tok.label.as_deref(), Some("wait-for-ci"));
     }
 }

--- a/src/contexts/evaluation/domain/pr_state/blocked/ci.rs
+++ b/src/contexts/evaluation/domain/pr_state/blocked/ci.rs
@@ -5,4 +5,6 @@ pub enum CiState {
     Fail,
     /// 手動アクションが必要なチェックが存在する
     ActionRequired,
+    /// チェックが実行中
+    Pending,
 }

--- a/src/contexts/evaluation/infrastructure/gh.rs
+++ b/src/contexts/evaluation/infrastructure/gh.rs
@@ -186,8 +186,34 @@ fn aggregate_ci(buckets: &[CheckBucket]) -> Option<CiState> {
         .any(|b| matches!(b, CheckBucket::ActionRequired))
     {
         Some(CiState::ActionRequired)
+    } else if buckets.iter().any(|b| matches!(b, CheckBucket::Pending)) {
+        Some(CiState::Pending)
     } else {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::contexts::evaluation::infrastructure::gh::schema::CheckBucket;
+
+    #[test]
+    fn aggregate_ci_pending_returns_pending() {
+        let buckets = vec![CheckBucket::Pending];
+        assert_eq!(aggregate_ci(&buckets), Some(CiState::Pending));
+    }
+
+    #[test]
+    fn aggregate_ci_fail_takes_priority_over_pending() {
+        let buckets = vec![CheckBucket::Fail, CheckBucket::Pending];
+        assert_eq!(aggregate_ci(&buckets), Some(CiState::Fail));
+    }
+
+    #[test]
+    fn aggregate_ci_no_pending_returns_none() {
+        let buckets = vec![CheckBucket::Other];
+        assert_eq!(aggregate_ci(&buckets), None);
     }
 }
 

--- a/src/contexts/evaluation/infrastructure/gh/schema.rs
+++ b/src/contexts/evaluation/infrastructure/gh/schema.rs
@@ -47,6 +47,7 @@ pub(super) enum CheckBucket {
     Fail,
     Cancel,
     ActionRequired,
+    Pending,
     Other,
 }
 
@@ -55,6 +56,17 @@ pub(super) fn translate_bucket(bucket: &str) -> CheckBucket {
         "fail" => CheckBucket::Fail,
         "cancel" => CheckBucket::Cancel,
         "action_required" => CheckBucket::ActionRequired,
+        "pending" => CheckBucket::Pending,
         _ => CheckBucket::Other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn translate_bucket_pending() {
+        assert!(matches!(translate_bucket("pending"), CheckBucket::Pending));
     }
 }


### PR DESCRIPTION
## Summary

- `CiState::Pending` バリアントを追加し、CI チェックが実行中の場合を表現できるようにした
- `aggregate_ci()` に `pending` バケット検出を追加し、`CiState::Pending` を返すようにした
- `OutputToken::CiPending` を追加し、デフォルト表示を `⧖ wait-for-ci` に設定した
- 既存の `CiFail` / `CiAction` の挙動は変更なし

Closes #177

## Test plan

- [x] `aggregate_ci` に pending バケットのみ → `CiState::Pending` を返すことを確認
- [x] `aggregate_ci` に fail + pending → `CiState::Fail` が優先されることを確認
- [x] `CiState::Pending` → `OutputToken::CiPending` にマッピングされることを確認
- [x] `⧖ wait-for-ci` がデフォルト設定で正しくレンダリングされることを確認
- [x] `cargo test --workspace` 全テスト通過
- [x] `cargo clippy` 警告なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)