### PR TITLE
feat!: [error] を単一セクションに統一し、静的 label をエラーメッセージで置換する

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,20 +173,9 @@ symbol = "⧖"
 label = "Wait for status"
 # format = "$symbol $label"
 
-[error.auth_required]
-symbol = "!"
-label = "gh auth login"
-# format = "$symbol $label"
-
-[error.rate_limited]
+[error]
 symbol = "✗"
-label = "rate-limited"
-# format = "$symbol $label"
-
-[error.api_error]
-symbol = "✗"
-label = "api-error"
-# format = "$symbol $label"
+# format = "$symbol $message"
 ```
 
 Each token supports three optional fields:
@@ -196,6 +185,13 @@ Each token supports three optional fields:
 | `symbol` | Leading symbol | see above |
 | `label` | Status text | see above |
 | `format` | Output template | `"$symbol $label"` |
+
+The `[error]` section uses `$message` instead of `$label`. The message is set automatically from the error that occurred (e.g. `authentication required`, `rate limited`, or the raw API error message).
+
+| Field | Description | Default |
+|-------|-------------|---------|
+| `symbol` | Leading symbol | `"✗"` |
+| `format` | Output template | `"$symbol $message"` |
 
 ## Requirements
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -28,8 +28,11 @@ pub fn run(cli: Cli) -> ExitCode {
                             crate::contexts::evaluation::application::prompt::fetch_output(
                                 &client, &Logger,
                             );
-                        let output =
-                            config_service::render_output(&tokens, error, &TomlConfigRepository);
+                        let output = config_service::render_output(
+                            &tokens,
+                            error.as_ref(),
+                            &TomlConfigRepository,
+                        );
                         daemon_cache_app::update(&DaemonClient, &repo_id, &output, is_terminal);
                     },
                 );

--- a/src/contexts/evaluation/application.rs
+++ b/src/contexts/evaluation/application.rs
@@ -1,5 +1,6 @@
 pub mod config_service;
 pub mod errors;
+pub mod port;
 pub mod prompt;
 
 use crate::contexts::evaluation::domain::pr_state::NotApplicableState;

--- a/src/contexts/evaluation/application/config_service.rs
+++ b/src/contexts/evaluation/application/config_service.rs
@@ -1,9 +1,11 @@
-use super::super::domain::display_config::{DisplayConfig, DisplayConfigRepository, render_token};
+use super::super::domain::display_config::{
+    DisplayConfig, DisplayConfigRepository, render_error_token, render_token,
+};
 use super::{OutputToken, errors::ErrorToken};
 
 pub fn render_output(
     tokens: &[OutputToken],
-    error: Option<ErrorToken>,
+    error: Option<&ErrorToken>,
     repo: &impl DisplayConfigRepository,
 ) -> String {
     let config = repo.load();
@@ -39,12 +41,8 @@ fn render_token_output(config: &DisplayConfig, token: &OutputToken) -> String {
     }
 }
 
-fn render_error(config: &DisplayConfig, token: ErrorToken) -> String {
-    match token {
-        ErrorToken::AuthRequired => render_token(&config.error.auth_required),
-        ErrorToken::RateLimited => render_token(&config.error.rate_limited),
-        ErrorToken::ApiError => render_token(&config.error.api_error),
-    }
+fn render_error(config: &DisplayConfig, token: &ErrorToken) -> String {
+    render_error_token(&config.error, &token.message)
 }
 
 #[cfg(test)]
@@ -86,5 +84,23 @@ mod tests {
     fn status_calculating_renders_with_default_config() {
         let result = render_output(&[OutputToken::StatusCalculating], None, &DefaultRepo);
         assert_eq!(result, "⧖ Wait for status");
+    }
+
+    #[test]
+    fn error_renders_with_message() {
+        let token = ErrorToken {
+            message: "authentication required".to_owned(),
+        };
+        let result = render_output(&[], Some(&token), &DefaultRepo);
+        assert_eq!(result, "✗ authentication required");
+    }
+
+    #[test]
+    fn error_renders_rate_limited_message() {
+        let token = ErrorToken {
+            message: "rate limited".to_owned(),
+        };
+        let result = render_output(&[], Some(&token), &DefaultRepo);
+        assert_eq!(result, "✗ rate limited");
     }
 }

--- a/src/contexts/evaluation/application/errors.rs
+++ b/src/contexts/evaluation/application/errors.rs
@@ -1,8 +1,7 @@
-use crate::contexts::evaluation::domain::error::{ErrorCategory, LogRecord, RepositoryError};
+use crate::contexts::evaluation::domain::error::RepositoryError;
 
-pub trait ErrorLogger {
-    fn log(&self, record: &LogRecord);
-}
+pub use super::port::ErrorLogger;
+use super::port::{ErrorCategory, LogRecord};
 
 /// エラー時に表示するトークン。メッセージはエラー発生箇所で定義される。
 #[derive(Clone)]

--- a/src/contexts/evaluation/application/errors.rs
+++ b/src/contexts/evaluation/application/errors.rs
@@ -4,17 +4,10 @@ pub trait ErrorLogger {
     fn log(&self, record: &LogRecord);
 }
 
-/// エラー時に表示するトークンの意味オブジェクト（検知パス）
-///
-/// 文字列表現への変換は presentation 層が担う。
-#[derive(Clone, Copy)]
-pub enum ErrorToken {
-    /// 認証が必要（ツール未インストール含む）
-    AuthRequired,
-    /// レート制限によりアクセス不可
-    RateLimited,
-    /// 予期しない API エラー
-    ApiError,
+/// エラー時に表示するトークン。メッセージはエラー発生箇所で定義される。
+#[derive(Clone)]
+pub struct ErrorToken {
+    pub message: String,
 }
 
 /// エラーをユーザーに表示するポート
@@ -30,7 +23,9 @@ pub fn handle(
 ) {
     match e {
         RepositoryError::Unauthenticated => {
-            err_presenter.show_error(ErrorToken::AuthRequired);
+            err_presenter.show_error(ErrorToken {
+                message: "authentication required".to_owned(),
+            });
         }
         RepositoryError::NotFound => {}
         RepositoryError::RateLimited => {
@@ -38,14 +33,17 @@ pub fn handle(
                 category: ErrorCategory::RateLimit,
                 detail: None,
             });
-            err_presenter.show_error(ErrorToken::RateLimited);
+            err_presenter.show_error(ErrorToken {
+                message: "rate limited".to_owned(),
+            });
         }
         RepositoryError::Unexpected(msg) => {
+            let message = msg.lines().next().map(str::to_owned).unwrap_or_default();
             err_logger.log(&LogRecord {
                 category: ErrorCategory::Unknown,
                 detail: Some(msg),
             });
-            err_presenter.show_error(ErrorToken::ApiError);
+            err_presenter.show_error(ErrorToken { message });
         }
     }
 }

--- a/src/contexts/evaluation/application/port.rs
+++ b/src/contexts/evaluation/application/port.rs
@@ -1,0 +1,19 @@
+/// ロギングのためのエラーカテゴリ（横断的関心事）
+#[allow(dead_code)]
+pub enum ErrorCategory {
+    Auth,
+    RateLimit,
+    Timeout,
+    Unknown,
+}
+
+/// ログに記録する構造化エントリ
+pub struct LogRecord {
+    pub category: ErrorCategory,
+    pub detail: Option<String>,
+}
+
+/// エラーをログ記録するポート
+pub trait ErrorLogger {
+    fn log(&self, record: &LogRecord);
+}

--- a/src/contexts/evaluation/domain/display_config.rs
+++ b/src/contexts/evaluation/domain/display_config.rs
@@ -1,6 +1,7 @@
 use serde::Serialize;
 
 const DEFAULT_FORMAT: &str = "$symbol $label";
+const DEFAULT_ERROR_FORMAT: &str = "$symbol $message";
 
 #[derive(Serialize)]
 pub struct DisplayConfig {
@@ -65,24 +66,25 @@ pub fn render_token(token: &TokenConfig) -> String {
 
 #[derive(Serialize)]
 pub struct ErrorConfig {
-    pub auth_required: TokenConfig,
-    pub rate_limited: TokenConfig,
-    pub api_error: TokenConfig,
+    pub symbol: String,
+    pub format: String,
 }
 
 impl Default for ErrorConfig {
     fn default() -> Self {
-        let tok = |symbol: &str, label: &str| TokenConfig {
-            symbol: symbol.to_owned(),
-            label: label.to_owned(),
-            format: DEFAULT_FORMAT.to_owned(),
-        };
         Self {
-            auth_required: tok("!", "gh auth login"),
-            rate_limited: tok("✗", "rate-limited"),
-            api_error: tok("✗", "api-error"),
+            symbol: "✗".to_owned(),
+            format: DEFAULT_ERROR_FORMAT.to_owned(),
         }
     }
+}
+
+#[must_use]
+pub fn render_error_token(config: &ErrorConfig, message: &str) -> String {
+    config
+        .format
+        .replace("$symbol", &config.symbol)
+        .replace("$message", message)
 }
 
 #[cfg(test)]
@@ -122,5 +124,33 @@ mod tests {
         let config = DisplayConfig::default();
         assert_eq!(config.status_calculating.symbol, "⧖");
         assert_eq!(config.status_calculating.label, "Wait for status");
+    }
+
+    #[test]
+    fn default_error_config_sets_symbol_and_format() {
+        let config = DisplayConfig::default();
+        assert_eq!(config.error.symbol, "✗");
+        assert_eq!(config.error.format, "$symbol $message");
+    }
+
+    #[test]
+    fn render_error_token_substitutes_symbol_and_message() {
+        let config = ErrorConfig::default();
+        assert_eq!(
+            render_error_token(&config, "rate limited"),
+            "✗ rate limited"
+        );
+    }
+
+    #[test]
+    fn render_error_token_respects_custom_format() {
+        let config = ErrorConfig {
+            symbol: "!".to_owned(),
+            format: "[$symbol] $message".to_owned(),
+        };
+        assert_eq!(
+            render_error_token(&config, "authentication required"),
+            "[!] authentication required"
+        );
     }
 }

--- a/src/contexts/evaluation/domain/error.rs
+++ b/src/contexts/evaluation/domain/error.rs
@@ -11,19 +11,3 @@ pub enum RepositoryError {
     /// 上記に当てはまらない予期しないエラー
     Unexpected(String),
 }
-
-/// ログ記録のためのエラーカテゴリ（原因調査パス）
-#[allow(dead_code)]
-pub enum ErrorCategory {
-    Auth,
-    RateLimit,
-    Timeout,
-    Unknown,
-}
-
-/// ログに記録する構造化エントリ（原因調査パス）
-pub struct LogRecord {
-    pub category: ErrorCategory,
-    /// `Unknown` 系のみ raw メッセージを保持する
-    pub detail: Option<String>,
-}

--- a/src/contexts/evaluation/infrastructure/logger.rs
+++ b/src/contexts/evaluation/infrastructure/logger.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use simplelog::{Config, LevelFilter, WriteLogger};
 
-use crate::contexts::evaluation::domain::error::{ErrorCategory, LogRecord};
+use crate::contexts::evaluation::application::port::{ErrorCategory, ErrorLogger, LogRecord};
 
 pub struct Logger;
 
@@ -25,7 +25,7 @@ fn log_path() -> Option<PathBuf> {
     Some(dir.join("error.log"))
 }
 
-impl crate::contexts::evaluation::application::errors::ErrorLogger for Logger {
+impl ErrorLogger for Logger {
     fn log(&self, record: &LogRecord) {
         let category = match record.category {
             ErrorCategory::Auth => "Auth",

--- a/src/contexts/evaluation/infrastructure/toml_loader.rs
+++ b/src/contexts/evaluation/infrastructure/toml_loader.rs
@@ -56,9 +56,8 @@ fn merge_error(raw: Option<RawErrorConfig>, default: ErrorConfig) -> ErrorConfig
         return default;
     };
     ErrorConfig {
-        auth_required: merge_token(raw.auth_required, default.auth_required),
-        rate_limited: merge_token(raw.rate_limited, default.rate_limited),
-        api_error: merge_token(raw.api_error, default.api_error),
+        symbol: raw.symbol.unwrap_or(default.symbol),
+        format: raw.format.unwrap_or(default.format),
     }
 }
 
@@ -97,7 +96,6 @@ struct RawTokenConfig {
 
 #[derive(Deserialize)]
 struct RawErrorConfig {
-    auth_required: Option<RawTokenConfig>,
-    rate_limited: Option<RawTokenConfig>,
-    api_error: Option<RawTokenConfig>,
+    symbol: Option<String>,
+    format: Option<String>,
 }

--- a/tests/e2e/prompt/errors.rs
+++ b/tests/e2e/prompt/errors.rs
@@ -20,7 +20,7 @@ fn cmd(env: &TestEnv) -> Command {
 
 // ── #34: gh が PATH に存在しない ──────────────────────────────────────────────
 
-/// #34: `gh` バイナリが `PATH` に存在しない → `! gh auth login`
+/// #34: `gh` バイナリが `PATH` に存在しない → `✗ authentication required`
 #[test]
 fn test_gh_not_installed() {
     let env = TestEnv::without_gh();
@@ -30,36 +30,40 @@ fn test_gh_not_installed() {
     cmd(&env)
         .assert()
         .success()
-        .stdout("! gh auth login")
+        .stdout("✗ authentication required")
         .stderr("");
 }
 
 // ── #35–39: with_error() 系 ───────────────────────────────────────────────────
 
-/// #35 `exit 4`（未ログイン）/ #36 `HTTP 401`（認証エラー）→ `! gh auth login`
-/// #37 `HTTP 500` / #38 `connection refused` → `✗ api-error`
-/// #39 `HTTP 403`（レート制限）→ `✗ rate-limited`
+/// #35 `exit 4`（未ログイン）/ #36 `HTTP 401`（認証エラー）→ `✗ authentication required`
+/// #37 `HTTP 500` / #38 `connection refused` → `✗ <error message>`
+/// #39 `HTTP 403`（レート制限）→ `✗ rate limited`
 #[rstest]
 #[case::not_logged_in(
     "To get started with GitHub CLI, please run:  gh auth login",
     4,
-    "! gh auth login"
+    "✗ authentication required"
 )]
 #[case::bad_credentials(
     "HTTP 401: Bad credentials (https://api.github.com/graphql)",
     1,
-    "! gh auth login"
+    "✗ authentication required"
 )]
-#[case::api_error("HTTP 500: Internal Server Error", 1, "✗ api-error")]
+#[case::api_error(
+    "HTTP 500: Internal Server Error",
+    1,
+    "✗ HTTP 500: Internal Server Error"
+)]
 #[case::no_network(
     r#"Post "https://api.github.com/graphql": dial tcp: connection refused"#,
     1,
-    "✗ api-error"
+    r#"✗ Post "https://api.github.com/graphql": dial tcp: connection refused"#
 )]
 #[case::rate_limited(
     "HTTP 403: API rate limit exceeded (https://api.github.com/graphql)",
     1,
-    "✗ rate-limited"
+    "✗ rate limited"
 )]
 fn test_error_output(#[case] msg: &str, #[case] code: u8, #[case] expected: &str) {
     let env = TestEnv::with_error(msg, code);
@@ -75,14 +79,17 @@ fn test_error_output(#[case] msg: &str, #[case] code: u8, #[case] expected: &str
 
 // ── #40: タイムアウト ─────────────────────────────────────────────────────────
 
-/// #40: `gh` がハングした場合、タイムアウト後に `✗ api-error` を返すこと。
+/// #40: `gh` がハングした場合、タイムアウト後に `✗ gh command timed out` を返すこと。
 #[test]
 fn test_gh_timeout() {
     let env = TestEnv::with_hanging_gh();
     let _daemon = DaemonHandle::start_with_env(&env, &[("MERGE_READY_GH_TIMEOUT_SECS", "2")]);
     DaemonHandle::wait_for_cache(&env, 10000);
 
-    cmd(&env).assert().success().stdout("✗ api-error");
+    cmd(&env)
+        .assert()
+        .success()
+        .stdout("✗ gh command timed out");
 }
 
 // ── #41: エラーログ ───────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #188

## Summary

### feat!: `[error]` セクションの統一とエラーメッセージの動的化

- `ErrorToken` を enum から `struct { message: String }` に変更し、メッセージをエラー発生箇所（`errors::handle`）で定義するようにした
- `ErrorConfig` を `auth_required` / `rate_limited` / `api_error` の 3 サブキーから `symbol` + `format` の単一 `[error]` セクションに統一した
- `render_error_token(config, message)` を追加し、`$message` プレースホルダーで動的なエラー文字列を展開する
- E2E テスト・ユニットテスト・README を新しい仕様に合わせて更新した

**新しい表示例：**

| エラー種別 | 変更前 | 変更後 |
|---|---|---|
| 認証エラー | `! gh auth login` | `✗ authentication required` |
| レート制限 | `✗ rate-limited` | `✗ rate limited` |
| API エラー | `✗ api-error` | `✗ HTTP 500: Internal Server Error`（実際のメッセージ先頭行） |

**設定ファイルの変更（破壊的変更）：**

```toml
# 変更前
[error.auth_required]
symbol = "!"
label = "gh auth login"

