### PR TITLE
refactor: CacheEntry をドメインエンティティとして定義し直す

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4,7 +4,7 @@ use clap::CommandFactory;
 
 use crate::cli::{Cli, Command};
 use crate::contexts::daemon::application::cache as daemon_cache_app;
-use crate::contexts::daemon::domain::cache::RefreshMode;
+use crate::contexts::daemon::domain::cache::{RefreshMode, RepoId};
 use crate::contexts::daemon::infrastructure::daemon_client::DaemonClient;
 use crate::contexts::evaluation::infrastructure::toml_loader::TomlConfigRepository;
 use crate::contexts::evaluation::infrastructure::{gh::GhClient, logger::Logger};
@@ -32,7 +32,7 @@ pub fn run(cli: Cli) -> ExitCode {
                 crate::contexts::daemon::infrastructure::daemon_lifecycle::DaemonLifecycle::new(
                     // repo_id はブランチ変化を考慮して daemon_server が再導出して渡す
                     |repo_id: &str, cwd: &std::path::Path| {
-                        let repo_id = repo_id.to_owned();
+                        let repo_id = RepoId::new(repo_id);
                         let client = GhClient::new_in(cwd.to_path_buf(), Logger);
                         let (output, hint) = crate::contexts::evaluation::interface::prompt::render(
                             &client,

--- a/src/contexts/daemon/application/cache.rs
+++ b/src/contexts/daemon/application/cache.rs
@@ -1,6 +1,6 @@
-use crate::contexts::daemon::domain::cache::{CachePort, RefreshMode};
+use crate::contexts::daemon::domain::cache::{CachePort, RefreshMode, RepoId};
 
 /// キャッシュを更新するユースケース
-pub fn update(port: &impl CachePort, repo_id: &str, output: &str, refresh_mode: RefreshMode) {
+pub fn update(port: &impl CachePort, repo_id: &RepoId, output: &str, refresh_mode: RefreshMode) {
     port.update(repo_id, output, refresh_mode);
 }

--- a/src/contexts/daemon/domain/cache.rs
+++ b/src/contexts/daemon/domain/cache.rs
@@ -201,7 +201,7 @@ impl CacheEntry {
 /// キャッシュの更新ポート
 pub trait CachePort {
     /// キャッシュを更新する。失敗は静かに無視する。
-    fn update(&self, repo_id: &str, output: &str, refresh_mode: RefreshMode);
+    fn update(&self, repo_id: &RepoId, output: &str, refresh_mode: RefreshMode);
 }
 
 #[cfg(test)]

--- a/src/contexts/daemon/domain/cache.rs
+++ b/src/contexts/daemon/domain/cache.rs
@@ -1,3 +1,6 @@
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
 /// daemon がキャッシュエントリのリフレッシュ頻度を制御するモード。
 /// evaluation コンテキストの知識（CI 状態・終端状態）を抽象化した daemon 固有の概念。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -8,6 +11,191 @@ pub enum RefreshMode {
     Warm,
     /// PR が merged / closed。リフレッシュ不要。
     Terminal,
+}
+
+/// リポジトリとブランチの組み合わせを識別する値オブジェクト。
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RepoId(String);
+
+impl RepoId {
+    pub fn new(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<String> for RepoId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<RepoId> for String {
+    fn from(r: RepoId) -> Self {
+        r.0
+    }
+}
+
+impl std::fmt::Display for RepoId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// キャッシュエントリのドメインエンティティ。
+///
+/// 1 リポジトリ＋ブランチに対応するキャッシュ状態を保持し、
+/// 状態遷移（update・mark_refreshing・record_query 等）と
+/// 状態クエリ（is_active・is_fresh・is_expired 等）を提供する。
+pub struct CacheEntry {
+    output: String,
+    has_fetched: bool,
+    pub(crate) fetched_at: Instant,
+    refreshing: bool,
+    pub(crate) refresh_started_at: Option<Instant>,
+    cwd: PathBuf,
+    refresh_mode: RefreshMode,
+    pub(crate) last_queried_at: Option<Instant>,
+    cold_refresh_count: u32,
+}
+
+impl CacheEntry {
+    /// 初回ミス時に生成する新規エントリ。即リフレッシュ済み状態でマークする。
+    ///
+    /// `stale_ttl` は `fetched_at` を TTL 超過済みの過去時刻にセットするために使う。
+    pub fn new(cwd: PathBuf, stale_ttl: u64) -> Self {
+        let past = Instant::now()
+            .checked_sub(Duration::from_secs(stale_ttl.saturating_add(1)))
+            .unwrap_or_else(Instant::now);
+        Self {
+            output: String::new(),
+            has_fetched: false,
+            fetched_at: past,
+            refreshing: true,
+            refresh_started_at: Some(Instant::now()),
+            cwd,
+            refresh_mode: RefreshMode::Warm,
+            last_queried_at: Some(Instant::now()),
+            cold_refresh_count: 0,
+        }
+    }
+
+    // ── 状態遷移 ──────────────────────────────────────────────────────────────
+
+    /// バックグラウンドワーカーの取得結果でエントリを更新する。
+    pub fn update(&mut self, output: String, refresh_mode: RefreshMode) {
+        self.output = output;
+        self.has_fetched = true;
+        self.fetched_at = Instant::now();
+        self.refreshing = false;
+        self.refresh_started_at = None;
+        self.refresh_mode = refresh_mode;
+    }
+
+    /// リフレッシュ開始をマークする。
+    pub fn mark_refreshing(&mut self) {
+        self.refreshing = true;
+        self.refresh_started_at = Some(Instant::now());
+    }
+
+    /// Query 受付時刻を記録する（Cold 判定・Hot 昇格の基準）。
+    pub fn record_query(&mut self) {
+        self.last_queried_at = Some(Instant::now());
+    }
+
+    /// Cold カウンタをリセットする（Query で Warm に戻ったとき）。
+    pub fn reset_cold_count(&mut self) {
+        self.cold_refresh_count = 0;
+    }
+
+    /// Cold カウンタをインクリメントする（Cold モードでリフレッシュするとき）。
+    pub fn increment_cold_count(&mut self) {
+        self.cold_refresh_count = self.cold_refresh_count.saturating_add(1);
+    }
+
+    /// Terminal → Warm にリセットする（PR 再オープン検知時）。
+    pub fn reset_to_warm(&mut self) {
+        self.refresh_mode = RefreshMode::Warm;
+    }
+
+    /// リフレッシュロックを解除する（タイムアウト時）。
+    pub fn clear_refresh_lock(&mut self) {
+        self.refreshing = false;
+        self.refresh_started_at = None;
+    }
+
+    // ── アクセサ ──────────────────────────────────────────────────────────────
+
+    pub fn output(&self) -> &str {
+        &self.output
+    }
+
+    pub fn has_fetched(&self) -> bool {
+        self.has_fetched
+    }
+
+    pub fn cwd(&self) -> &std::path::Path {
+        &self.cwd
+    }
+
+    pub fn refresh_mode(&self) -> RefreshMode {
+        self.refresh_mode
+    }
+
+    pub fn is_refreshing(&self) -> bool {
+        self.refreshing
+    }
+
+    pub fn cold_refresh_count(&self) -> u32 {
+        self.cold_refresh_count
+    }
+
+    // ── 状態クエリ ────────────────────────────────────────────────────────────
+
+    /// 出力が存在し Terminal でないとき active とみなす（バックグラウンドリフレッシュ対象）。
+    pub fn is_active(&self) -> bool {
+        !self.output.is_empty() && self.refresh_mode != RefreshMode::Terminal
+    }
+
+    /// `fetched_at` から `ttl` 秒以内なら fresh とみなす。
+    pub fn is_fresh(&self, ttl: u64) -> bool {
+        self.fetched_at.elapsed().as_secs() <= ttl
+    }
+
+    /// `last_queried_at` から `max_age_secs` 以上経過したエントリを削除対象とみなす。
+    pub fn is_expired(&self, max_age_secs: u64) -> bool {
+        self.last_queried_at
+            .is_some_and(|t| t.elapsed().as_secs() >= max_age_secs)
+    }
+
+    /// リフレッシュ開始から `timeout_secs` 以上経過したらロック切れとみなす。
+    pub fn refresh_lock_expired(&self, timeout_secs: u64) -> bool {
+        self.refresh_started_at
+            .is_some_and(|started| started.elapsed().as_secs() >= timeout_secs)
+    }
+
+    /// `last_queried_at` が未設定、または `warm_to_cold_secs` 以上経過していれば Cold とみなす。
+    ///
+    /// `record_query()` を呼ぶ前に評価すること（呼び後は必ず false になる）。
+    pub fn is_cold_or_never_queried(&self, warm_to_cold_secs: u64) -> bool {
+        self.last_queried_at
+            .is_none_or(|t| t.elapsed().as_secs() >= warm_to_cold_secs)
+    }
+
+    /// `last_queried_at` が `recent_secs` 以内なら recent とみなす（Hot 昇格判定）。
+    pub fn has_recent_query(&self, recent_secs: u64) -> bool {
+        self.last_queried_at
+            .is_some_and(|t| t.elapsed().as_secs() <= recent_secs)
+    }
+
+    /// `last_queried_at` が `warm_to_cold_secs` 以上経過しているか（is_cold のエイリアス）。
+    pub fn is_cold(&self, warm_to_cold_secs: u64) -> bool {
+        self.last_queried_at
+            .is_some_and(|t| t.elapsed().as_secs() >= warm_to_cold_secs)
+    }
 }
 
 /// キャッシュの更新ポート

--- a/src/contexts/daemon/domain/cache.rs
+++ b/src/contexts/daemon/domain/cache.rs
@@ -56,10 +56,10 @@ pub struct CacheEntry {
     pub(crate) fetched_at: Instant,
     refreshing: bool,
     pub(crate) refresh_started_at: Option<Instant>,
-    cwd: PathBuf,
+    pub(crate) cwd: PathBuf,
     refresh_mode: RefreshMode,
     pub(crate) last_queried_at: Option<Instant>,
-    cold_refresh_count: u32,
+    pub(crate) cold_refresh_count: u32,
 }
 
 impl CacheEntry {

--- a/src/contexts/daemon/domain/cache.rs
+++ b/src/contexts/daemon/domain/cache.rs
@@ -46,10 +46,6 @@ impl std::fmt::Display for RepoId {
 }
 
 /// キャッシュエントリのドメインエンティティ。
-///
-/// 1 リポジトリ＋ブランチに対応するキャッシュ状態を保持し、
-/// 状態遷移（update・mark_refreshing・record_query 等）と
-/// 状態クエリ（is_active・is_fresh・is_expired 等）を提供する。
 pub struct CacheEntry {
     output: String,
     has_fetched: bool,
@@ -191,7 +187,7 @@ impl CacheEntry {
             .is_some_and(|t| t.elapsed().as_secs() <= recent_secs)
     }
 
-    /// `last_queried_at` が `warm_to_cold_secs` 以上経過しているか（is_cold のエイリアス）。
+    /// `last_queried_at` が `warm_to_cold_secs` 以上経過しているか（queried 前提版、never queried は false）。
     pub fn is_cold(&self, warm_to_cold_secs: u64) -> bool {
         self.last_queried_at
             .is_some_and(|t| t.elapsed().as_secs() >= warm_to_cold_secs)
@@ -399,11 +395,7 @@ mod tests {
     #[test]
     fn stale_query_outside_threshold() {
         let mut e = make_entry("out", RefreshMode::Warm);
-        e.last_queried_at = Some(
-            Instant::now()
-                .checked_sub(Duration::from_secs(31))
-                .unwrap(),
-        );
+        e.last_queried_at = Some(Instant::now().checked_sub(Duration::from_secs(31)).unwrap());
         assert!(!e.has_recent_query(30));
     }
 

--- a/src/contexts/daemon/domain/cache.rs
+++ b/src/contexts/daemon/domain/cache.rs
@@ -15,3 +15,226 @@ pub trait CachePort {
     /// キャッシュを更新する。失敗は静かに無視する。
     fn update(&self, repo_id: &str, output: &str, refresh_mode: RefreshMode);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::time::{Duration, Instant};
+
+    fn make_entry(output: &str, refresh_mode: RefreshMode) -> CacheEntry {
+        let mut e = CacheEntry::new(PathBuf::new(), 5);
+        e.update(output.to_owned(), refresh_mode);
+        e.record_query();
+        e
+    }
+
+    fn make_stale_entry(output: &str, refresh_mode: RefreshMode, age_secs: u64) -> CacheEntry {
+        let mut e = make_entry(output, refresh_mode);
+        e.fetched_at = Instant::now()
+            .checked_sub(Duration::from_secs(age_secs))
+            .unwrap_or_else(Instant::now);
+        e
+    }
+
+    // ── RepoId ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn repo_id_as_str_returns_inner() {
+        let id = RepoId::new("abc123");
+        assert_eq!(id.as_str(), "abc123");
+    }
+
+    #[test]
+    fn repo_id_equality() {
+        assert_eq!(RepoId::new("a"), RepoId::new("a"));
+        assert_ne!(RepoId::new("a"), RepoId::new("b"));
+    }
+
+    #[test]
+    fn repo_id_from_and_into_string() {
+        let id = RepoId::from("test".to_owned());
+        assert_eq!(id.as_str(), "test");
+        let s: String = RepoId::new("test").into();
+        assert_eq!(s, "test");
+    }
+
+    // ── CacheEntry::new ───────────────────────────────────────────────────────
+
+    #[test]
+    fn new_entry_starts_refreshing() {
+        let e = CacheEntry::new(PathBuf::new(), 5);
+        assert!(e.is_refreshing());
+    }
+
+    #[test]
+    fn new_entry_has_not_fetched() {
+        let e = CacheEntry::new(PathBuf::new(), 5);
+        assert!(!e.has_fetched());
+    }
+
+    #[test]
+    fn new_entry_is_stale() {
+        let e = CacheEntry::new(PathBuf::new(), 5);
+        assert!(!e.is_fresh(5));
+    }
+
+    // ── CacheEntry::update ────────────────────────────────────────────────────
+
+    #[test]
+    fn update_clears_refreshing_and_sets_has_fetched() {
+        let mut e = CacheEntry::new(PathBuf::new(), 5);
+        e.update("out".to_owned(), RefreshMode::Warm);
+        assert!(!e.is_refreshing());
+        assert!(e.has_fetched());
+    }
+
+    #[test]
+    fn update_sets_fresh() {
+        let mut e = CacheEntry::new(PathBuf::new(), 5);
+        e.update("out".to_owned(), RefreshMode::Warm);
+        assert!(e.is_fresh(5));
+    }
+
+    #[test]
+    fn update_sets_refresh_mode() {
+        let mut e = make_entry("out", RefreshMode::Warm);
+        e.update(String::new(), RefreshMode::Terminal);
+        assert_eq!(e.refresh_mode(), RefreshMode::Terminal);
+    }
+
+    // ── CacheEntry::is_active ─────────────────────────────────────────────────
+
+    #[test]
+    fn active_when_non_empty_and_warm() {
+        assert!(make_entry("✓ Ready", RefreshMode::Warm).is_active());
+    }
+
+    #[test]
+    fn active_when_hot() {
+        assert!(make_entry("⧖ CI", RefreshMode::Hot).is_active());
+    }
+
+    #[test]
+    fn inactive_when_empty_output() {
+        assert!(!make_entry("", RefreshMode::Warm).is_active());
+    }
+
+    #[test]
+    fn inactive_when_terminal() {
+        assert!(!make_entry("✓ Ready", RefreshMode::Terminal).is_active());
+    }
+
+    // ── CacheEntry::reset_to_warm ─────────────────────────────────────────────
+
+    #[test]
+    fn reset_to_warm_from_terminal() {
+        let mut e = make_entry("out", RefreshMode::Terminal);
+        e.reset_to_warm();
+        assert_eq!(e.refresh_mode(), RefreshMode::Warm);
+    }
+
+    // ── CacheEntry::cold_count ────────────────────────────────────────────────
+
+    #[test]
+    fn increment_and_reset_cold_count() {
+        let mut e = make_entry("out", RefreshMode::Warm);
+        assert_eq!(e.cold_refresh_count(), 0);
+        e.increment_cold_count();
+        e.increment_cold_count();
+        assert_eq!(e.cold_refresh_count(), 2);
+        e.reset_cold_count();
+        assert_eq!(e.cold_refresh_count(), 0);
+    }
+
+    // ── CacheEntry::is_expired ────────────────────────────────────────────────
+
+    #[test]
+    fn recently_queried_entry_is_not_expired() {
+        let e = make_entry("out", RefreshMode::Warm);
+        assert!(!e.is_expired(3600));
+    }
+
+    #[test]
+    fn old_query_entry_is_expired() {
+        let mut e = make_entry("out", RefreshMode::Warm);
+        e.last_queried_at = Some(
+            Instant::now()
+                .checked_sub(Duration::from_secs(3601))
+                .unwrap(),
+        );
+        assert!(e.is_expired(3600));
+    }
+
+    // ── CacheEntry::refresh_lock_expired ──────────────────────────────────────
+
+    #[test]
+    fn fresh_lock_is_not_expired() {
+        let e = CacheEntry::new(PathBuf::new(), 5);
+        assert!(!e.refresh_lock_expired(120));
+    }
+
+    #[test]
+    fn old_lock_is_expired() {
+        let mut e = CacheEntry::new(PathBuf::new(), 5);
+        e.refresh_started_at = Some(
+            Instant::now()
+                .checked_sub(Duration::from_secs(121))
+                .unwrap(),
+        );
+        assert!(e.refresh_lock_expired(120));
+    }
+
+    // ── CacheEntry::is_cold_or_never_queried ──────────────────────────────────
+
+    #[test]
+    fn never_queried_is_cold() {
+        let mut e = CacheEntry::new(PathBuf::new(), 5);
+        e.last_queried_at = None;
+        assert!(e.is_cold_or_never_queried(1800));
+    }
+
+    #[test]
+    fn recently_queried_is_not_cold() {
+        let e = make_entry("out", RefreshMode::Warm);
+        assert!(!e.is_cold_or_never_queried(1800));
+    }
+
+    // ── CacheEntry::has_recent_query ──────────────────────────────────────────
+
+    #[test]
+    fn recent_query_within_threshold() {
+        let e = make_entry("out", RefreshMode::Warm);
+        assert!(e.has_recent_query(30));
+    }
+
+    #[test]
+    fn stale_query_outside_threshold() {
+        let mut e = make_entry("out", RefreshMode::Warm);
+        e.last_queried_at = Some(
+            Instant::now()
+                .checked_sub(Duration::from_secs(31))
+                .unwrap(),
+        );
+        assert!(!e.has_recent_query(30));
+    }
+
+    // ── make_stale_entry (infra tests でも使う共通パターンの検証) ─────────────
+
+    #[test]
+    fn stale_entry_is_not_fresh() {
+        let e = make_stale_entry("out", RefreshMode::Hot, 9999);
+        assert!(!e.is_fresh(5));
+    }
+
+    // ── CacheEntry::clear_refresh_lock ────────────────────────────────────────
+
+    #[test]
+    fn clear_refresh_lock_resets_refreshing() {
+        let mut e = CacheEntry::new(PathBuf::new(), 5);
+        assert!(e.is_refreshing());
+        e.clear_refresh_lock();
+        assert!(!e.is_refreshing());
+        assert!(!e.refresh_lock_expired(120));
+    }
+}

--- a/src/contexts/daemon/infrastructure/daemon_client.rs
+++ b/src/contexts/daemon/infrastructure/daemon_client.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use super::paths;
 use super::protocol::{Request, Response};
-use crate::contexts::daemon::domain::cache::CachePort;
+use crate::contexts::daemon::domain::cache::{CachePort, RepoId};
 
 /// デーモンソケットへの接続タイムアウト（ms）
 const READ_TIMEOUT_MS: u64 = 500;
@@ -14,12 +14,12 @@ pub struct DaemonClient;
 impl CachePort for DaemonClient {
     fn update(
         &self,
-        repo_id: &str,
+        repo_id: &RepoId,
         output: &str,
         refresh_mode: crate::contexts::daemon::domain::cache::RefreshMode,
     ) {
         let _ = Self::send(&Request::Update {
-            repo_id: repo_id.to_owned(),
+            repo_id: repo_id.as_str().to_owned(),
             output: output.to_owned(),
             refresh_mode,
         });

--- a/src/contexts/daemon/infrastructure/daemon_server.rs
+++ b/src/contexts/daemon/infrastructure/daemon_server.rs
@@ -11,7 +11,7 @@ use super::paths;
 use super::pid;
 use super::protocol::{Request, Response};
 use super::repo_id;
-use crate::contexts::daemon::domain::cache::RefreshMode;
+use crate::contexts::daemon::domain::cache::{CacheEntry, RefreshMode};
 
 const DEFAULT_STALE_TTL_SECS: u64 = 5;
 const DEFAULT_REFRESH_LOCK_TIMEOUT_SECS: u64 = 120;
@@ -48,21 +48,6 @@ const DEFAULT_COLD_EARLY_LIMIT: u32 = 10;
 // ── エントリ寿命 ──────────────────────────────────────────────────────────────
 /// 最終 Query から この秒数が経過したエントリを削除する（2 日）
 const DEFAULT_ENTRY_MAX_AGE_SECS: u64 = 2 * 24 * 60 * 60;
-
-struct CacheEntry {
-    output: String,
-    has_fetched: bool,
-    fetched_at: Instant,
-    refreshing: bool,
-    refresh_started_at: Option<Instant>,
-    cwd: PathBuf,
-    /// 評価コンテキストから渡されたリフレッシュモード
-    refresh_mode: RefreshMode,
-    /// 最後に Query を受け付けた時刻（Cold 判定・Hot 昇格に使用）
-    last_queried_at: Option<Instant>,
-    /// Cold モードでのリフレッシュ累計回数（初期→後期の切り替え判定）
-    cold_refresh_count: u32,
-}
 
 struct DaemonState {
     entries: HashMap<String, CacheEntry>,
@@ -320,7 +305,7 @@ fn process(request: &Request, state: &Arc<Mutex<DaemonState>>) -> ActionResult {
 fn effective_ttl(entry: &CacheEntry, base_ttl: u64) -> u64 {
     // Terminal エントリは Query 起点のリフレッシュを Warm 間隔で許容する
     // （PR が再オープンされた場合に検知できるようにする）
-    if entry.refresh_mode == RefreshMode::Terminal {
+    if entry.refresh_mode() == RefreshMode::Terminal {
         warm_refresh_secs()
     } else {
         base_ttl
@@ -335,12 +320,12 @@ fn process_query(
     entries: &mut HashMap<String, CacheEntry>,
 ) -> ActionResult {
     match entries.get_mut(repo_id) {
-        Some(entry) if entry.fetched_at.elapsed().as_secs() <= effective_ttl(entry, ttl) => {
+        Some(entry) if entry.is_fresh(effective_ttl(entry, ttl)) => {
             // Fresh キャッシュ
-            entry.last_queried_at = Some(Instant::now());
+            entry.record_query();
             ActionResult {
                 response: Response::Output {
-                    output: entry.output.clone(),
+                    output: entry.output().to_owned(),
                 },
                 refresh_repo_id: None,
                 refresh_cwd: None,
@@ -350,23 +335,21 @@ fn process_query(
         }
         Some(entry) => {
             // Stale または TTL 超過
-            let output = entry.output.clone();
-            let has_fetched = entry.has_fetched;
-            let stored_cwd = entry.cwd.clone();
-            let need_refresh = !entry.refreshing;
-            let refreshing_now = entry.refreshing;
-            let is_terminal = entry.refresh_mode == RefreshMode::Terminal;
+            let output = entry.output().to_owned();
+            let has_fetched = entry.has_fetched();
+            let stored_cwd = entry.cwd().to_path_buf();
+            let need_refresh = !entry.is_refreshing();
+            let refreshing_now = entry.is_refreshing();
+            let is_terminal = entry.refresh_mode() == RefreshMode::Terminal;
             // Query を受けたので last_queried_at を更新し Cold カウンタをリセット
-            let was_cold = entry
-                .last_queried_at
-                .is_none_or(|t| t.elapsed().as_secs() >= warm_to_cold_secs());
+            let was_cold = entry.is_cold_or_never_queried(warm_to_cold_secs());
             if was_cold {
-                entry.cold_refresh_count = 0;
+                entry.reset_cold_count();
             }
-            entry.last_queried_at = Some(Instant::now());
+            entry.record_query();
             if is_terminal && need_refresh {
                 // Terminal が stale になったらモードをリセットして再確認
-                entry.refresh_mode = RefreshMode::Warm;
+                entry.reset_to_warm();
             }
             process_stale_query(
                 repo_id,
@@ -383,23 +366,7 @@ fn process_query(
         }
         None => {
             // 初回 Miss → エントリを作成してリフレッシュ予約
-            let past = Instant::now()
-                .checked_sub(Duration::from_secs(ttl.saturating_add(1)))
-                .unwrap_or_else(Instant::now);
-            entries.insert(
-                repo_id.to_owned(),
-                CacheEntry {
-                    output: String::new(),
-                    has_fetched: false,
-                    fetched_at: past,
-                    refreshing: true,
-                    refresh_started_at: Some(Instant::now()),
-                    cwd: cwd_path.clone(),
-                    refresh_mode: RefreshMode::Warm,
-                    last_queried_at: Some(Instant::now()),
-                    cold_refresh_count: 0,
-                },
-            );
+            entries.insert(repo_id.to_owned(), CacheEntry::new(cwd_path.clone(), ttl));
             ActionResult {
                 response: Response::Output {
                     output: "? loading".to_owned(),
@@ -500,18 +467,6 @@ fn env_u64(key: &str, default: u64) -> u64 {
 
 // ── リフレッシュ間隔計算 ──────────────────────────────────────────────────────
 
-fn is_recent_query(entry: &CacheEntry) -> bool {
-    entry
-        .last_queried_at
-        .is_some_and(|t| t.elapsed().as_secs() <= hot_recent_query_secs())
-}
-
-fn is_cold_mode(entry: &CacheEntry) -> bool {
-    entry
-        .last_queried_at
-        .is_some_and(|t| t.elapsed().as_secs() >= warm_to_cold_secs())
-}
-
 fn cold_interval_secs(count: u32) -> u64 {
     if count < cold_early_limit() {
         cold_early_secs()
@@ -522,21 +477,21 @@ fn cold_interval_secs(count: u32) -> u64 {
 
 /// エントリの現在の状態からリフレッシュ間隔（秒）を計算する。
 fn effective_refresh_interval_secs(entry: &CacheEntry) -> u64 {
-    match entry.refresh_mode {
+    match entry.refresh_mode() {
         RefreshMode::Terminal => u64::MAX,
         RefreshMode::Hot => {
-            if is_recent_query(entry) {
+            if entry.has_recent_query(hot_recent_query_secs()) {
                 hot_with_query_secs()
             } else {
                 hot_without_query_secs()
             }
         }
         RefreshMode::Warm => {
-            if is_recent_query(entry) {
+            if entry.has_recent_query(hot_recent_query_secs()) {
                 // Warm + 最近 Query → Hot 相当
                 hot_with_query_secs()
-            } else if is_cold_mode(entry) {
-                cold_interval_secs(entry.cold_refresh_count)
+            } else if entry.is_cold(warm_to_cold_secs()) {
+                cold_interval_secs(entry.cold_refresh_count())
             } else {
                 warm_refresh_secs()
             }
@@ -545,11 +500,6 @@ fn effective_refresh_interval_secs(entry: &CacheEntry) -> u64 {
 }
 
 // ── 内部処理ヘルパー ──────────────────────────────────────────────────────────
-
-fn mark_refreshing(entry: &mut CacheEntry) {
-    entry.refreshing = true;
-    entry.refresh_started_at = Some(Instant::now());
-}
 
 #[allow(clippy::struct_excessive_bools)]
 struct StaleQueryParams {
@@ -588,7 +538,7 @@ fn process_stale_query(
             };
         }
         if need_refresh {
-            mark_refreshing(entries.get_mut(repo_id).expect("entry exists"));
+            entries.get_mut(repo_id).expect("entry exists").mark_refreshing();
         }
         return ActionResult {
             response: Response::Output {
@@ -602,7 +552,7 @@ fn process_stale_query(
     }
 
     if need_refresh {
-        mark_refreshing(entries.get_mut(repo_id).expect("entry exists"));
+        entries.get_mut(repo_id).expect("entry exists").mark_refreshing();
     }
     ActionResult {
         response: Response::Output { output },
@@ -611,22 +561,6 @@ fn process_stale_query(
         stop: false,
         restart_after_response,
     }
-}
-
-fn is_active_entry(entry: &CacheEntry) -> bool {
-    !entry.output.is_empty() && entry.refresh_mode != RefreshMode::Terminal
-}
-
-fn refresh_lock_expired(entry: &CacheEntry) -> bool {
-    entry
-        .refresh_started_at
-        .is_some_and(|started| started.elapsed().as_secs() >= refresh_lock_timeout_secs())
-}
-
-fn entry_expired(entry: &CacheEntry) -> bool {
-    entry
-        .last_queried_at
-        .is_some_and(|t| t.elapsed().as_secs() >= entry_max_age_secs())
 }
 
 /// エントリは必ず `process_query`（Query 経由）で生成される。
@@ -639,12 +573,7 @@ fn process_update(
     entries: &mut HashMap<String, CacheEntry>,
 ) -> ActionResult {
     if let Some(entry) = entries.get_mut(repo_id) {
-        entry.output.clone_from(&output.to_owned());
-        entry.has_fetched = true;
-        entry.fetched_at = Instant::now();
-        entry.refreshing = false;
-        entry.refresh_started_at = None;
-        entry.refresh_mode = refresh_mode;
+        entry.update(output.to_owned(), refresh_mode);
     }
     ActionResult {
         response: Response::Ok,
@@ -661,18 +590,18 @@ fn collect_background_refresh_targets(state: &Arc<Mutex<DaemonState>>) -> Vec<(S
         .unwrap_or_else(std::sync::PoisonError::into_inner);
 
     // 期限切れエントリを削除
-    s.entries.retain(|_, entry| !entry_expired(entry));
+    s.entries
+        .retain(|_, entry| !entry.is_expired(entry_max_age_secs()));
 
     let mut targets = Vec::new();
     for (repo_id, entry) in &mut s.entries {
-        if !is_active_entry(entry) {
+        if !entry.is_active() {
             continue;
         }
-        if entry.refreshing && refresh_lock_expired(entry) {
-            entry.refreshing = false;
-            entry.refresh_started_at = None;
+        if entry.is_refreshing() && entry.refresh_lock_expired(refresh_lock_timeout_secs()) {
+            entry.clear_refresh_lock();
         }
-        if entry.refreshing {
+        if entry.is_refreshing() {
             continue;
         }
         let interval = effective_refresh_interval_secs(entry);
@@ -680,10 +609,10 @@ fn collect_background_refresh_targets(state: &Arc<Mutex<DaemonState>>) -> Vec<(S
             continue;
         }
         // Cold モードでリフレッシュする場合はカウンタを進める
-        if entry.refresh_mode == RefreshMode::Warm && is_cold_mode(entry) {
-            entry.cold_refresh_count = entry.cold_refresh_count.saturating_add(1);
+        if entry.refresh_mode() == RefreshMode::Warm && entry.is_cold(warm_to_cold_secs()) {
+            entry.increment_cold_count();
         }
-        mark_refreshing(entry);
+        entry.mark_refreshing();
         targets.push((repo_id.clone(), entry.cwd.clone()));
     }
 
@@ -695,57 +624,40 @@ mod tests {
     use super::*;
 
     fn make_entry(output: &str, refresh_mode: RefreshMode) -> CacheEntry {
-        CacheEntry {
-            output: output.to_owned(),
-            has_fetched: true,
-            fetched_at: Instant::now(),
-            refreshing: false,
-            refresh_started_at: None,
-            cwd: PathBuf::new(),
-            refresh_mode,
-            last_queried_at: Some(Instant::now()),
-            cold_refresh_count: 0,
-        }
+        let mut e = CacheEntry::new(PathBuf::new(), 5);
+        e.update(output.to_owned(), refresh_mode);
+        e.record_query();
+        e
     }
 
     fn make_stale_entry(output: &str, refresh_mode: RefreshMode, age_secs: u64) -> CacheEntry {
-        CacheEntry {
-            fetched_at: Instant::now()
-                .checked_sub(Duration::from_secs(age_secs))
-                .unwrap_or_else(Instant::now),
-            ..make_entry(output, refresh_mode)
-        }
+        let mut e = make_entry(output, refresh_mode);
+        e.fetched_at = Instant::now()
+            .checked_sub(Duration::from_secs(age_secs))
+            .unwrap_or_else(Instant::now);
+        e
     }
 
-    // ── is_active_entry ────────────────────────────────────────────────────────
+    // ── is_active (via CacheEntry) ─────────────────────────────────────────────
 
     #[test]
     fn active_when_non_empty_output_and_warm() {
-        assert!(is_active_entry(&make_entry(
-            "✓ Ready for merge",
-            RefreshMode::Warm
-        )));
+        assert!(make_entry("✓ Ready for merge", RefreshMode::Warm).is_active());
     }
 
     #[test]
     fn active_when_hot() {
-        assert!(is_active_entry(&make_entry(
-            "⧖ Wait for CI",
-            RefreshMode::Hot
-        )));
+        assert!(make_entry("⧖ Wait for CI", RefreshMode::Hot).is_active());
     }
 
     #[test]
     fn inactive_when_empty_output() {
-        assert!(!is_active_entry(&make_entry("", RefreshMode::Warm)));
+        assert!(!make_entry("", RefreshMode::Warm).is_active());
     }
 
     #[test]
     fn inactive_when_terminal() {
-        assert!(!is_active_entry(&make_entry(
-            "✓ Ready for merge",
-            RefreshMode::Terminal
-        )));
+        assert!(!make_entry("✓ Ready for merge", RefreshMode::Terminal).is_active());
     }
 
     // ── process_update ─────────────────────────────────────────────────────────
@@ -758,7 +670,7 @@ mod tests {
             make_entry("✓ Ready for merge", RefreshMode::Warm),
         );
         process_update("repo", "", RefreshMode::Terminal, &mut entries);
-        assert_eq!(entries["repo"].refresh_mode, RefreshMode::Terminal);
+        assert_eq!(entries["repo"].refresh_mode(), RefreshMode::Terminal);
     }
 
     #[test]
@@ -769,7 +681,7 @@ mod tests {
             make_entry("✓ Ready for merge", RefreshMode::Warm),
         );
         process_update("repo", "⧖ Wait for CI", RefreshMode::Hot, &mut entries);
-        assert_eq!(entries["repo"].refresh_mode, RefreshMode::Hot);
+        assert_eq!(entries["repo"].refresh_mode(), RefreshMode::Hot);
     }
 
     #[test]
@@ -789,7 +701,7 @@ mod tests {
         let mut entries = HashMap::new();
         entries.insert("repo".to_owned(), make_entry("", RefreshMode::Terminal));
         process_update("repo", "✓ Ready for merge", RefreshMode::Warm, &mut entries);
-        assert_eq!(entries["repo"].refresh_mode, RefreshMode::Warm);
+        assert_eq!(entries["repo"].refresh_mode(), RefreshMode::Warm);
     }
 
     // ── effective_refresh_interval_secs ────────────────────────────────────────
@@ -916,7 +828,7 @@ mod tests {
         }
         collect_background_refresh_targets(&state);
         let s = state.lock().unwrap();
-        assert_eq!(s.entries["repo"].cold_refresh_count, 4);
+        assert_eq!(s.entries["repo"].cold_refresh_count(), 4);
     }
 
     #[test]

--- a/src/contexts/daemon/infrastructure/daemon_server.rs
+++ b/src/contexts/daemon/infrastructure/daemon_server.rs
@@ -538,7 +538,10 @@ fn process_stale_query(
             };
         }
         if need_refresh {
-            entries.get_mut(repo_id).expect("entry exists").mark_refreshing();
+            entries
+                .get_mut(repo_id)
+                .expect("entry exists")
+                .mark_refreshing();
         }
         return ActionResult {
             response: Response::Output {
@@ -552,7 +555,10 @@ fn process_stale_query(
     }
 
     if need_refresh {
-        entries.get_mut(repo_id).expect("entry exists").mark_refreshing();
+        entries
+            .get_mut(repo_id)
+            .expect("entry exists")
+            .mark_refreshing();
     }
     ActionResult {
         response: Response::Output { output },


### PR DESCRIPTION
Closes #201

## Summary

- `RepoId` 値オブジェクトを `domain/cache.rs` に新規定義（`String` のニュータイプ）
- `CacheEntry` ドメインエンティティを `domain/cache.rs` に新規定義し、状態遷移メソッド（`update` / `mark_refreshing` / `record_query` など）と状態クエリメソッド（`is_active` / `is_fresh` / `is_expired` など）を持たせる
- `daemon_server.rs` から private `CacheEntry` struct を削除し、domain エンティティに差し替え
- `CachePort::update` の `repo_id` 引数を `&str` → `&RepoId` に変更し、呼び出し側を全更新

## Test plan

- [x] `cargo test --bin merge-ready`（94テスト通過）
- [x] `cargo clippy --workspace -- -D warnings`（警告なし）
- [x] `cargo fmt --check --all`
- [x] `bash scripts/check-layer-deps.sh`（All layer dependency rules OK）

🤖 Generated with [Claude Code](https://claude.com/claude-code)