### PR TITLE
refactor: RepositoryError::Unexpected のドメイン汚染を解消する (#190)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -22,7 +22,7 @@ pub fn run(cli: Cli) -> ExitCode {
                 crate::contexts::daemon::infrastructure::daemon_lifecycle::DaemonLifecycle::new(
                     |repo_id: &str, cwd: &std::path::Path| {
                         let repo_id = repo_id.to_owned();
-                        let client = GhClient::new_in(cwd.to_path_buf());
+                        let client = GhClient::new_in(cwd.to_path_buf(), Logger);
                         let (output, is_terminal) =
                             crate::contexts::evaluation::interface::prompt::render(
                                 &client,

--- a/src/contexts/evaluation/application/errors.rs
+++ b/src/contexts/evaluation/application/errors.rs
@@ -25,13 +25,8 @@ pub fn into_token<L: ErrorLogger>(e: RepositoryError, logger: &L) -> Option<Erro
                 message: "rate limited".to_owned(),
             })
         }
-        RepositoryError::Unexpected(msg) => {
-            let message = msg.lines().next().map(str::to_owned).unwrap_or_default();
-            logger.log(&LogRecord {
-                category: ErrorCategory::Unknown,
-                detail: Some(msg),
-            });
-            Some(ErrorToken { message })
-        }
+        RepositoryError::Unexpected => Some(ErrorToken {
+            message: "unexpected error".to_owned(),
+        }),
     }
 }

--- a/src/contexts/evaluation/domain/error.rs
+++ b/src/contexts/evaluation/domain/error.rs
@@ -1,6 +1,7 @@
 /// リポジトリ操作で発生しうるエラー種別（全ドメイントレイト共通）
 ///
 /// infra の実装手段（CLI・REST 等）に依存しない抽象的な分類のみを持つ。
