### PR TITLE
feat: BLOCKED かつ理由不明のとき ? Check merge blocker を表示する

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,11 @@ symbol = "⧖"
 label = "Wait for status"
 # format = "$symbol $label"
 
+[blocked_unknown]
+symbol = "?"
+label = "Check merge blocker"
+# format = "$symbol $label"
+
 [error]
 symbol = "✗"
 # format = "$symbol $message"

--- a/src/contexts/evaluation/application.rs
+++ b/src/contexts/evaluation/application.rs
@@ -6,6 +6,7 @@ pub mod prompt;
 use crate::contexts::evaluation::domain::pr_state::NotApplicableState;
 use crate::contexts::evaluation::domain::pr_state::PrState;
 use crate::contexts::evaluation::domain::pr_state::blocked::BlockedState;
+use crate::contexts::evaluation::domain::pr_state::blocked::GenericBlockedState;
 use crate::contexts::evaluation::domain::pr_state::blocked::branch_sync::BranchSyncState;
 use crate::contexts::evaluation::domain::pr_state::blocked::ci::CiState;
 use crate::contexts::evaluation::domain::pr_state::blocked::review::ReviewState;
@@ -27,6 +28,7 @@ pub enum OutputToken {
     NoPullRequest,
     Draft,
     StatusCalculating,
+    BlockedUnknown,
 }
 
 fn map_blocked_to_tokens(blocked: BlockedState) -> Vec<OutputToken> {
@@ -49,6 +51,11 @@ fn map_blocked_to_tokens(blocked: BlockedState) -> Vec<OutputToken> {
         tokens.push(match r {
             ReviewState::ChangesRequested => OutputToken::ReviewRequested,
             ReviewState::ReviewRequired => OutputToken::ReviewRequired,
+        });
+    }
+    if let Some(g) = blocked.generic {
+        tokens.push(match g {
+            GenericBlockedState::BlockedUnknown => OutputToken::BlockedUnknown,
         });
     }
     tokens
@@ -93,6 +100,7 @@ mod tests {
             branch_sync: None,
             ci: None,
             review: Some(ReviewState::ReviewRequired),
+            generic: None,
         };
         let tokens = map_pr_state_to_tokens(PrState::Blocked(blocked));
         assert_eq!(tokens.len(), 1);
@@ -106,6 +114,7 @@ mod tests {
             branch_sync: None,
             ci: Some(CiState::Pending),
             review: None,
+            generic: None,
         };
         let tokens = map_pr_state_to_tokens(PrState::Blocked(blocked));
         assert_eq!(tokens.len(), 1);
@@ -118,5 +127,19 @@ mod tests {
             map_pr_state_to_tokens(PrState::NotApplicable(NotApplicableState::Calculating));
         assert_eq!(tokens.len(), 1);
         assert!(matches!(tokens[0], OutputToken::StatusCalculating));
+    }
+
+    #[test]
+    fn blocked_unknown_maps_to_blocked_unknown_token() {
+        use crate::contexts::evaluation::domain::pr_state::blocked::BlockedState;
+        let blocked = BlockedState {
+            branch_sync: None,
+            ci: None,
+            review: None,
+            generic: Some(GenericBlockedState::BlockedUnknown),
+        };
+        let tokens = map_pr_state_to_tokens(PrState::Blocked(blocked));
+        assert_eq!(tokens.len(), 1);
+        assert!(matches!(tokens[0], OutputToken::BlockedUnknown));
     }
 }

--- a/src/contexts/evaluation/application/config_service.rs
+++ b/src/contexts/evaluation/application/config_service.rs
@@ -38,6 +38,7 @@ fn render_token_output(config: &DisplayConfig, token: &OutputToken) -> String {
         OutputToken::ReviewRequired => render_token(&config.review_required),
         OutputToken::Draft => render_token(&config.draft),
         OutputToken::StatusCalculating => render_token(&config.status_calculating),
+        OutputToken::BlockedUnknown => render_token(&config.blocked_unknown),
     }
 }
 
@@ -102,5 +103,11 @@ mod tests {
         };
         let result = render_output(&[], Some(&token), &DefaultRepo);
         assert_eq!(result, "✗ rate limited");
+    }
+
+    #[test]
+    fn blocked_unknown_renders_with_default_config() {
+        let result = render_output(&[OutputToken::BlockedUnknown], None, &DefaultRepo);
+        assert_eq!(result, "? Check merge blocker");
     }
 }

--- a/src/contexts/evaluation/domain/display_config.rs
+++ b/src/contexts/evaluation/domain/display_config.rs
@@ -17,6 +17,7 @@ pub struct DisplayConfig {
     pub review_required: TokenConfig,
     pub draft: TokenConfig,
     pub status_calculating: TokenConfig,
+    pub blocked_unknown: TokenConfig,
     pub error: ErrorConfig,
 }
 
