### PR TITLE
feat!: ラベルをセンテンスケースのアクション表現に統一し、review キーを changes_requested に改名

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,18 +52,18 @@ This makes it easy to use from shell scripts and prompt hooks.
 
 ## Output Tokens
 
-- `✓ merge-ready` - ready to merge
-- `✎ ready-for-review` - pull request is in draft state
-- `+ create-pr` - branch exists but no pull request has been created yet
-- `⚠ review` - changes were requested in review
-- `@ assign-reviewer` - no reviewer assigned yet
-- `⚠ ci-action` - CI checks require manual action
-- `⧖ wait-for-ci` - CI checks are pending
-- `✗ ci-fail` - CI checks failed
-- `✗ conflict` - merge conflicts exist
-- `✗ update-branch` - branch is behind base branch
-- `? sync-unknown` - branch sync status is unknown
-- `⧖ wait-for-status` - GitHub is calculating merge status
+- `✓ Ready for merge` - ready to merge
+- `✎ Ready for review` - pull request is in draft state
+- `+ Create PR` - branch exists but no pull request has been created yet
+- `⚠ Resolve review` - changes were requested in review
+- `@ Assign reviewer` - no reviewer assigned yet
+- `⚠ Run CI action` - CI checks require manual action
+- `⧖ Wait for CI` - CI checks are pending
+- `✗ Fix CI failure` - CI checks failed
+- `✗ Resolve conflict` - merge conflicts exist
+- `✗ Update branch` - branch is behind base branch
+- `? Check branch sync` - branch sync status is unknown
+- `⧖ Wait for status` - GitHub is calculating merge status
 - `? loading` - cache miss; daemon is fetching in the background
 
 ## Background Daemon
@@ -96,7 +96,7 @@ format = "[$output]($style) "
 style = "bold yellow"
 ```
 
-`require_repo = true` limits the module to git repositories without any shell command overhead. `merge-ready-prompt` itself returns `+ create-pr` when no pull request exists for the branch, so no additional filtering is needed.
+`require_repo = true` limits the module to git repositories without any shell command overhead. `merge-ready-prompt` itself returns `+ Create PR` when no pull request exists for the branch, so no additional filtering is needed.
 
 If your environment sets `STARSHIP_SHELL` to a slower shell (for example `fish`), custom modules can be noticeably slower due to shell startup cost. Pinning `shell = ["/bin/zsh"]` (or another lightweight shell on your system) keeps prompt latency low.
 
@@ -115,62 +115,62 @@ All fields are optional — omitting any field falls back to the default shown b
 ```toml
 [merge_ready]
 symbol = "✓"
-label = "merge-ready"
+label = "Ready for merge"
 # format = "$symbol $label"
 
 [no_pull_request]
 symbol = "+"
-label = "create-pr"
+label = "Create PR"
 # format = "$symbol $label"
 
 [conflict]
 symbol = "✗"
-label = "conflict"
+label = "Resolve conflict"
 # format = "$symbol $label"
 
 [update_branch]
 symbol = "✗"
-label = "update-branch"
+label = "Update branch"
 # format = "$symbol $label"
 
 [sync_unknown]
 symbol = "?"
-label = "sync-unknown"
+label = "Check branch sync"
 # format = "$symbol $label"
 
 [ci_fail]
 symbol = "✗"
-label = "ci-fail"
+label = "Fix CI failure"
 # format = "$symbol $label"
 
 [ci_action]
 symbol = "⚠"
-label = "ci-action"
+label = "Run CI action"
 # format = "$symbol $label"
 
 [ci_pending]
 symbol = "⧖"
-label = "wait-for-ci"
+label = "Wait for CI"
 # format = "$symbol $label"
 
-[review]
+[changes_requested]
 symbol = "⚠"
-label = "review"
+label = "Resolve review"
 # format = "$symbol $label"
 
 [review_required]
 symbol = "@"
-label = "assign-reviewer"
+label = "Assign reviewer"
 # format = "$symbol $label"
 
 [draft]
 symbol = "✎"
-label = "ready-for-review"
+label = "Ready for review"
 # format = "$symbol $label"
 
 [status_calculating]
 symbol = "⧖"
-label = "wait-for-status"
+label = "Wait for status"
 # format = "$symbol $label"
 
 [error.auth_required]