+#[derive(Copy, Clone)]
 pub enum RepositoryError {
     /// 認証不可（ツール未インストール・未認証を含む）
     Unauthenticated,
@@ -9,5 +10,5 @@ pub enum RepositoryError {
     /// レート制限によりアクセス不可
     RateLimited,
     /// 上記に当てはまらない予期しないエラー
-    Unexpected(String),
+    Unexpected,
 }

--- a/src/contexts/evaluation/infrastructure/gh.rs
+++ b/src/contexts/evaluation/infrastructure/gh.rs
@@ -10,6 +10,7 @@ use schema::{
     CheckBucket, GhCheckItem, GhCompare, GhPrView, GhRepoView, GhRepoViewFull, translate_bucket,
 };
 
+use crate::contexts::evaluation::application::port::{ErrorCategory, ErrorLogger, LogRecord};
 use crate::contexts::evaluation::domain::error::RepositoryError;
 use crate::contexts::evaluation::domain::pr_state::blocked::GenericBlockedState;
 use crate::contexts::evaluation::domain::pr_state::blocked::branch_sync::BranchSyncState;
@@ -22,39 +23,50 @@ use crate::contexts::evaluation::infrastructure::git::{current_branch, is_git_re
 
 // ── GhClient ────────────────────────────────────────────────────────────────
 
-pub struct GhClient {
+pub struct GhClient<L> {
     cwd: Option<std::path::PathBuf>,
+    logger: L,
 }
 
-impl Default for GhClient {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl GhClient {
+impl<L: ErrorLogger + Sync> GhClient<L> {
     #[must_use]
-    pub fn new() -> Self {
-        Self { cwd: None }
-    }
-
-    #[must_use]
-    pub fn new_in(cwd: std::path::PathBuf) -> Self {
-        Self { cwd: Some(cwd) }
+    pub fn new_in(cwd: std::path::PathBuf, logger: L) -> Self {
+        Self {
+            cwd: Some(cwd),
+            logger,
+        }
     }
 
     fn run_gh(&self, args: &[&str]) -> Result<Vec<u8>, GhError> {
         run_gh(args, self.cwd.as_deref())
     }
 
+    fn log_and_convert(&self, e: GhError) -> RepositoryError {
+        if let GhError::ApiError(ref msg) = e {
+            self.logger.log(&LogRecord {
+                category: ErrorCategory::Unknown,
+                detail: Some(msg.clone()),
+            });
+        }
+        RepositoryError::from(e)
+    }
+
     fn fetch_pr_view(&self) -> Result<GhPrView, RepositoryError> {
-        let bytes = self.run_gh(&[
-            "pr",
-            "view",
-            "--json",
-            "state,isDraft,mergeable,mergeStateStatus,reviewDecision,baseRefName,headRefName",
-        ])?;
-        serde_json::from_slice(&bytes).map_err(|e| RepositoryError::Unexpected(e.to_string()))
+        let bytes = self
+            .run_gh(&[
+                "pr",
+                "view",
+                "--json",
+                "state,isDraft,mergeable,mergeStateStatus,reviewDecision,baseRefName,headRefName",
+            ])
+            .map_err(|e| self.log_and_convert(e))?;
+        serde_json::from_slice(&bytes).map_err(|e| {
+            self.logger.log(&LogRecord {
+                category: ErrorCategory::Unknown,
+                detail: Some(e.to_string()),
+            });
+            RepositoryError::Unexpected
+        })
     }
 
     fn fetch_ci_state(&self) -> Result<Option<CiState>, RepositoryError> {
@@ -63,10 +75,15 @@ impl GhClient {
             Err(GhError::ApiError(msg)) if msg.contains("no checks reported") => {
                 return Ok(None);
             }
-            Err(e) => return Err(e.into()),
+            Err(e) => return Err(self.log_and_convert(e)),
         };
-        let items: Vec<GhCheckItem> = serde_json::from_slice(&bytes)
-            .map_err(|e| RepositoryError::Unexpected(e.to_string()))?;
+        let items: Vec<GhCheckItem> = serde_json::from_slice(&bytes).map_err(|e| {
+            self.logger.log(&LogRecord {
+                category: ErrorCategory::Unknown,
+                detail: Some(e.to_string()),
+            });
+            RepositoryError::Unexpected
+        })?;
         let buckets: Vec<CheckBucket> = items.iter().map(|c| translate_bucket(&c.bucket)).collect();
         Ok(aggregate_ci(&buckets))
     }
@@ -102,7 +119,7 @@ impl GhClient {
 
 // ── PrRepository 実装 ────────────────────────────────────────────────────────
 
-impl PrRepository for GhClient {
+impl<L: ErrorLogger + Sync> PrRepository for GhClient<L> {
     fn fetch(&self) -> Result<PrState, RepositoryError> {
         if !is_git_repo(self.cwd.as_deref()) {
             return Ok(PrState::NotApplicable(NotApplicableState::NoRepository));
@@ -293,7 +310,7 @@ impl From<GhError> for RepositoryError {
             GhError::NotInstalled | GhError::AuthRequired => RepositoryError::Unauthenticated,
             GhError::NoPr => RepositoryError::NotFound,
             GhError::RateLimited => RepositoryError::RateLimited,
-            GhError::ApiError(msg) => RepositoryError::Unexpected(msg),
+            GhError::ApiError(_) => RepositoryError::Unexpected,
         }
     }
 }

--- a/src/contexts/evaluation/infrastructure/gh.rs
+++ b/src/contexts/evaluation/infrastructure/gh.rs
@@ -43,7 +43,7 @@ impl GhClient {
         Self { cwd: Some(cwd) }
     }
 
-    fn run_gh(&self, args: &[&str]) -> Result<Vec<u8>, RepositoryError> {
+    fn run_gh(&self, args: &[&str]) -> Result<Vec<u8>, GhError> {
         run_gh(args, self.cwd.as_deref())
     }
 
@@ -60,10 +60,10 @@ impl GhClient {
     fn fetch_ci_state(&self) -> Result<Option<CiState>, RepositoryError> {
         let bytes = match self.run_gh(&["pr", "checks", "--json", "bucket,state"]) {
             Ok(b) => b,
-            Err(RepositoryError::Unexpected(msg)) if msg.contains("no checks reported") => {
+            Err(GhError::ApiError(msg)) if msg.contains("no checks reported") => {
                 return Ok(None);
             }
-            Err(e) => return Err(e),
+            Err(e) => return Err(e.into()),
         };
         let items: Vec<GhCheckItem> = serde_json::from_slice(&bytes)
             .map_err(|e| RepositoryError::Unexpected(e.to_string()))?;
@@ -306,7 +306,7 @@ fn gh_timeout() -> Duration {
     Duration::from_secs(secs)
 }
 
-fn run_gh(args: &[&str], cwd: Option<&Path>) -> Result<Vec<u8>, RepositoryError> {
+fn run_gh(args: &[&str], cwd: Option<&Path>) -> Result<Vec<u8>, GhError> {
     let mut cmd = Command::new("gh");
     cmd.args(args);
     cmd.stdout(Stdio::piped());
@@ -316,8 +316,8 @@ fn run_gh(args: &[&str], cwd: Option<&Path>) -> Result<Vec<u8>, RepositoryError>
     }
 
     let mut child = match cmd.spawn() {
-        Err(e) if e.kind() == ErrorKind::NotFound => return Err(GhError::NotInstalled.into()),
-        Err(e) => return Err(GhError::ApiError(e.to_string()).into()),
+        Err(e) if e.kind() == ErrorKind::NotFound => return Err(GhError::NotInstalled),
+        Err(e) => return Err(GhError::ApiError(e.to_string())),
         Ok(c) => c,
     };
 
@@ -348,15 +348,15 @@ fn run_gh(args: &[&str], cwd: Option<&Path>) -> Result<Vec<u8>, RepositoryError>
                 }
                 let exit_code = status.code().unwrap_or(1);
                 let stderr_str = String::from_utf8_lossy(&stderr).into_owned();
-                return Err(classify_gh_error(exit_code, &stderr_str).into());
+                return Err(classify_gh_error(exit_code, &stderr_str));
             }
             Ok(None) if Instant::now() >= deadline => {
                 let _ = child.kill();
                 let _ = child.wait();
-                return Err(GhError::ApiError("gh command timed out".to_string()).into());
+                return Err(GhError::ApiError("gh command timed out".to_string()));
             }
             Ok(None) => std::thread::sleep(Duration::from_millis(50)),
-            Err(e) => return Err(GhError::ApiError(e.to_string()).into()),
+            Err(e) => return Err(GhError::ApiError(e.to_string())),
         }
     }
 }

--- a/tests/e2e/prompt/errors.rs
+++ b/tests/e2e/prompt/errors.rs
@@ -37,7 +37,7 @@ fn test_gh_not_installed() {
 // ── #35–39: with_error() 系 ───────────────────────────────────────────────────
 
 /// #35 `exit 4`（未ログイン）/ #36 `HTTP 401`（認証エラー）→ `✗ authentication required`
-/// #37 `HTTP 500` / #38 `connection refused` → `✗ <error message>`
+/// #37 `HTTP 500` / #38 `connection refused` → `✗ unexpected error`（詳細はログ）
 /// #39 `HTTP 403`（レート制限）→ `✗ rate limited`
 #[rstest]
 #[case::not_logged_in(
@@ -53,12 +53,12 @@ fn test_gh_not_installed() {
 #[case::api_error(
     "HTTP 500: Internal Server Error",
     1,
-    "✗ HTTP 500: Internal Server Error"
+    "✗ unexpected error"
 )]
 #[case::no_network(
     r#"Post "https://api.github.com/graphql": dial tcp: connection refused"#,
     1,
-    r#"✗ Post "https://api.github.com/graphql": dial tcp: connection refused"#
+    "✗ unexpected error"
 )]
 #[case::rate_limited(
     "HTTP 403: API rate limit exceeded (https://api.github.com/graphql)",
@@ -79,7 +79,7 @@ fn test_error_output(#[case] msg: &str, #[case] code: u8, #[case] expected: &str
 
 // ── #40: タイムアウト ─────────────────────────────────────────────────────────
 
-/// #40: `gh` がハングした場合、タイムアウト後に `✗ gh command timed out` を返すこと。
+/// #40: `gh` がハングした場合、タイムアウト後に `✗ unexpected error` を返すこと（詳細はログ）。
 #[test]
 fn test_gh_timeout() {
     let env = TestEnv::with_hanging_gh();
@@ -89,7 +89,7 @@ fn test_gh_timeout() {
     cmd(&env)
         .assert()
         .success()
-        .stdout("✗ gh command timed out");
+        .stdout("✗ unexpected error");
 }
 
 // ── #41: エラーログ ───────────────────────────────────────────────────────────

--- a/tests/e2e/prompt/errors.rs
+++ b/tests/e2e/prompt/errors.rs
@@ -50,11 +50,7 @@ fn test_gh_not_installed() {
     1,
     "✗ authentication required"
 )]
-#[case::api_error(
-    "HTTP 500: Internal Server Error",
-    1,
-    "✗ unexpected error"
-)]
+#[case::api_error("HTTP 500: Internal Server Error", 1, "✗ unexpected error")]
 #[case::no_network(
     r#"Post "https://api.github.com/graphql": dial tcp: connection refused"#,
     1,
@@ -86,10 +82,7 @@ fn test_gh_timeout() {
     let _daemon = DaemonHandle::start_with_env(&env, &[("MERGE_READY_GH_TIMEOUT_SECS", "2")]);
     DaemonHandle::wait_for_cache(&env, 10000);
 
-    cmd(&env)
-        .assert()
-        .success()
-        .stdout("✗ unexpected error");
+    cmd(&env).assert().success().stdout("✗ unexpected error");
 }
 
 // ── #41: エラーログ ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `fetch_ci_state` が `RepositoryError::Unexpected(msg).contains("no checks reported")` でドメイン型を infra 内ルーティングに使っていた問題を解消（`run_gh` の返り値を `GhError` に変更し、infra 型で直接マッチ）
- `RepositoryError::Unexpected(String)` の String ペイロードを削除。infra 詳細は `GhClient` に注入した `ErrorLogger` 経由で直接 `error.log` に記録するよう変更
- ユーザー表示は `"✗ <infra の生文字列>"` から静的な `"✗ unexpected error"` に変更

## Changes

| ファイル | 変更内容 |
|---|---|
| `infrastructure/gh.rs` | `GhClient<L: ErrorLogger + Sync>` にジェネリック logger を注入。`run_gh` 返り値を `GhError` に変更。`log_and_convert` で詳細をログ記録してから `RepositoryError` に変換 |
| `domain/error.rs` | `Unexpected(String)` → `Unexpected`。`Copy` を derive |
| `application/errors.rs` | `into_token` の `Unexpected` アームを静的メッセージ `"unexpected error"` に変更 |
| `app.rs` | `GhClient::new_in(cwd, Logger)` に logger を渡すよう更新 |
| `tests/e2e/prompt/errors.rs` | `api_error` / `no_network` / `timeout` の期待値を `"✗ unexpected error"` に更新 |

## Commit structure (TDD)

1. `refactor: run_gh の返り値を GhError に変更し fetch_ci_state のドメイン型マッチを除去`
2. `test: Unexpected 表示を静的 "unexpected error" に変更する E2E テストを書き換え` (Red)
3. `refactor: GhClient に logger を注入し RepositoryError::Unexpected のペイロードを除去` (Green)

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)