@@ -40,6 +41,7 @@ impl Default for DisplayConfig {
             review_required: tok("@", "Assign reviewer"),
             draft: tok("✎", "Ready for review"),
             status_calculating: tok("⧖", "Wait for status"),
+            blocked_unknown: tok("?", "Check merge blocker"),
             error: ErrorConfig::default(),
         }
     }
@@ -124,6 +126,13 @@ mod tests {
         let config = DisplayConfig::default();
         assert_eq!(config.status_calculating.symbol, "⧖");
         assert_eq!(config.status_calculating.label, "Wait for status");
+    }
+
+    #[test]
+    fn default_sets_blocked_unknown() {
+        let config = DisplayConfig::default();
+        assert_eq!(config.blocked_unknown.symbol, "?");
+        assert_eq!(config.blocked_unknown.label, "Check merge blocker");
     }
 
     #[test]

--- a/src/contexts/evaluation/domain/pr_state.rs
+++ b/src/contexts/evaluation/domain/pr_state.rs
@@ -62,6 +62,7 @@ pub fn evaluate(
             branch_sync,
             ci,
             review,
+            generic: None,
         })
     } else if let Some(u) = unblocked {
         PrState::Unblocked(u)
@@ -130,5 +131,14 @@ mod tests {
     fn calculating_is_not_terminal() {
         let state = PrState::NotApplicable(NotApplicableState::Calculating);
         assert!(!state.is_terminal());
+    }
+
+    #[test]
+    fn evaluate_sets_generic_none_when_blockers_present() {
+        let state = evaluate(Some(BranchSyncState::Conflict), None, None, None);
+        let PrState::Blocked(blocked) = state else {
+            panic!("expected Blocked");
+        };
+        assert_eq!(blocked.generic, None);
     }
 }

--- a/src/contexts/evaluation/domain/pr_state/blocked.rs
+++ b/src/contexts/evaluation/domain/pr_state/blocked.rs
@@ -1,9 +1,11 @@
 pub mod branch_sync;
 pub mod ci;
+pub mod generic;
 pub mod review;
 
 use branch_sync::BranchSyncState;
 use ci::CiState;
+pub use generic::GenericBlockedState;
 use review::ReviewState;
 
 /// PR がブロックされているときのブロッカー集合（複数同時に存在できる）
@@ -17,4 +19,6 @@ pub struct BlockedState {
     pub ci: Option<CiState>,
     /// レビューの blocker（変更要求）
     pub review: Option<ReviewState>,
+    /// 汎用ブロッカー（API では原因を特定できないブロック）
+    pub generic: Option<GenericBlockedState>,
 }

--- a/src/contexts/evaluation/domain/pr_state/blocked/generic.rs
+++ b/src/contexts/evaluation/domain/pr_state/blocked/generic.rs
@@ -1,0 +1,6 @@
+/// 汎用ブロッカー評価状態
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GenericBlockedState {
+    /// API で原因を特定できないブロック（`mergeStateStatus == "BLOCKED"` かつ他シグナルすべて None）
+    BlockedUnknown,
+}

--- a/src/contexts/evaluation/infrastructure/gh.rs
+++ b/src/contexts/evaluation/infrastructure/gh.rs
@@ -11,6 +11,7 @@ use schema::{
 };
 
 use crate::contexts::evaluation::domain::error::RepositoryError;
+use crate::contexts::evaluation::domain::pr_state::blocked::GenericBlockedState;
 use crate::contexts::evaluation::domain::pr_state::blocked::branch_sync::BranchSyncState;
 use crate::contexts::evaluation::domain::pr_state::blocked::ci::CiState;
 use crate::contexts::evaluation::domain::pr_state::blocked::review::ReviewState;
@@ -143,13 +144,21 @@ impl PrRepository for GhClient {
         let unblocked = translate_unblocked(pr_view.is_draft, &pr_view.merge_state_status);
 
         let state = evaluate(branch_sync, ci, review, unblocked);
-        if matches!(state, PrState::Unknown)
-            && matches!(
-                pr_view.merge_state_status.as_str(),
-                "MERGE_STATE_UNKNOWN" | "UNKNOWN"
-            )
-        {
-            return Ok(PrState::NotApplicable(NotApplicableState::Calculating));
+        if matches!(state, PrState::Unknown) {
+            return Ok(match pr_view.merge_state_status.as_str() {
+                "MERGE_STATE_UNKNOWN" | "UNKNOWN" => {
+                    PrState::NotApplicable(NotApplicableState::Calculating)
+                }
+                "BLOCKED" => PrState::Blocked(
+                    crate::contexts::evaluation::domain::pr_state::blocked::BlockedState {
+                        branch_sync: None,
+                        ci: None,
+                        review: None,
+                        generic: Some(GenericBlockedState::BlockedUnknown),
+                    },
+                ),
+                _ => state,
+            });
         }
         Ok(state)
     }
@@ -233,6 +242,11 @@ mod tests {
     #[test]
     fn translate_unblocked_unknown_returns_none() {
         assert_eq!(translate_unblocked(false, "UNKNOWN"), None);
+    }
+
+    #[test]
+    fn translate_unblocked_blocked_returns_none() {
+        assert_eq!(translate_unblocked(false, "BLOCKED"), None);
     }
 }
 

--- a/src/contexts/evaluation/infrastructure/toml_loader.rs
+++ b/src/contexts/evaluation/infrastructure/toml_loader.rs
@@ -36,6 +36,7 @@ fn merge_with_defaults(raw: RawDisplayConfig) -> DisplayConfig {
         review_required: merge_token(raw.review_required, defaults.review_required),
         draft: merge_token(raw.draft, defaults.draft),
         status_calculating: merge_token(raw.status_calculating, defaults.status_calculating),
+        blocked_unknown: merge_token(raw.blocked_unknown, defaults.blocked_unknown),
         error: merge_error(raw.error, defaults.error),
     }
 }
@@ -84,6 +85,7 @@ struct RawDisplayConfig {
     review_required: Option<RawTokenConfig>,
     draft: Option<RawTokenConfig>,
     status_calculating: Option<RawTokenConfig>,
+    blocked_unknown: Option<RawTokenConfig>,
     error: Option<RawErrorConfig>,
 }
 

--- a/tests/e2e/prompt/pr_state.rs
+++ b/tests/e2e/prompt/pr_state.rs
@@ -16,6 +16,7 @@ const MERGED_PR: &str = r#"{"state":"MERGED","isDraft":false,"mergeable":"UNKNOW
 const DRAFT_PR: &str = r#"{"state":"OPEN","isDraft":true,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}"#;
 const MERGE_STATE_UNKNOWN_PR: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"UNKNOWN","mergeStateStatus":"MERGE_STATE_UNKNOWN","reviewDecision":null,"baseRefName":"","headRefName":""}"#;
 const UNKNOWN_STATUS_PR: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"UNKNOWN","mergeStateStatus":"UNKNOWN","reviewDecision":null,"baseRefName":"","headRefName":""}"#;
