### PR TITLE
perf: リリースバイナリにデバッグシンボルの strip を追加する

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,8 @@ tempfile = "3.27.0"
 [[bench]]
 name = "hot_path"
 harness = false
+
+[profile.release]
+lto = "thin"
+codegen-units = 1
+strip = "symbols"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,4 @@ name = "hot_path"
 harness = false
 
 [profile.release]
-lto = "thin"
-codegen-units = 1
 strip = "symbols"

--- a/src_prompt/main.rs
+++ b/src_prompt/main.rs
@@ -1,6 +1,6 @@
 // merge-ready-prompt: 軽量なシェルプロンプト用バイナリ。
 
-use std::io::{BufRead, BufReader, Write};
+use std::io::{Read, Write};
 use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 use std::process::Stdio;
@@ -31,31 +31,43 @@ fn query_daemon() -> Option<String> {
     let msg = encode_query(&cwd, env!("CARGO_PKG_VERSION"));
     stream.write_all(msg.as_bytes()).ok()?;
 
-    let mut buf = String::new();
-    BufReader::new(&stream).read_line(&mut buf).ok()?;
+    // レスポンスはスタックバッファで受け取る（8KB BufReader ヒープ確保を回避）
+    let mut buf = [0u8; 512];
+    let n = stream.read(&mut buf).ok()?;
 
-    decode_query_response(&buf)
+    decode_query_response(&buf[..n])
 }
 
 /// `{"action":"query","cwd":"...","client_version":"..."}\n`
 fn encode_query(cwd: &str, client_version: &str) -> String {
-    format!(
-        "{}\n",
-        serde_json::json!({
-            "action": "query",
-            "cwd": cwd,
-            "client_version": client_version,
-        })
-    )
+    #[derive(serde::Serialize)]
+    struct QueryMsg<'a> {
+        action: &'a str,
+        cwd: &'a str,
+        client_version: &'a str,
+    }
+    let mut s = serde_json::to_string(&QueryMsg {
+        action: "query",
+        cwd,
+        client_version,
+    })
+    .unwrap_or_default();
+    s.push('\n');
+    s
 }
 
 /// `{"tag":"output","output":"..."}` → output フィールドを返す
-fn decode_query_response(line: &str) -> Option<String> {
-    let v: serde_json::Value = serde_json::from_str(line.trim()).ok()?;
-    if v.get("tag")?.as_str()? != "output" {
+fn decode_query_response(bytes: &[u8]) -> Option<String> {
+    #[derive(serde::Deserialize)]
+    struct ResponseMsg {
+        tag: String,
+        output: Option<String>,
+    }
+    let msg: ResponseMsg = serde_json::from_slice(bytes.split(|&b| b == b'\n').next()?).ok()?;
+    if msg.tag != "output" {
         return None;
     }
-    v.get("output")?.as_str().map(str::to_owned)
+    Some(msg.output.unwrap_or_default())
 }
 
 fn socket_path() -> PathBuf {


### PR DESCRIPTION
## Summary

- `[profile.release]` に `strip="symbols"` を追加し、バイナリサイズを削減
- `encode_query` を `serde_json::json!`（`Value` 経由）から typed struct serialize に変更し、中間 `Value` のヒープアロケーションを排除
- `decode_query_response` を typed struct deserialize + スタック配列読み取りに変更し、`BufReader` の 8KB ヒープ確保を回避

## 調査結果

個別計測の結果、`lto="thin"` / `codegen-units=1` / `strip="symbols"` の3設定をそれぞれ単独で計測。

| 設定 | 中央値 | ベースライン比 | 有意差 |
|---|---|---|---|
| なし（ベースライン） | 11.986 ms | — | — |
| `strip = "symbols"` のみ | 12.008 ms | +0.19% | なし |
| `lto = "thin"` のみ | 12.075 ms | +0.75% | なし |
| `codegen-units = 1` のみ | 11.945 ms | -0.34% | なし |

起動時間への有意な効果は確認できなかった。ただし `strip="symbols"` はバイナリサイズを **-20%（543KB → 436KB）** 削減するため残す。`lto` と `codegen-units=1` はビルド時間を増やすだけで効果がないため削除。

支配コストは **fork/exec + ELF ロード + Rust ランタイム初期化** であり、ユーザー空間での改善余地は限定的。プロセス起動を排除しない限りこれ以上の短縮は難しい。

## Test plan

- [x] `cargo test --workspace` — 143 tests passed
- [x] `cargo clippy --workspace -- -D warnings` — no issues
- [x] `cargo bench --bench hot_path` — 中央値 12.151ms ≤ 15ms 閾値

🤖 Generated with [Claude Code](https://claude.com/claude-code)