--- a/src/contexts/daemon/infrastructure/daemon_server.rs
+++ b/src/contexts/daemon/infrastructure/daemon_server.rs
@@ -621,7 +621,7 @@ mod tests {
 
     #[test]
     fn active_when_non_empty_output_and_not_terminal() {
-        assert!(is_active_entry(&make_entry("✓ merge-ready", false)));
+        assert!(is_active_entry(&make_entry("✓ Ready for merge", false)));
     }
 
     #[test]
@@ -636,7 +636,7 @@ mod tests {
 
     #[test]
     fn inactive_when_terminal_even_with_non_empty_output() {
-        assert!(!is_active_entry(&make_entry("✓ merge-ready", true)));
+        assert!(!is_active_entry(&make_entry("✓ Ready for merge", true)));
     }
 
     // ── process_update ─────────────────────────────────────────────────────────
@@ -644,7 +644,7 @@ mod tests {
     #[test]
     fn process_update_sets_is_terminal_true() {
         let mut entries = HashMap::new();
-        entries.insert("repo".to_owned(), make_entry("✓ merge-ready", false));
+        entries.insert("repo".to_owned(), make_entry("✓ Ready for merge", false));
         process_update("repo", "", true, &mut entries);
         assert!(entries["repo"].is_terminal);
     }
@@ -653,7 +653,7 @@ mod tests {
     fn process_update_clears_is_terminal_when_pr_reopens() {
         let mut entries = HashMap::new();
         entries.insert("repo".to_owned(), make_entry("", true));
-        process_update("repo", "✓ merge-ready", false, &mut entries);
+        process_update("repo", "✓ Ready for merge", false, &mut entries);
         assert!(!entries["repo"].is_terminal);
     }
 
@@ -665,7 +665,7 @@ mod tests {
         {
             let mut s = state.lock().unwrap();
             // terminal エントリ（stale）
-            let mut entry = make_entry("✓ merge-ready", true);
+            let mut entry = make_entry("✓ Ready for merge", true);
             entry.fetched_at = Instant::now()
                 .checked_sub(Duration::from_secs(9999))
                 .unwrap();
@@ -683,7 +683,7 @@ mod tests {
         let state = Arc::new(Mutex::new(DaemonState::new()));
         {
             let mut s = state.lock().unwrap();
-            let mut entry = make_entry("✓ merge-ready", false);
+            let mut entry = make_entry("✓ Ready for merge", false);
             entry.fetched_at = Instant::now()
                 .checked_sub(Duration::from_secs(9999))
                 .unwrap();
@@ -704,7 +704,7 @@ mod tests {
 
     #[test]
     fn non_terminal_entry_uses_base_ttl() {
-        let entry = make_entry("✓ merge-ready", false);
+        let entry = make_entry("✓ Ready for merge", false);
         assert_eq!(effective_ttl(&entry, 5), 5);
     }
 

--- a/src/contexts/evaluation/application/config_service.rs
+++ b/src/contexts/evaluation/application/config_service.rs
@@ -31,58 +31,62 @@ fn render_token(config: &DisplayConfig, token: &OutputToken) -> String {
         OutputToken::MergeReady => apply_format(
             config.merge_ready.as_ref().unwrap_or(&empty()),
             "✓",
-            "merge-ready",
+            "Ready for merge",
         ),
         OutputToken::NoPullRequest => apply_format(
             config.no_pull_request.as_ref().unwrap_or(&empty()),
             "+",
-            "create-pr",
+            "Create PR",
         ),
         OutputToken::Conflict => apply_format(
             config.conflict.as_ref().unwrap_or(&empty()),
             "✗",
-            "conflict",
+            "Resolve conflict",
         ),
         OutputToken::UpdateBranch => apply_format(
             config.update_branch.as_ref().unwrap_or(&empty()),
             "✗",
-            "update-branch",
+            "Update branch",
         ),
         OutputToken::SyncUnknown => apply_format(
             config.sync_unknown.as_ref().unwrap_or(&empty()),
             "?",
-            "sync-unknown",
+            "Check branch sync",
         ),
-        OutputToken::CiFail => {
-            apply_format(config.ci_fail.as_ref().unwrap_or(&empty()), "✗", "ci-fail")
-        }
+        OutputToken::CiFail => apply_format(
+            config.ci_fail.as_ref().unwrap_or(&empty()),
+            "✗",
+            "Fix CI failure",
+        ),
         OutputToken::CiAction => apply_format(
             config.ci_action.as_ref().unwrap_or(&empty()),
             "⚠",
-            "ci-action",
+            "Run CI action",
         ),
         OutputToken::CiPending => apply_format(
             config.ci_pending.as_ref().unwrap_or(&empty()),
             "⧖",
-            "wait-for-ci",
+            "Wait for CI",
         ),
-        OutputToken::ReviewRequested => {
-            apply_format(config.review.as_ref().unwrap_or(&empty()), "⚠", "review")
-        }
+        OutputToken::ReviewRequested => apply_format(
+            config.changes_requested.as_ref().unwrap_or(&empty()),
+            "⚠",
+            "Resolve review",
+        ),
         OutputToken::ReviewRequired => apply_format(
             config.review_required.as_ref().unwrap_or(&empty()),
             "@",
-            "assign-reviewer",
+            "Assign reviewer",
         ),
         OutputToken::Draft => apply_format(
             config.draft.as_ref().unwrap_or(&empty()),
             "✎",
-            "ready-for-review",
+            "Ready for review",
         ),
         OutputToken::StatusCalculating => apply_format(
             config.status_calculating.as_ref().unwrap_or(&empty()),
             "⧖",
-            "wait-for-status",
+            "Wait for status",
         ),
     }
 }
@@ -131,30 +135,30 @@ mod tests {
     #[test]
     fn no_pull_request_renders_with_default_config() {
         let result = render_output(&[OutputToken::NoPullRequest], None, &DefaultRepo);
-        assert_eq!(result, "+ create-pr");
+        assert_eq!(result, "+ Create PR");
     }
 
     #[test]
     fn draft_renders_with_default_config() {
         let result = render_output(&[OutputToken::Draft], None, &DefaultRepo);
-        assert_eq!(result, "✎ ready-for-review");
+        assert_eq!(result, "✎ Ready for review");
     }
 
     #[test]
     fn review_required_renders_with_default_config() {
         let result = render_output(&[OutputToken::ReviewRequired], None, &DefaultRepo);
-        assert_eq!(result, "@ assign-reviewer");
+        assert_eq!(result, "@ Assign reviewer");
     }
 
     #[test]
     fn ci_pending_renders_with_default_config() {
         let result = render_output(&[OutputToken::CiPending], None, &DefaultRepo);
-        assert_eq!(result, "⧖ wait-for-ci");
+        assert_eq!(result, "⧖ Wait for CI");
     }
 
     #[test]
     fn status_calculating_renders_with_default_config() {
         let result = render_output(&[OutputToken::StatusCalculating], None, &DefaultRepo);
-        assert_eq!(result, "⧖ wait-for-status");
+        assert_eq!(result, "⧖ Wait for status");
     }
 }

--- a/src/contexts/evaluation/domain/display_config.rs
+++ b/src/contexts/evaluation/domain/display_config.rs
@@ -12,7 +12,7 @@ pub struct DisplayConfig {
     pub ci_fail: Option<TokenConfig>,
     pub ci_action: Option<TokenConfig>,
     pub ci_pending: Option<TokenConfig>,
-    pub review: Option<TokenConfig>,
+    pub changes_requested: Option<TokenConfig>,
     pub review_required: Option<TokenConfig>,
     pub draft: Option<TokenConfig>,
     pub status_calculating: Option<TokenConfig>,
@@ -27,25 +27,29 @@ impl DisplayConfig {
             format: None,
         };
         self.merge_ready
-            .get_or_insert_with(|| tok("✓", "merge-ready"));
+            .get_or_insert_with(|| tok("✓", "Ready for merge"));
         self.no_pull_request
-            .get_or_insert_with(|| tok("+", "create-pr"));
-        self.conflict.get_or_insert_with(|| tok("✗", "conflict"));
+            .get_or_insert_with(|| tok("+", "Create PR"));
+        self.conflict
+            .get_or_insert_with(|| tok("✗", "Resolve conflict"));
         self.update_branch
-            .get_or_insert_with(|| tok("✗", "update-branch"));
+            .get_or_insert_with(|| tok("✗", "Update branch"));
         self.sync_unknown
-            .get_or_insert_with(|| tok("?", "sync-unknown"));
-        self.ci_fail.get_or_insert_with(|| tok("✗", "ci-fail"));
-        self.ci_action.get_or_insert_with(|| tok("⚠", "ci-action"));
+            .get_or_insert_with(|| tok("?", "Check branch sync"));
+        self.ci_fail
+            .get_or_insert_with(|| tok("✗", "Fix CI failure"));
+        self.ci_action
+            .get_or_insert_with(|| tok("⚠", "Run CI action"));
         self.ci_pending
-            .get_or_insert_with(|| tok("⧖", "wait-for-ci"));
-        self.review.get_or_insert_with(|| tok("⚠", "review"));
+            .get_or_insert_with(|| tok("⧖", "Wait for CI"));
+        self.changes_requested
+            .get_or_insert_with(|| tok("⚠", "Resolve review"));
         self.review_required
-            .get_or_insert_with(|| tok("@", "assign-reviewer"));
+            .get_or_insert_with(|| tok("@", "Assign reviewer"));
         self.draft
-            .get_or_insert_with(|| tok("✎", "ready-for-review"));
+            .get_or_insert_with(|| tok("✎", "Ready for review"));
         self.status_calculating
-            .get_or_insert_with(|| tok("⧖", "wait-for-status"));
+            .get_or_insert_with(|| tok("⧖", "Wait for status"));
         let error = self.error.get_or_insert_with(ErrorConfig::empty);
         error
             .auth_required
@@ -103,7 +107,7 @@ mod tests {
         config.fill_defaults();
         let tok = config.no_pull_request.as_ref().unwrap();
         assert_eq!(tok.symbol.as_deref(), Some("+"));
-        assert_eq!(tok.label.as_deref(), Some("create-pr"));
+        assert_eq!(tok.label.as_deref(), Some("Create PR"));
     }
 
     #[test]
@@ -112,7 +116,7 @@ mod tests {
         config.fill_defaults();
         let tok = config.draft.as_ref().unwrap();
         assert_eq!(tok.symbol.as_deref(), Some("✎"));
-        assert_eq!(tok.label.as_deref(), Some("ready-for-review"));
+        assert_eq!(tok.label.as_deref(), Some("Ready for review"));
     }
 
     #[test]
@@ -121,7 +125,7 @@ mod tests {
         config.fill_defaults();
         let tok = config.review_required.as_ref().unwrap();
         assert_eq!(tok.symbol.as_deref(), Some("@"));
-        assert_eq!(tok.label.as_deref(), Some("assign-reviewer"));
+        assert_eq!(tok.label.as_deref(), Some("Assign reviewer"));
     }
 
     #[test]
@@ -130,7 +134,7 @@ mod tests {
         config.fill_defaults();
         let tok = config.ci_pending.as_ref().unwrap();
         assert_eq!(tok.symbol.as_deref(), Some("⧖"));
-        assert_eq!(tok.label.as_deref(), Some("wait-for-ci"));
+        assert_eq!(tok.label.as_deref(), Some("Wait for CI"));
     }
 
     #[test]
@@ -139,6 +143,6 @@ mod tests {
         config.fill_defaults();
         let tok = config.status_calculating.as_ref().unwrap();
         assert_eq!(tok.symbol.as_deref(), Some("⧖"));
-        assert_eq!(tok.label.as_deref(), Some("wait-for-status"));
+        assert_eq!(tok.label.as_deref(), Some("Wait for status"));
     }
 }

--- a/tests/e2e/config/config.rs
+++ b/tests/e2e/config/config.rs
@@ -34,18 +34,18 @@ fn assert_prompt_with_config(env: &TestEnv, expected: &str) {
 
 /// #42 設定なし / #43 symbol / #44 label / #45 format / #46 全フィールド / #48 不正 TOML
 #[rstest]
-#[case::no_config(None, "✓ merge-ready")]
-#[case::custom_symbol(Some("[merge_ready]\nsymbol = \"★\""), "★ merge-ready")]
+#[case::no_config(None, "✓ Ready for merge")]
+#[case::custom_symbol(Some("[merge_ready]\nsymbol = \"★\""), "★ Ready for merge")]
 #[case::custom_label(Some("[merge_ready]\nlabel = \"OK!\""), "✓ OK!")]
 #[case::custom_format(
     Some("[merge_ready]\nformat = \"[$symbol] $label\""),
-    "[✓] merge-ready"
+    "[✓] Ready for merge"
 )]
 #[case::all_fields_custom(
     Some("[merge_ready]\nsymbol = \"✅\"\nlabel = \"lgtm\"\nformat = \"$label $symbol\""),
     "lgtm ✅"
 )]
-#[case::invalid_toml(Some("this is not valid toml ][[["), "✓ merge-ready")]
+#[case::invalid_toml(Some("this is not valid toml ][[["), "✓ Ready for merge")]
 fn test_config_prompt(#[case] config: Option<&str>, #[case] expected: &str) {
     let env = TestEnv::new(MERGE_READY_JSON, Some(CHECKS_PASS_JSON));
     if let Some(cfg) = config {
@@ -61,7 +61,7 @@ fn test_config_prompt(#[case] config: Option<&str>, #[case] expected: &str) {
 fn test_partial_config_other_tokens_use_defaults() {
     let env = TestEnv::new(CONFLICT_JSON, Some(CHECKS_PASS_JSON));
     env.write_config("[conflict]\nsymbol = \"✘\"");
-    assert_prompt_with_config(&env, "✘ conflict");
+    assert_prompt_with_config(&env, "✘ Resolve conflict");
 }
 
 // ── #49–50: XDG_CONFIG_HOME ───────────────────────────────────────────────────
@@ -91,7 +91,7 @@ fn test_xdg_config_home_is_used() {
 
     let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
     env.apply_with_cache(&mut cmd);
-    cmd.assert().success().stdout("★ merge-ready").stderr("");
+    cmd.assert().success().stdout("★ Ready for merge").stderr("");
 }
 
 /// #50: `XDG_CONFIG_HOME` と `HOME` 両方ある → `XDG_CONFIG_HOME` が優先される
@@ -120,7 +120,7 @@ fn test_xdg_config_home_takes_precedence_over_home() {
 
     let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
     env.apply_with_cache(&mut cmd);
-    cmd.assert().success().stdout("★ merge-ready").stderr("");
+    cmd.assert().success().stdout("★ Ready for merge").stderr("");
 }
 
 // ── #51–58: config ────────────────────────────────────────────────────────────

--- a/tests/e2e/config/config.rs
+++ b/tests/e2e/config/config.rs
@@ -91,7 +91,10 @@ fn test_xdg_config_home_is_used() {
 
     let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
     env.apply_with_cache(&mut cmd);
-    cmd.assert().success().stdout("★ Ready for merge").stderr("");
+    cmd.assert()
+        .success()
+        .stdout("★ Ready for merge")
+        .stderr("");
 }
 
 /// #50: `XDG_CONFIG_HOME` と `HOME` 両方ある → `XDG_CONFIG_HOME` が優先される
@@ -120,7 +123,10 @@ fn test_xdg_config_home_takes_precedence_over_home() {
 
     let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
     env.apply_with_cache(&mut cmd);
-    cmd.assert().success().stdout("★ Ready for merge").stderr("");
+    cmd.assert()
+        .success()
+        .stdout("★ Ready for merge")
+        .stderr("");
 }
 
 // ── #51–58: config ────────────────────────────────────────────────────────────

--- a/tests/e2e/prompt/branch_sync.rs
+++ b/tests/e2e/prompt/branch_sync.rs
@@ -1,6 +1,6 @@
 //! ブランチ同期状態の E2E テスト（シナリオ #17–22）
 //!
-//! 対象条件: `conflict` / `update-branch` / `sync-unknown`
+//! 対象条件: `conflict` / `update_branch` / `sync_unknown`
 //! 実行フローは daemon 経由（`merge-ready prompt`）に統一する。
 
 use assert_cmd::Command;
@@ -31,15 +31,15 @@ fn assert_prompt(env: &TestEnv, expected: &str) {
 
 // ── #17, #20–22: conflict 系 ──────────────────────────────────────────────────
 
-/// #17 `CONFLICTING` → `✗ conflict`
-/// #20 `CONFLICTING` + `BEHIND` → `conflict` のみ（`update-branch` は抑制）
-/// #21 `conflict` + `ci-fail` → 両方をスペース区切りで出力
-/// #22 `conflict` + `review` → 両方をスペース区切りで出力
+/// #17 `CONFLICTING` → `✗ Resolve conflict`
+/// #20 `CONFLICTING` + `BEHIND` → `Resolve conflict` のみ（`Update branch` は抑制）
+/// #21 `Resolve conflict` + `Fix CI failure` → 両方をスペース区切りで出力
+/// #22 `Resolve conflict` + `Resolve review` → 両方をスペース区切りで出力
 #[rstest]
-#[case::conflict(CONFLICTING_DIRTY, PASS_JSON, "✗ conflict")]
-#[case::conflict_wins_over_update_branch(CONFLICTING_BEHIND, PASS_JSON, "✗ conflict")]
-#[case::conflict_and_ci_fail(CONFLICTING_DIRTY, FAIL_JSON, "✗ conflict ✗ ci-fail")]
-#[case::conflict_and_review(CONFLICTING_DIRTY_CHANGES, PASS_JSON, "✗ conflict ⚠ review")]
+#[case::conflict(CONFLICTING_DIRTY, PASS_JSON, "✗ Resolve conflict")]
+#[case::conflict_wins_over_update_branch(CONFLICTING_BEHIND, PASS_JSON, "✗ Resolve conflict")]
+#[case::conflict_and_ci_fail(CONFLICTING_DIRTY, FAIL_JSON, "✗ Resolve conflict ✗ Fix CI failure")]
+#[case::conflict_and_review(CONFLICTING_DIRTY_CHANGES, PASS_JSON, "✗ Resolve conflict ⚠ Resolve review")]
 fn test_conflict_prompt(#[case] pr_json: &str, #[case] checks_json: &str, #[case] expected: &str) {
     let env = TestEnv::new(pr_json, Some(checks_json));
     assert_prompt(&env, expected);
@@ -47,18 +47,18 @@ fn test_conflict_prompt(#[case] pr_json: &str, #[case] checks_json: &str, #[case
 
 // ── #18: update-branch ────────────────────────────────────────────────────────
 
-/// #18: compare API の `behind_by > 0` → `✗ update-branch`
+/// #18: compare API の `behind_by > 0` → `✗ Update branch`
 #[test]
 fn test_update_branch() {
     let env = TestEnv::with_behind_by(MERGEABLE_BLOCKED, Some(PASS_JSON), 1);
-    assert_prompt(&env, "✗ update-branch");
+    assert_prompt(&env, "✗ Update branch");
 }
 
 // ── #19: sync-unknown ────────────────────────────────────────────────────────
 
-/// #19: compare API がエラーを返す → `? sync-unknown`
+/// #19: compare API がエラーを返す → `? Check branch sync`
 #[test]
 fn test_compare_api_error() {
     let env = TestEnv::with_compare_error(MERGEABLE_BLOCKED, Some(PASS_JSON));
-    assert_prompt(&env, "? sync-unknown");
+    assert_prompt(&env, "? Check branch sync");
 }

--- a/tests/e2e/prompt/branch_sync.rs
+++ b/tests/e2e/prompt/branch_sync.rs
@@ -39,7 +39,11 @@ fn assert_prompt(env: &TestEnv, expected: &str) {
 #[case::conflict(CONFLICTING_DIRTY, PASS_JSON, "✗ Resolve conflict")]
 #[case::conflict_wins_over_update_branch(CONFLICTING_BEHIND, PASS_JSON, "✗ Resolve conflict")]
 #[case::conflict_and_ci_fail(CONFLICTING_DIRTY, FAIL_JSON, "✗ Resolve conflict ✗ Fix CI failure")]
-#[case::conflict_and_review(CONFLICTING_DIRTY_CHANGES, PASS_JSON, "✗ Resolve conflict ⚠ Resolve review")]
+#[case::conflict_and_review(
+    CONFLICTING_DIRTY_CHANGES,
+    PASS_JSON,
+    "✗ Resolve conflict ⚠ Resolve review"
+)]
 fn test_conflict_prompt(#[case] pr_json: &str, #[case] checks_json: &str, #[case] expected: &str) {
     let env = TestEnv::new(pr_json, Some(checks_json));
     assert_prompt(&env, expected);

--- a/tests/e2e/prompt/ci_checks.rs
+++ b/tests/e2e/prompt/ci_checks.rs
@@ -1,6 +1,6 @@
 //! CI チェックの E2E テスト（シナリオ #23–29）
 //!
-//! 対象条件: `ci-fail` / `ci-action`（`gh pr checks --json bucket,state` の結果）
+//! 対象条件: `ci_fail` / `ci_action`（`gh pr checks --json bucket,state` の結果）
 //! 実行フローは daemon 経由（`merge-ready prompt`）に統一する。
 
 use assert_cmd::Command;
@@ -32,16 +32,16 @@ fn assert_prompt(env: &TestEnv, expected: &str) {
 
 // ── #23–26, #29: checks bucket ────────────────────────────────────────────────
 
-/// #23 `fail` / #24 `cancel` → `✗ ci-fail`
-/// #25 `action_required` → `⚠ ci-action`
-/// #26 `fail` + `action_required` 混在 → `✗ ci-fail`（`ci-action` は抑制）
-/// #29 `ci-fail` + `review` → 両方をスペース区切りで出力
+/// #23 `fail` / #24 `cancel` → `✗ Fix CI failure`
+/// #25 `action_required` → `⚠ Run CI action`
+/// #26 `fail` + `action_required` 混在 → `✗ Fix CI failure`（`Run CI action` は抑制）
+/// #29 `Fix CI failure` + `Resolve review` → 両方をスペース区切りで出力
 #[rstest]
-#[case::ci_fail_failure(BLOCKED_NO_REVIEW, FAIL_JSON, "✗ ci-fail")]
-#[case::ci_fail_cancelled(BLOCKED_NO_REVIEW, CANCEL_JSON, "✗ ci-fail")]
-#[case::ci_action(BLOCKED_NO_REVIEW, ACTION_REQUIRED_JSON, "⚠ ci-action")]
-#[case::ci_fail_wins_over_ci_action(BLOCKED_NO_REVIEW, FAIL_AND_ACTION_JSON, "✗ ci-fail")]
-#[case::ci_fail_and_review(BLOCKED_CHANGES_REQUESTED, FAIL_JSON, "✗ ci-fail ⚠ review")]
+#[case::ci_fail_failure(BLOCKED_NO_REVIEW, FAIL_JSON, "✗ Fix CI failure")]
+#[case::ci_fail_cancelled(BLOCKED_NO_REVIEW, CANCEL_JSON, "✗ Fix CI failure")]
+#[case::ci_action(BLOCKED_NO_REVIEW, ACTION_REQUIRED_JSON, "⚠ Run CI action")]
+#[case::ci_fail_wins_over_ci_action(BLOCKED_NO_REVIEW, FAIL_AND_ACTION_JSON, "✗ Fix CI failure")]
+#[case::ci_fail_and_review(BLOCKED_CHANGES_REQUESTED, FAIL_JSON, "✗ Fix CI failure ⚠ Resolve review")]
 fn test_ci_check_prompt(#[case] pr_json: &str, #[case] checks_json: &str, #[case] expected: &str) {
     let env = TestEnv::new(pr_json, Some(checks_json));
     assert_prompt(&env, expected);
@@ -49,11 +49,11 @@ fn test_ci_check_prompt(#[case] pr_json: &str, #[case] checks_json: &str, #[case
 
 // ── #27–28: CI 未設定 ─────────────────────────────────────────────────────────
 
-/// #27 `no checks reported` + review なし → `✓ merge-ready`
-/// #28 `no checks reported` + review あり → `⚠ review`
+/// #27 `no checks reported` + review なし → `✓ Ready for merge`
+/// #28 `no checks reported` + review あり → `⚠ Resolve review`
 #[rstest]
-#[case::merge_ready(APPROVED_CLEAN, "✓ merge-ready")]
-#[case::review(BLOCKED_CHANGES_REQUESTED, "⚠ review")]
+#[case::merge_ready(APPROVED_CLEAN, "✓ Ready for merge")]
+#[case::review(BLOCKED_CHANGES_REQUESTED, "⚠ Resolve review")]
 fn test_no_ci_checks_prompt(#[case] pr_json: &str, #[case] expected: &str) {
     let env = TestEnv::with_no_ci_checks(pr_json);
     assert_prompt(&env, expected);

--- a/tests/e2e/prompt/ci_checks.rs
+++ b/tests/e2e/prompt/ci_checks.rs
@@ -41,7 +41,11 @@ fn assert_prompt(env: &TestEnv, expected: &str) {
 #[case::ci_fail_cancelled(BLOCKED_NO_REVIEW, CANCEL_JSON, "✗ Fix CI failure")]
 #[case::ci_action(BLOCKED_NO_REVIEW, ACTION_REQUIRED_JSON, "⚠ Run CI action")]
 #[case::ci_fail_wins_over_ci_action(BLOCKED_NO_REVIEW, FAIL_AND_ACTION_JSON, "✗ Fix CI failure")]
-#[case::ci_fail_and_review(BLOCKED_CHANGES_REQUESTED, FAIL_JSON, "✗ Fix CI failure ⚠ Resolve review")]
+#[case::ci_fail_and_review(
+    BLOCKED_CHANGES_REQUESTED,
+    FAIL_JSON,
+    "✗ Fix CI failure ⚠ Resolve review"
+)]
 fn test_ci_check_prompt(#[case] pr_json: &str, #[case] checks_json: &str, #[case] expected: &str) {
     let env = TestEnv::new(pr_json, Some(checks_json));
     assert_prompt(&env, expected);

--- a/tests/e2e/prompt/merge_ready.rs
+++ b/tests/e2e/prompt/merge_ready.rs
@@ -1,7 +1,7 @@
 //! `merge-ready` 判定の E2E テスト（シナリオ #15–16）
 //!
-//! `✓ merge-ready` が表示される条件と、全ブロッカーが同時成立したときに
-//! `merge-ready` が表示されないことを検証する。
+//! `✓ Ready for merge` が表示される条件と、全ブロッカーが同時成立したときに
+//! `Ready for merge` が表示されないことを検証する。
 //! 実行フローは daemon 経由（`merge-ready prompt`）に統一する。
 
 const PROMPT_BIN: &str = "merge-ready-prompt";
@@ -26,24 +26,24 @@ fn assert_prompt(env: &TestEnv, expected: &str) {
 
 // ── #15: マージ可能 ──────────────────────────────────────────────────────────
 
-/// #15: mergeable=MERGEABLE + CI pass + reviewDecision=APPROVED → `✓ merge-ready`
+/// #15: mergeable=MERGEABLE + CI pass + reviewDecision=APPROVED → `✓ Ready for merge`
 #[test]
 fn test_merge_ready() {
     let env = TestEnv::new(
         r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED"}"#,
         Some(r#"[{"bucket":"pass","state":"SUCCESS"}]"#),
     );
-    assert_prompt(&env, "✓ merge-ready");
+    assert_prompt(&env, "✓ Ready for merge");
 }
 
 // ── #16: 全ブロッカーが成立 ──────────────────────────────────────────────────
 
-/// #16: conflict + ci-fail + review が全部成立 → `✓ merge-ready` は表示されない
+/// #16: conflict + ci_fail + changes_requested が全部成立 → `✓ Ready for merge` は表示されない
 #[test]
 fn test_all_conditions_block_merge_ready() {
     let env = TestEnv::new(
         r#"{"state":"OPEN","isDraft":false,"mergeable":"CONFLICTING","mergeStateStatus":"DIRTY","reviewDecision":"CHANGES_REQUESTED"}"#,
         Some(r#"[{"bucket":"fail","state":"FAILURE"}]"#),
     );
-    assert_prompt(&env, "✗ conflict ✗ ci-fail ⚠ review");
+    assert_prompt(&env, "✗ Resolve conflict ✗ Fix CI failure ⚠ Resolve review");
 }

--- a/tests/e2e/prompt/pr_state.rs
+++ b/tests/e2e/prompt/pr_state.rs
@@ -1,6 +1,6 @@
 //! PR ライフサイクル状態の E2E テスト（シナリオ #31–33）
 //!
-//! `OPEN` 以外の PR 状態は何も出力しない。PR が存在しない場合は `+ create-pr` を出力する。
+//! `OPEN` 以外の PR 状態は何も出力しない。PR が存在しない場合は `+ Create PR` を出力する。
 //! 実行フローは daemon 経由（`merge-ready prompt`）に統一する。
 
 const PROMPT_BIN: &str = "merge-ready-prompt";
@@ -40,7 +40,7 @@ fn assert_prompt_empty(env: &TestEnv) {
 
 // ── #31: PR なし ──────────────────────────────────────────────────────────────
 
-/// #31: ブランチに PR が存在しない → `+ create-pr`（`exit 0`）
+/// #31: ブランチに PR が存在しない → `+ Create PR`（`exit 0`）
 #[test]
 fn test_no_pr() {
     let env = TestEnv::with_error(
@@ -54,7 +54,7 @@ fn test_no_pr() {
     env.apply_with_cache(&mut cmd);
     cmd.assert()
         .success()
-        .stdout(predicate::str::diff("+ create-pr"))
+        .stdout(predicate::str::diff("+ Create PR"))
         .stderr("");
 }
 
@@ -62,11 +62,11 @@ fn test_no_pr() {
 
 // ── #34: Draft PR ────────────────────────────────────────────────────────────
 
-/// #34: Draft PR → `✎ ready-for-review`
+/// #34: Draft PR → `✎ Ready for review`
 #[test]
 fn test_draft_pr_shows_ready_for_review() {
     let env = TestEnv::new(DRAFT_PR, Some(r#"[]"#));
-    assert_prompt(&env, "✎ ready-for-review");
+    assert_prompt(&env, "✎ Ready for review");
 }
 
 // ── #32–33: CLOSED / MERGED ───────────────────────────────────────────────────
@@ -82,16 +82,16 @@ fn test_non_open_pr_shows_nothing(#[case] pr_json: &str) {
 
 // ── #179: MERGE_STATE_UNKNOWN / UNKNOWN ──────────────────────────────────────
 
-/// #179: `mergeStateStatus == "MERGE_STATE_UNKNOWN"` → `⧖ wait-for-status`
+/// #179: `mergeStateStatus == "MERGE_STATE_UNKNOWN"` → `⧖ Wait for status`
 #[test]
 fn test_merge_state_unknown_shows_wait_for_status() {
     let env = TestEnv::new(MERGE_STATE_UNKNOWN_PR, Some(r#"[]"#));
-    assert_prompt(&env, "⧖ wait-for-status");
+    assert_prompt(&env, "⧖ Wait for status");
 }
 
-/// #179: `mergeStateStatus == "UNKNOWN"` → `⧖ wait-for-status`
+/// #179: `mergeStateStatus == "UNKNOWN"` → `⧖ Wait for status`
 #[test]
 fn test_unknown_merge_state_status_shows_wait_for_status() {
     let env = TestEnv::new(UNKNOWN_STATUS_PR, Some(r#"[]"#));
-    assert_prompt(&env, "⧖ wait-for-status");
+    assert_prompt(&env, "⧖ Wait for status");
 }

--- a/tests/e2e/prompt/review.rs
+++ b/tests/e2e/prompt/review.rs
@@ -1,8 +1,8 @@
 //! レビュー状態の E2E テスト（シナリオ #30, #31）
 //!
 //! 対象条件:
-//!   #30: `reviewDecision == CHANGES_REQUESTED` → `⚠ review`
-//!   #31: `reviewDecision == REVIEW_REQUIRED`   → `@ assign-reviewer`
+//!   #30: `reviewDecision == CHANGES_REQUESTED` → `⚠ Resolve review`
+//!   #31: `reviewDecision == REVIEW_REQUIRED`   → `@ Assign reviewer`
 //! 実行フローは daemon 経由（`merge-ready prompt`）に統一する。
 
 const PROMPT_BIN: &str = "merge-ready-prompt";
@@ -11,7 +11,7 @@ use assert_cmd::Command;
 
 use super::super::helpers::{DaemonHandle, TestEnv};
 
-/// #30: `reviewDecision == CHANGES_REQUESTED` → `⚠ review`
+/// #30: `reviewDecision == CHANGES_REQUESTED` → `⚠ Resolve review`
 #[test]
 fn test_review_changes_requested() {
     let env = TestEnv::new(
@@ -23,10 +23,10 @@ fn test_review_changes_requested() {
 
     let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
     env.apply_with_cache(&mut cmd);
-    cmd.assert().success().stdout("⚠ review").stderr("");
+    cmd.assert().success().stdout("⚠ Resolve review").stderr("");
 }
 
-/// #31: `reviewDecision == REVIEW_REQUIRED` → `@ assign-reviewer`
+/// #31: `reviewDecision == REVIEW_REQUIRED` → `@ Assign reviewer`
 #[test]
 fn test_review_required() {
     let env = TestEnv::new(
@@ -40,6 +40,6 @@ fn test_review_required() {
     env.apply_with_cache(&mut cmd);
     cmd.assert()
         .success()
-        .stdout("@ assign-reviewer")
+        .stdout("@ Assign reviewer")
         .stderr("");
 }

--- a/tests/e2e/scenarios/cache_hit.rs
+++ b/tests/e2e/scenarios/cache_hit.rs
@@ -36,5 +36,5 @@ fn test_daemon_fresh_returns_cached_output() {
     cmd.current_dir(env.repo_dir.path());
     cmd.assert()
         .success()
-        .stdout(predicate::str::diff("✓ merge-ready"));
+        .stdout(predicate::str::diff("✓ Ready for merge"));
 }

--- a/tests/e2e/scenarios/initial_load.rs
+++ b/tests/e2e/scenarios/initial_load.rs
@@ -32,7 +32,7 @@ fn test_initial_load_then_shows_result() {
     env.apply_with_cache(&mut cmd);
     cmd.assert()
         .success()
-        .stdout(predicate::str::diff("✓ merge-ready"));
+        .stdout(predicate::str::diff("✓ Ready for merge"));
 
     // 自動起動された daemon を後始末
     let bin = assert_cmd::cargo::cargo_bin(BIN);

--- a/tests/e2e/scenarios/multi_repo.rs
+++ b/tests/e2e/scenarios/multi_repo.rs
@@ -22,7 +22,10 @@ fn test_daemon_multi_repo_isolation() {
     let out_a = env.prompt_output(&env.repo_a);
     let out_b = env.prompt_output(&env.repo_b);
 
-    assert_eq!(out_a, "✓ Ready for merge", "repo_a should be ready for merge");
+    assert_eq!(
+        out_a, "✓ Ready for merge",
+        "repo_a should be ready for merge"
+    );
     assert!(
         out_b.contains("Resolve conflict"),
         "repo_b should show Resolve conflict, got: {out_b}"

--- a/tests/e2e/scenarios/multi_repo.rs
+++ b/tests/e2e/scenarios/multi_repo.rs
@@ -1,6 +1,6 @@
 //! キャッシュライフサイクル シナリオ #6: 複数リポジトリの分離
 //!
-//! repo_a（merge-ready）と repo_b（conflict）が同一 daemon を共有し、
+//! repo_a（Ready for merge）と repo_b（Resolve conflict）が同一 daemon を共有し、
 //! キャッシュを汚染しない
 
 use super::super::helpers::MultiRepoEnv;
@@ -22,10 +22,10 @@ fn test_daemon_multi_repo_isolation() {
     let out_a = env.prompt_output(&env.repo_a);
     let out_b = env.prompt_output(&env.repo_b);
 
-    assert_eq!(out_a, "✓ merge-ready", "repo_a should be merge-ready");
+    assert_eq!(out_a, "✓ Ready for merge", "repo_a should be ready for merge");
     assert!(
-        out_b.contains("conflict"),
-        "repo_b should show conflict, got: {out_b}"
+        out_b.contains("Resolve conflict"),
+        "repo_b should show Resolve conflict, got: {out_b}"
     );
     assert_ne!(out_a, out_b, "repos must not share cached output");
 }

--- a/tests/e2e/scenarios/no_pr.rs
+++ b/tests/e2e/scenarios/no_pr.rs
@@ -1,7 +1,7 @@
 //! キャッシュライフサイクル シナリオ #4, #5: PR なし
 //!
-//! #4: PR なしブランチ → loading → キャッシュ確定後に `+ create-pr`（`? loading` が永続しない）
-//! #5: PR なし + TTL=0 + リフレッシュ遅延 → stale 中も `? loading` に戻らず `+ create-pr` 維持
+//! #4: PR なしブランチ → loading → キャッシュ確定後に `+ Create PR`（`? loading` が永続しない）
+//! #5: PR なし + TTL=0 + リフレッシュ遅延 → stale 中も `? loading` に戻らず `+ Create PR` 維持
 
 const PROMPT_BIN: &str = "merge-ready-prompt";
 
@@ -10,7 +10,7 @@ use predicates::prelude::*;
 
 use super::super::helpers::{DaemonHandle, TestEnv};
 
-/// #4: PR なしブランチで daemon 経由: リフレッシュ完了後に `+ create-pr` が表示される
+/// #4: PR なしブランチで daemon 経由: リフレッシュ完了後に `+ Create PR` が表示される
 #[test]
 fn test_daemon_no_pr_shows_nothing_after_refresh() {
     let env = TestEnv::with_no_pr();
@@ -26,12 +26,12 @@ fn test_daemon_no_pr_shows_nothing_after_refresh() {
     // daemon リフレッシュ完了を待つ
     DaemonHandle::wait_for_cache(&env, 5000);
 
-    // キャッシュ確定後は + create-pr を出力する（? loading が永続しないことを確認）
+    // キャッシュ確定後は + Create PR を出力する（? loading が永続しないことを確認）
     let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
     env.apply_with_cache(&mut cmd);
     cmd.assert()
         .success()
-        .stdout(predicate::str::diff("+ create-pr"));
+        .stdout(predicate::str::diff("+ Create PR"));
 }
 
 /// #5: no-PR の stale リフレッシュ中でも `? loading` に戻らず空出力を維持する
@@ -50,20 +50,20 @@ fn test_daemon_no_pr_stale_while_refreshing_keeps_empty_output() {
     // 初回リフレッシュ完了で + create-pr キャッシュ確定
     DaemonHandle::wait_for_cache(&env, 5000);
 
-    // stale 1回目: リフレッシュ開始しつつ + create-pr 出力
+    // stale 1回目: リフレッシュ開始しつつ + Create PR 出力
     let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
     env.apply_with_cache(&mut cmd);
     cmd.assert()
         .success()
-        .stdout(predicate::str::diff("+ create-pr"));
+        .stdout(predicate::str::diff("+ Create PR"));
 
-    // stale 2回目以降（refresh 実行中を狙う）: loading に戻らず + create-pr を維持
+    // stale 2回目以降（refresh 実行中を狙う）: loading に戻らず + Create PR を維持
     for _ in 0..5 {
         let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
         env.apply_with_cache(&mut cmd);
         cmd.assert()
             .success()
-            .stdout(predicate::str::diff("+ create-pr"));
+            .stdout(predicate::str::diff("+ Create PR"));
         std::thread::sleep(std::time::Duration::from_millis(50));
     }
 }


### PR DESCRIPTION
Closes #184

## Summary

- 全ラベルのデフォルト値をケバブケースから自然な文章表現（センテンスケース）に変更（例: `merge-ready` → `Ready for merge`）
- 各ラベルを状態表現からアクション表現に統一（例: `conflict` → `Resolve conflict`、`ci-fail` → `Fix CI failure`）
- `DisplayConfig` の `review` フィールドを `changes_requested` に改名（ドメインの `ReviewState::ChangesRequested` に対応）

## Breaking Changes

**1. 設定ファイルのキー名変更**

`[review]` セクションを使用している場合は `[changes_requested]` に変更が必要です。

```toml
# Before
[review]
symbol = "⚠"

# After
[changes_requested]
symbol = "⚠"
```

**2. デフォルトラベル文字列の変更**

出力文字列をスクリプト等で比較している場合は更新が必要です。

| キー | 旧ラベル | 新ラベル |
|------|---------|---------|
| `merge_ready` | `merge-ready` | `Ready for merge` |
| `no_pull_request` | `create-pr` | `Create PR` |
| `conflict` | `conflict` | `Resolve conflict` |
| `update_branch` | `update-branch` | `Update branch` |
| `sync_unknown` | `sync-unknown` | `Check branch sync` |
| `ci_fail` | `ci-fail` | `Fix CI failure` |
| `ci_action` | `ci-action` | `Run CI action` |
| `ci_pending` | `wait-for-ci` | `Wait for CI` |
| `changes_requested` | `review` | `Resolve review` |
| `review_required` | `assign-reviewer` | `Assign reviewer` |
| `draft` | `ready-for-review` | `Ready for review` |
| `status_calculating` | `wait-for-status` | `Wait for status` |

## Test plan

- [x] `cargo clippy` パス
- [x] ユニットテスト（43件）パス
- [ ] E2E テスト（CI で確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)