+const BLOCKED_UNKNOWN_PR: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"BLOCKED","reviewDecision":null,"baseRefName":"","headRefName":""}"#;
 
 fn assert_prompt(env: &TestEnv, expected: &str) {
     let _daemon = DaemonHandle::start(env);
@@ -94,4 +95,14 @@ fn test_merge_state_unknown_shows_wait_for_status() {
 fn test_unknown_merge_state_status_shows_wait_for_status() {
     let env = TestEnv::new(UNKNOWN_STATUS_PR, Some(r#"[]"#));
     assert_prompt(&env, "⧖ Wait for status");
+}
+
+// ── #178: BLOCKED + 全シグナル None ──────────────────────────────────────────
+
+/// #178: `mergeStateStatus == "BLOCKED"` かつ branch_sync / ci / review がすべて None
+///       → `? Check merge blocker`
+#[test]
+fn test_blocked_unknown_shows_check_merge_blocker() {
+    let env = TestEnv::new(BLOCKED_UNKNOWN_PR, Some(r#"[]"#));
+    assert_prompt(&env, "? Check merge blocker");
 }


### PR DESCRIPTION
## Summary

- `mergeStateStatus == "BLOCKED"` かつ branch_sync / ci / review がすべて `None` のとき、汎用ブロック状態を示す `blocked_unknown` トークン（`? Check merge blocker`）を表示する
- `BlockedState` に `generic: Option<GenericBlockedState>` フィールドを追加し、`BranchSyncState::SyncUnknown` と同様の catch-all 設計で実装
- `gh.rs` で `evaluate()` が `Unknown` を返し、かつ `merge_state_status == "BLOCKED"` のときに `Blocked { generic: Some(BlockedUnknown) }` へ変換する

## Test plan

- [x] 単体テスト：`display_config`, `application`, `config_service`, `pr_state`, `gh` に追加
- [x] E2E テスト：`mergeStateStatus == "BLOCKED"` + CI チェックなしで `? Check merge blocker` が出力されることを確認
- [x] `cargo test --workspace` 127 tests passed
- [x] `cargo clippy --workspace -- -D warnings` issues なし
- [x] `cargo fmt --check --all` 差分なし

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)