### PR TITLE
refactor: DisplayConfig から Option を除去し、TOML 解析をインフラ層に分離する

### DIFF
--- a/src/contexts/evaluation/application/config_service.rs
+++ b/src/contexts/evaluation/application/config_service.rs
@@ -1,6 +1,4 @@
-use super::super::domain::display_config::{
-    DisplayConfig, DisplayConfigRepository, TokenConfig, render_token as apply_format,
-};
+use super::super::domain::display_config::{DisplayConfig, DisplayConfigRepository, render_token};
 use super::{OutputToken, errors::ErrorToken};
 
 pub fn render_output(
@@ -14,110 +12,38 @@ pub fn render_output(
     } else {
         tokens
             .iter()
-            .map(|t| render_token(&config, t))
+            .map(|t| render_token_output(&config, t))
             .collect::<Vec<_>>()
             .join(" ")
     }
 }
 
 pub fn default_display_config() -> DisplayConfig {
-    let mut config = DisplayConfig::default();
-    config.fill_defaults();
-    config
+    DisplayConfig::default()
 }
 
-fn render_token(config: &DisplayConfig, token: &OutputToken) -> String {
+fn render_token_output(config: &DisplayConfig, token: &OutputToken) -> String {
     match token {
-        OutputToken::MergeReady => apply_format(
-            config.merge_ready.as_ref().unwrap_or(&empty()),
-            "✓",
-            "Ready for merge",
-        ),
-        OutputToken::NoPullRequest => apply_format(
-            config.no_pull_request.as_ref().unwrap_or(&empty()),
-            "+",
-            "Create PR",
-        ),
-        OutputToken::Conflict => apply_format(
-            config.conflict.as_ref().unwrap_or(&empty()),
-            "✗",
-            "Resolve conflict",
-        ),
-        OutputToken::UpdateBranch => apply_format(
-            config.update_branch.as_ref().unwrap_or(&empty()),
-            "✗",
-            "Update branch",
-        ),
-        OutputToken::SyncUnknown => apply_format(
-            config.sync_unknown.as_ref().unwrap_or(&empty()),
-            "?",
-            "Check branch sync",
-        ),
-        OutputToken::CiFail => apply_format(
-            config.ci_fail.as_ref().unwrap_or(&empty()),
-            "✗",
-            "Fix CI failure",
-        ),
-        OutputToken::CiAction => apply_format(
-            config.ci_action.as_ref().unwrap_or(&empty()),
-            "⚠",
-            "Run CI action",
-        ),
-        OutputToken::CiPending => apply_format(
-            config.ci_pending.as_ref().unwrap_or(&empty()),
-            "⧖",
-            "Wait for CI",
-        ),
-        OutputToken::ReviewRequested => apply_format(
-            config.changes_requested.as_ref().unwrap_or(&empty()),
-            "⚠",
-            "Resolve review",
-        ),
-        OutputToken::ReviewRequired => apply_format(
-            config.review_required.as_ref().unwrap_or(&empty()),
-            "@",
-            "Assign reviewer",
-        ),
-        OutputToken::Draft => apply_format(
-            config.draft.as_ref().unwrap_or(&empty()),
-            "✎",
-            "Ready for review",
-        ),
-        OutputToken::StatusCalculating => apply_format(
-            config.status_calculating.as_ref().unwrap_or(&empty()),
-            "⧖",
-            "Wait for status",
-        ),
+        OutputToken::MergeReady => render_token(&config.merge_ready),
+        OutputToken::NoPullRequest => render_token(&config.no_pull_request),
+        OutputToken::Conflict => render_token(&config.conflict),
+        OutputToken::UpdateBranch => render_token(&config.update_branch),
+        OutputToken::SyncUnknown => render_token(&config.sync_unknown),
+        OutputToken::CiFail => render_token(&config.ci_fail),
+        OutputToken::CiAction => render_token(&config.ci_action),
+        OutputToken::CiPending => render_token(&config.ci_pending),
+        OutputToken::ReviewRequested => render_token(&config.changes_requested),
+        OutputToken::ReviewRequired => render_token(&config.review_required),
+        OutputToken::Draft => render_token(&config.draft),
+        OutputToken::StatusCalculating => render_token(&config.status_calculating),
     }
 }
 
 fn render_error(config: &DisplayConfig, token: ErrorToken) -> String {
-    let ec = config.error.as_ref();
     match token {
-        ErrorToken::AuthRequired => apply_format(
-            ec.and_then(|e| e.auth_required.as_ref())
-                .unwrap_or(&empty()),
-            "!",
-            "gh auth login",
-        ),
-        ErrorToken::RateLimited => apply_format(
-            ec.and_then(|e| e.rate_limited.as_ref()).unwrap_or(&empty()),
-            "✗",
-            "rate-limited",
-        ),
-        ErrorToken::ApiError => apply_format(
-            ec.and_then(|e| e.api_error.as_ref()).unwrap_or(&empty()),
-            "✗",
-            "api-error",
-        ),
-    }
-}
-
-fn empty() -> TokenConfig {
-    TokenConfig {
-        symbol: None,
-        label: None,
-        format: None,
+        ErrorToken::AuthRequired => render_token(&config.error.auth_required),
+        ErrorToken::RateLimited => render_token(&config.error.rate_limited),
+        ErrorToken::ApiError => render_token(&config.error.api_error),
     }
 }
 
@@ -128,7 +54,7 @@ mod tests {
     struct DefaultRepo;
     impl DisplayConfigRepository for DefaultRepo {
         fn load(&self) -> DisplayConfig {
-            default_display_config()
+            DisplayConfig::default()
         }
     }
 

--- a/src/contexts/evaluation/domain/display_config.rs
+++ b/src/contexts/evaluation/domain/display_config.rs
@@ -1,63 +1,46 @@
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 const DEFAULT_FORMAT: &str = "$symbol $label";
 
-#[derive(Deserialize, Serialize, Default)]
+#[derive(Serialize)]
 pub struct DisplayConfig {
-    pub merge_ready: Option<TokenConfig>,
-    pub no_pull_request: Option<TokenConfig>,
-    pub conflict: Option<TokenConfig>,
-    pub update_branch: Option<TokenConfig>,
-    pub sync_unknown: Option<TokenConfig>,
-    pub ci_fail: Option<TokenConfig>,
-    pub ci_action: Option<TokenConfig>,
-    pub ci_pending: Option<TokenConfig>,
-    pub changes_requested: Option<TokenConfig>,
-    pub review_required: Option<TokenConfig>,
-    pub draft: Option<TokenConfig>,
-    pub status_calculating: Option<TokenConfig>,
-    pub error: Option<ErrorConfig>,
+    pub merge_ready: TokenConfig,
+    pub no_pull_request: TokenConfig,
+    pub conflict: TokenConfig,
+    pub update_branch: TokenConfig,
+    pub sync_unknown: TokenConfig,
+    pub ci_fail: TokenConfig,
+    pub ci_action: TokenConfig,
+    pub ci_pending: TokenConfig,
+    pub changes_requested: TokenConfig,
+    pub review_required: TokenConfig,
+    pub draft: TokenConfig,
+    pub status_calculating: TokenConfig,
+    pub error: ErrorConfig,
 }
 
-impl DisplayConfig {
-    pub fn fill_defaults(&mut self) {
+impl Default for DisplayConfig {
+    fn default() -> Self {
         let tok = |symbol: &str, label: &str| TokenConfig {
-            symbol: Some(symbol.to_owned()),
-            label: Some(label.to_owned()),
-            format: None,
+            symbol: symbol.to_owned(),
+            label: label.to_owned(),
+            format: DEFAULT_FORMAT.to_owned(),
         };
-        self.merge_ready
-            .get_or_insert_with(|| tok("✓", "Ready for merge"));
-        self.no_pull_request
-            .get_or_insert_with(|| tok("+", "Create PR"));
-        self.conflict
-            .get_or_insert_with(|| tok("✗", "Resolve conflict"));
-        self.update_branch
-            .get_or_insert_with(|| tok("✗", "Update branch"));
-        self.sync_unknown
-            .get_or_insert_with(|| tok("?", "Check branch sync"));
-        self.ci_fail
-            .get_or_insert_with(|| tok("✗", "Fix CI failure"));
-        self.ci_action
-            .get_or_insert_with(|| tok("⚠", "Run CI action"));
-        self.ci_pending
-            .get_or_insert_with(|| tok("⧖", "Wait for CI"));
-        self.changes_requested
-            .get_or_insert_with(|| tok("⚠", "Resolve review"));
-        self.review_required
-            .get_or_insert_with(|| tok("@", "Assign reviewer"));
-        self.draft
-            .get_or_insert_with(|| tok("✎", "Ready for review"));
-        self.status_calculating
-            .get_or_insert_with(|| tok("⧖", "Wait for status"));
-        let error = self.error.get_or_insert_with(ErrorConfig::empty);
-        error
-            .auth_required
-            .get_or_insert_with(|| tok("!", "gh auth login"));
-        error
-            .rate_limited
-            .get_or_insert_with(|| tok("✗", "rate-limited"));
-        error.api_error.get_or_insert_with(|| tok("✗", "api-error"));
+        Self {
+            merge_ready: tok("✓", "Ready for merge"),
+            no_pull_request: tok("+", "Create PR"),
+            conflict: tok("✗", "Resolve conflict"),
+            update_branch: tok("✗", "Update branch"),
+            sync_unknown: tok("?", "Check branch sync"),
+            ci_fail: tok("✗", "Fix CI failure"),
+            ci_action: tok("⚠", "Run CI action"),
+            ci_pending: tok("⧖", "Wait for CI"),
+            changes_requested: tok("⚠", "Resolve review"),
+            review_required: tok("@", "Assign reviewer"),
+            draft: tok("✎", "Ready for review"),
+            status_calculating: tok("⧖", "Wait for status"),
+            error: ErrorConfig::default(),
+        }
     }
 }
 
@@ -65,34 +48,39 @@ pub trait DisplayConfigRepository {
     fn load(&self) -> DisplayConfig;
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Serialize)]
 pub struct TokenConfig {
-    pub symbol: Option<String>,
-    pub label: Option<String>,
-    pub format: Option<String>,
+    pub symbol: String,
+    pub label: String,
+    pub format: String,
 }
 
 #[must_use]
-pub fn render_token(token: &TokenConfig, default_symbol: &str, default_label: &str) -> String {
-    let symbol = token.symbol.as_deref().unwrap_or(default_symbol);
-    let label = token.label.as_deref().unwrap_or(default_label);
-    let fmt = token.format.as_deref().unwrap_or(DEFAULT_FORMAT);
-    fmt.replace("$symbol", symbol).replace("$label", label)
+pub fn render_token(token: &TokenConfig) -> String {
+    token
+        .format
+        .replace("$symbol", &token.symbol)
+        .replace("$label", &token.label)
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Serialize)]
 pub struct ErrorConfig {
-    pub auth_required: Option<TokenConfig>,
-    pub rate_limited: Option<TokenConfig>,
-    pub api_error: Option<TokenConfig>,
+    pub auth_required: TokenConfig,
+    pub rate_limited: TokenConfig,
+    pub api_error: TokenConfig,
 }
 
-impl ErrorConfig {
-    fn empty() -> Self {
+impl Default for ErrorConfig {
+    fn default() -> Self {
+        let tok = |symbol: &str, label: &str| TokenConfig {
+            symbol: symbol.to_owned(),
+            label: label.to_owned(),
+            format: DEFAULT_FORMAT.to_owned(),
+        };
         Self {
-            auth_required: None,
-            rate_limited: None,
-            api_error: None,
+            auth_required: tok("!", "gh auth login"),
+            rate_limited: tok("✗", "rate-limited"),
+            api_error: tok("✗", "api-error"),
         }
     }
 }
@@ -102,47 +90,37 @@ mod tests {
     use super::*;
 
     #[test]
-    fn fill_defaults_sets_no_pull_request() {
-        let mut config = DisplayConfig::default();
-        config.fill_defaults();
-        let tok = config.no_pull_request.as_ref().unwrap();
-        assert_eq!(tok.symbol.as_deref(), Some("+"));
-        assert_eq!(tok.label.as_deref(), Some("Create PR"));
+    fn default_sets_no_pull_request() {
+        let config = DisplayConfig::default();
+        assert_eq!(config.no_pull_request.symbol, "+");
+        assert_eq!(config.no_pull_request.label, "Create PR");
     }
 
     #[test]
-    fn fill_defaults_sets_draft() {
-        let mut config = DisplayConfig::default();
-        config.fill_defaults();
-        let tok = config.draft.as_ref().unwrap();
-        assert_eq!(tok.symbol.as_deref(), Some("✎"));
-        assert_eq!(tok.label.as_deref(), Some("Ready for review"));
+    fn default_sets_draft() {
+        let config = DisplayConfig::default();
+        assert_eq!(config.draft.symbol, "✎");
+        assert_eq!(config.draft.label, "Ready for review");
     }
 
     #[test]
-    fn fill_defaults_sets_review_required() {
-        let mut config = DisplayConfig::default();
-        config.fill_defaults();
-        let tok = config.review_required.as_ref().unwrap();
-        assert_eq!(tok.symbol.as_deref(), Some("@"));
-        assert_eq!(tok.label.as_deref(), Some("Assign reviewer"));
+    fn default_sets_review_required() {
+        let config = DisplayConfig::default();
+        assert_eq!(config.review_required.symbol, "@");
+        assert_eq!(config.review_required.label, "Assign reviewer");
     }
 
     #[test]
-    fn fill_defaults_sets_ci_pending() {
-        let mut config = DisplayConfig::default();
-        config.fill_defaults();
-        let tok = config.ci_pending.as_ref().unwrap();
-        assert_eq!(tok.symbol.as_deref(), Some("⧖"));
-        assert_eq!(tok.label.as_deref(), Some("Wait for CI"));
+    fn default_sets_ci_pending() {
+        let config = DisplayConfig::default();
+        assert_eq!(config.ci_pending.symbol, "⧖");
+        assert_eq!(config.ci_pending.label, "Wait for CI");
     }
 
     #[test]
-    fn fill_defaults_sets_status_calculating() {
-        let mut config = DisplayConfig::default();
-        config.fill_defaults();
-        let tok = config.status_calculating.as_ref().unwrap();
-        assert_eq!(tok.symbol.as_deref(), Some("⧖"));
-        assert_eq!(tok.label.as_deref(), Some("Wait for status"));
+    fn default_sets_status_calculating() {
+        let config = DisplayConfig::default();
+        assert_eq!(config.status_calculating.symbol, "⧖");
+        assert_eq!(config.status_calculating.label, "Wait for status");
     }
 }

--- a/src/contexts/evaluation/infrastructure/toml_loader.rs
+++ b/src/contexts/evaluation/infrastructure/toml_loader.rs
@@ -1,6 +1,9 @@
+use serde::Deserialize;
 use std::path::PathBuf;
 
-use crate::contexts::evaluation::domain::display_config::{DisplayConfig, DisplayConfigRepository};
+use crate::contexts::evaluation::domain::display_config::{
+    DisplayConfig, DisplayConfigRepository, ErrorConfig, TokenConfig,
+};
 
 pub struct TomlConfigRepository;
 
@@ -13,7 +16,49 @@ impl DisplayConfigRepository for TomlConfigRepository {
         let Ok(content) = std::fs::read_to_string(path) else {
             return DisplayConfig::default();
         };
-        toml::from_str(&content).unwrap_or_default()
+        let raw: RawDisplayConfig = toml::from_str(&content).unwrap_or_default();
+        merge_with_defaults(raw)
+    }
+}
+
+fn merge_with_defaults(raw: RawDisplayConfig) -> DisplayConfig {
+    let defaults = DisplayConfig::default();
+    DisplayConfig {
+        merge_ready: merge_token(raw.merge_ready, defaults.merge_ready),
+        no_pull_request: merge_token(raw.no_pull_request, defaults.no_pull_request),
+        conflict: merge_token(raw.conflict, defaults.conflict),
+        update_branch: merge_token(raw.update_branch, defaults.update_branch),
+        sync_unknown: merge_token(raw.sync_unknown, defaults.sync_unknown),
+        ci_fail: merge_token(raw.ci_fail, defaults.ci_fail),
+        ci_action: merge_token(raw.ci_action, defaults.ci_action),
+        ci_pending: merge_token(raw.ci_pending, defaults.ci_pending),
+        changes_requested: merge_token(raw.changes_requested, defaults.changes_requested),
+        review_required: merge_token(raw.review_required, defaults.review_required),
+        draft: merge_token(raw.draft, defaults.draft),
+        status_calculating: merge_token(raw.status_calculating, defaults.status_calculating),
+        error: merge_error(raw.error, defaults.error),
+    }
+}
+
+fn merge_token(raw: Option<RawTokenConfig>, default: TokenConfig) -> TokenConfig {
+    let Some(raw) = raw else {
+        return default;
+    };
+    TokenConfig {
+        symbol: raw.symbol.unwrap_or(default.symbol),
+        label: raw.label.unwrap_or(default.label),
+        format: raw.format.unwrap_or(default.format),
+    }
+}
+
+fn merge_error(raw: Option<RawErrorConfig>, default: ErrorConfig) -> ErrorConfig {
+    let Some(raw) = raw else {
+        return default;
+    };
+    ErrorConfig {
+        auth_required: merge_token(raw.auth_required, default.auth_required),
+        rate_limited: merge_token(raw.rate_limited, default.rate_limited),
+        api_error: merge_token(raw.api_error, default.api_error),
     }
 }
 
@@ -24,4 +69,35 @@ pub(crate) fn config_path() -> Option<PathBuf> {
     }
     let home = std::env::var_os("HOME")?;
     Some(PathBuf::from(home).join(".config").join("merge-ready.toml"))
+}
+
+#[derive(Deserialize, Default)]
+struct RawDisplayConfig {
+    merge_ready: Option<RawTokenConfig>,
+    no_pull_request: Option<RawTokenConfig>,
+    conflict: Option<RawTokenConfig>,
+    update_branch: Option<RawTokenConfig>,
+    sync_unknown: Option<RawTokenConfig>,
+    ci_fail: Option<RawTokenConfig>,
+    ci_action: Option<RawTokenConfig>,
+    ci_pending: Option<RawTokenConfig>,
+    changes_requested: Option<RawTokenConfig>,
+    review_required: Option<RawTokenConfig>,
+    draft: Option<RawTokenConfig>,
+    status_calculating: Option<RawTokenConfig>,
+    error: Option<RawErrorConfig>,
+}
+
+#[derive(Deserialize)]
+struct RawTokenConfig {
+    symbol: Option<String>,
+    label: Option<String>,
+    format: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct RawErrorConfig {
+    auth_required: Option<RawTokenConfig>,
+    rate_limited: Option<RawTokenConfig>,
+    api_error: Option<RawTokenConfig>,
 }


### PR DESCRIPTION
Closes #186

## Summary

- **ドメイン層** (`display_config.rs`): `TokenConfig` / `DisplayConfig` / `ErrorConfig` のフィールドを `Option<String>` → `String` に変更。`Default` impl にデフォルト値を一本化。`fill_defaults()` を削除。`render_token` の冗長なデフォルト引数を除去。
- **インフラ層** (`toml_loader.rs`): `RawTokenConfig` / `RawDisplayConfig` / `RawErrorConfig` を追加。TOML デシリアライズはこれらの Raw 型で受け取り、`merge_with_defaults` でドメイン型に変換する。
- **アプリ層** (`config_service.rs`): `render` 関数から重複していたデフォルト値をすべて削除。

## 変更の背景

変更前はデフォルト値が2箇所に定義されていた:
1. `display_config.rs::fill_defaults()` — テンプレート生成用
2. `config_service.rs` の `apply_format` 呼び出し — レンダリング用

`TokenConfig` の `Option<String>` フィールドは TOML の省略可能フィールドへの対応（インフラの関心事）であり、ドメイン層に漏れ込んでいた。

## Test plan

- [x] `cargo clippy` パス
- [x] ユニットテスト（43件）パス
- [x] E2E テスト（CI で確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)