### PR TITLE
feat: mergeStateStatus が UNKNOWN のとき ⧖ wait-for-status を表示する

### DIFF
--- a/src/contexts/evaluation/application.rs
+++ b/src/contexts/evaluation/application.rs
@@ -2,6 +2,7 @@ pub mod config_service;
 pub mod errors;
 pub mod prompt;
 
+use crate::contexts::evaluation::domain::pr_state::NotApplicableState;
 use crate::contexts::evaluation::domain::pr_state::PrState;
 use crate::contexts::evaluation::domain::pr_state::blocked::BlockedState;
 use crate::contexts::evaluation::domain::pr_state::blocked::branch_sync::BranchSyncState;
@@ -24,6 +25,7 @@ pub enum OutputToken {
     MergeReady,
     NoPullRequest,
     Draft,
+    StatusCalculating,
 }
 
 fn map_blocked_to_tokens(blocked: BlockedState) -> Vec<OutputToken> {
@@ -57,7 +59,10 @@ pub(crate) fn map_pr_state_to_tokens(state: PrState) -> Vec<OutputToken> {
         PrState::Unblocked(UnblockedState::MergeReady) => vec![OutputToken::MergeReady],
         PrState::Unblocked(UnblockedState::Draft) => vec![OutputToken::Draft],
         PrState::NoPr => vec![OutputToken::NoPullRequest],
-        // NotApplicable / Unknown は何も表示しない
+        PrState::NotApplicable(NotApplicableState::Calculating) => {
+            vec![OutputToken::StatusCalculating]
+        }
+        // NotApplicable（Calculating 以外）/ Unknown は何も表示しない
         PrState::NotApplicable(_) | PrState::Unknown => vec![],
     }
 }
@@ -104,5 +109,13 @@ mod tests {
         let tokens = map_pr_state_to_tokens(PrState::Blocked(blocked));
         assert_eq!(tokens.len(), 1);
         assert!(matches!(tokens[0], OutputToken::CiPending));
+    }
+
+    #[test]
+    fn calculating_maps_to_status_calculating_token() {
+        let tokens =
+            map_pr_state_to_tokens(PrState::NotApplicable(NotApplicableState::Calculating));
+        assert_eq!(tokens.len(), 1);
+        assert!(matches!(tokens[0], OutputToken::StatusCalculating));
     }
 }

--- a/src/contexts/evaluation/application/config_service.rs
+++ b/src/contexts/evaluation/application/config_service.rs
@@ -79,6 +79,11 @@ fn render_token(config: &DisplayConfig, token: &OutputToken) -> String {
             "✎",
             "ready-for-review",
         ),
+        OutputToken::StatusCalculating => apply_format(
+            config.status_calculating.as_ref().unwrap_or(&empty()),
+            "⧖",
+            "wait-for-status",
+        ),
     }
 }
 
@@ -145,5 +150,11 @@ mod tests {
     fn ci_pending_renders_with_default_config() {
         let result = render_output(&[OutputToken::CiPending], None, &DefaultRepo);
         assert_eq!(result, "⧖ wait-for-ci");
+    }
+
+    #[test]
+    fn status_calculating_renders_with_default_config() {
+        let result = render_output(&[OutputToken::StatusCalculating], None, &DefaultRepo);
+        assert_eq!(result, "⧖ wait-for-status");
     }
 }

--- a/src/contexts/evaluation/domain/display_config.rs
+++ b/src/contexts/evaluation/domain/display_config.rs
@@ -15,6 +15,7 @@ pub struct DisplayConfig {
     pub review: Option<TokenConfig>,
     pub review_required: Option<TokenConfig>,
     pub draft: Option<TokenConfig>,
+    pub status_calculating: Option<TokenConfig>,
     pub error: Option<ErrorConfig>,
 }
 
@@ -43,6 +44,8 @@ impl DisplayConfig {
             .get_or_insert_with(|| tok("@", "assign-reviewer"));
         self.draft
             .get_or_insert_with(|| tok("✎", "ready-for-review"));
+        self.status_calculating
+            .get_or_insert_with(|| tok("⧖", "wait-for-status"));
         let error = self.error.get_or_insert_with(ErrorConfig::empty);
         error
             .auth_required
@@ -128,5 +131,14 @@ mod tests {
         let tok = config.ci_pending.as_ref().unwrap();
         assert_eq!(tok.symbol.as_deref(), Some("⧖"));
         assert_eq!(tok.label.as_deref(), Some("wait-for-ci"));
+    }
+
+    #[test]
+    fn fill_defaults_sets_status_calculating() {
+        let mut config = DisplayConfig::default();
+        config.fill_defaults();
+        let tok = config.status_calculating.as_ref().unwrap();
+        assert_eq!(tok.symbol.as_deref(), Some("⧖"));
+        assert_eq!(tok.label.as_deref(), Some("wait-for-status"));
     }
 }

--- a/src/contexts/evaluation/domain/pr_state.rs
+++ b/src/contexts/evaluation/domain/pr_state.rs
@@ -125,4 +125,10 @@ mod tests {
         );
         assert!(matches!(state, PrState::Blocked(_)));
     }