[error.rate_limited]
symbol = "✗"
label = "rate-limited"

[error.api_error]
symbol = "✗"
label = "api-error"

# 変更後
[error]
symbol = "✗"
# format = "$symbol $message"
```

既存の `[error.auth_required]` / `[error.rate_limited]` / `[error.api_error]` 設定は無視されます。`[error]` セクションに移行してください。

BREAKING CHANGE: `[error.*]` サブキーを廃止し `[error]` 単一セクションに統一。`label` フィールドも廃止され、エラーメッセージは自動的に設定されます。

### refactor: `ErrorCategory` / `LogRecord` をドメイン層からアプリケーション層の port モジュールへ移動

ロギングは横断的関心事であり、ドメイン層が持つべき概念ではない（DDD 改善）。

- `application/port.rs` を新設し `ErrorCategory` / `LogRecord` / `ErrorLogger` を集約
- `domain/error.rs` からロギング型を削除（`RepositoryError` のみ残存）
- `infrastructure/logger.rs` は `application::port` から import（layer deps ルールの `::application::port` 例外パスに準拠）

## Test plan

- [ ] `cargo test --workspace --bins` — ユニットテスト 48 件通過
- [ ] `cargo clippy --workspace -- -D warnings` — 警告なし
- [ ] `cargo fmt --check --all` — フォーマット差分なし
- [ ] `bash scripts/check-layer-deps.sh` — レイヤー依存ルール OK
- [ ] `bash scripts/check-no-mod-rs.sh` — mod.rs なし OK
- [ ] E2E テスト（CI で検証）

🤖 Generated with [Claude Code](https://claude.com/claude-code)