+
+    #[test]
+    fn calculating_is_not_terminal() {
+        let state = PrState::NotApplicable(NotApplicableState::Calculating);
+        assert!(!state.is_terminal());
+    }
 }

--- a/src/contexts/evaluation/domain/pr_state/not_applicable.rs
+++ b/src/contexts/evaluation/domain/pr_state/not_applicable.rs
@@ -9,4 +9,6 @@ pub enum NotApplicableState {
     DefaultBranch,
     /// Git リポジトリ外での実行
     NoRepository,
+    /// GitHub がマージ状態を計算中（過渡的な状態）
+    Calculating,
 }

--- a/src/contexts/evaluation/infrastructure/gh.rs
+++ b/src/contexts/evaluation/infrastructure/gh.rs
@@ -142,7 +142,16 @@ impl PrRepository for GhClient {
         let review = translate_review(pr_view.review_decision.as_deref());
         let unblocked = translate_unblocked(pr_view.is_draft, &pr_view.merge_state_status);
 
-        Ok(evaluate(branch_sync, ci, review, unblocked))
+        let state = evaluate(branch_sync, ci, review, unblocked);
+        if matches!(state, PrState::Unknown)
+            && matches!(
+                pr_view.merge_state_status.as_str(),
+                "MERGE_STATE_UNKNOWN" | "UNKNOWN"
+            )
+        {
+            return Ok(PrState::NotApplicable(NotApplicableState::Calculating));
+        }
+        Ok(state)
     }
 }
 
@@ -214,6 +223,16 @@ mod tests {
     fn aggregate_ci_no_pending_returns_none() {
         let buckets = vec![CheckBucket::Other];
         assert_eq!(aggregate_ci(&buckets), None);
+    }
+
+    #[test]
+    fn translate_unblocked_merge_state_unknown_returns_none() {
+        assert_eq!(translate_unblocked(false, "MERGE_STATE_UNKNOWN"), None);
+    }
+
+    #[test]
+    fn translate_unblocked_unknown_returns_none() {
+        assert_eq!(translate_unblocked(false, "UNKNOWN"), None);
     }
 }
 

--- a/tests/e2e/prompt/pr_state.rs
+++ b/tests/e2e/prompt/pr_state.rs
@@ -14,6 +14,8 @@ use super::super::helpers::{DaemonHandle, TestEnv};
 const CLOSED_PR: &str = r#"{"state":"CLOSED","isDraft":false,"mergeable":"UNKNOWN","mergeStateStatus":"UNKNOWN","reviewDecision":null}"#;
 const MERGED_PR: &str = r#"{"state":"MERGED","isDraft":false,"mergeable":"UNKNOWN","mergeStateStatus":"UNKNOWN","reviewDecision":null}"#;
 const DRAFT_PR: &str = r#"{"state":"OPEN","isDraft":true,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}"#;
+const MERGE_STATE_UNKNOWN_PR: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"UNKNOWN","mergeStateStatus":"MERGE_STATE_UNKNOWN","reviewDecision":null,"baseRefName":"","headRefName":""}"#;
+const UNKNOWN_STATUS_PR: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"UNKNOWN","mergeStateStatus":"UNKNOWN","reviewDecision":null,"baseRefName":"","headRefName":""}"#;
 
 fn assert_prompt(env: &TestEnv, expected: &str) {
     let _daemon = DaemonHandle::start(env);
@@ -76,4 +78,20 @@ fn test_draft_pr_shows_ready_for_review() {
 fn test_non_open_pr_shows_nothing(#[case] pr_json: &str) {
     let env = TestEnv::new(pr_json, None);
     assert_prompt_empty(&env);
+}
+
+// ── #179: MERGE_STATE_UNKNOWN / UNKNOWN ──────────────────────────────────────
+
+/// #179: `mergeStateStatus == "MERGE_STATE_UNKNOWN"` → `⧖ wait-for-status`
+#[test]
+fn test_merge_state_unknown_shows_wait_for_status() {
+    let env = TestEnv::new(MERGE_STATE_UNKNOWN_PR, Some(r#"[]"#));
+    assert_prompt(&env, "⧖ wait-for-status");
+}
+
+/// #179: `mergeStateStatus == "UNKNOWN"` → `⧖ wait-for-status`
+#[test]
+fn test_unknown_merge_state_status_shows_wait_for_status() {
+    let env = TestEnv::new(UNKNOWN_STATUS_PR, Some(r#"[]"#));
+    assert_prompt(&env, "⧖ wait-for-status");
 }


### PR DESCRIPTION
## Summary

- `mergeStateStatus == "MERGE_STATE_UNKNOWN"` または `"UNKNOWN"` のとき `⧖ wait-for-status` を表示する
- `NotApplicableState::Calculating` バリアントを追加し、`is_terminal()` は `false` を返す（ポーリング継続）
- 既存の `⧖ wait-for-ci` と同じ記号・命名規則に統一

## Test plan

- [x] `cargo test --workspace`（116件 pass）
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo fmt --check --all`
- [x] `bash scripts/check-layer-deps.sh`
- [x] `bash scripts/check-no-mod-rs.sh`

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)