### PR TITLE
refactor: DaemonLifecyclePort から ExitCode と PID をドメイン外に移す

### DIFF
--- a/src/contexts/daemon/application/lifecycle.rs
+++ b/src/contexts/daemon/application/lifecycle.rs
@@ -1,12 +1,10 @@
-use std::process::ExitCode;
-
-use crate::contexts::daemon::domain::daemon::{DaemonLifecyclePort, DaemonStatus};
+use crate::contexts::daemon::domain::daemon::{DaemonError, DaemonLifecyclePort, DaemonStatus};
 
 pub trait Port: DaemonLifecyclePort {}
 impl<T> Port for T where T: DaemonLifecyclePort {}
 
 /// デーモンを起動するユースケース
-pub fn start(port: &impl Port) -> ExitCode {
+pub fn start(port: &impl Port) -> Result<(), DaemonError> {
     port.start()
 }
 

--- a/src/contexts/daemon/application/lifecycle.rs
+++ b/src/contexts/daemon/application/lifecycle.rs
@@ -17,3 +17,8 @@ pub fn stop(port: &impl Port) -> bool {
 pub fn get_status(port: &impl Port) -> Option<DaemonStatus> {
     port.get_status()
 }
+
+/// 実行中デーモンの PID を取得するユースケース
+pub fn get_pid(port: &impl Port) -> Option<u32> {
+    port.get_pid()
+}

--- a/src/contexts/daemon/domain/daemon.rs
+++ b/src/contexts/daemon/domain/daemon.rs
@@ -1,8 +1,12 @@
-use std::process::ExitCode;
+/// デーモン起動の失敗理由
+#[derive(Copy, Clone, Debug)]
+pub enum DaemonError {
+    AlreadyRunning,
+    Failure,
+}
 
 /// デーモンのステータス情報
 pub struct DaemonStatus {
-    pub pid: u32,
     pub entries: usize,
     pub uptime_secs: u64,
     pub version: String,
@@ -11,7 +15,7 @@ pub struct DaemonStatus {
 /// デーモンのライフサイクル管理ポート
 pub trait DaemonLifecyclePort {
     /// デーモンを起動する。アイドルタイムアウトまたは Stop リクエストで返る。
-    fn start(&self) -> ExitCode;
+    fn start(&self) -> Result<(), DaemonError>;
     /// デーモンを停止する。成功時は `true` を返す。
     fn stop(&self) -> bool;
     /// デーモンのステータスを取得する。起動していない場合は `None` を返す。

--- a/src/contexts/daemon/domain/daemon.rs
+++ b/src/contexts/daemon/domain/daemon.rs
@@ -20,4 +20,6 @@ pub trait DaemonLifecyclePort {
     fn stop(&self) -> bool;
     /// デーモンのステータスを取得する。起動していない場合は `None` を返す。
     fn get_status(&self) -> Option<DaemonStatus>;
+    /// 実行中デーモンの PID を返す。未起動の場合は `None` を返す。
+    fn get_pid(&self) -> Option<u32>;
 }

--- a/src/contexts/daemon/infrastructure/daemon_client.rs
+++ b/src/contexts/daemon/infrastructure/daemon_client.rs
@@ -31,14 +31,13 @@ impl DaemonClient {
         Self::send(&Request::Stop).is_ok()
     }
 
-    pub(super) fn status_raw() -> Option<(u32, usize, u64, String)> {
+    pub(super) fn status_raw() -> Option<(usize, u64, String)> {
         match Self::send(&Request::Status) {
             Ok(Response::Status {
-                pid,
                 entries,
                 uptime_secs,
                 version,
-            }) => Some((pid, entries, uptime_secs, version)),
+            }) => Some((entries, uptime_secs, version)),
             _ => None,
         }
     }

--- a/src/contexts/daemon/infrastructure/daemon_lifecycle.rs
+++ b/src/contexts/daemon/infrastructure/daemon_lifecycle.rs
@@ -1,7 +1,6 @@
-use std::process::ExitCode;
 use std::sync::Arc;
 
-use crate::contexts::daemon::domain::daemon::{DaemonLifecyclePort, DaemonStatus};
+use crate::contexts::daemon::domain::daemon::{DaemonError, DaemonLifecyclePort, DaemonStatus};
 
 use super::{daemon_client::DaemonClient, daemon_server, pid};
 
@@ -20,16 +19,16 @@ impl DaemonLifecycle {
 }
 
 impl DaemonLifecyclePort for DaemonLifecycle {
-    fn start(&self) -> ExitCode {
+    fn start(&self) -> Result<(), DaemonError> {
         if let Some(p) = pid::read() {
             if pid::is_alive(p) {
                 log::error!("daemon is already running (pid {p})");
                 eprintln!("merge-ready daemon is already running (pid {p})");
-                return ExitCode::FAILURE;
+                return Err(DaemonError::AlreadyRunning);
             }
             pid::remove();
         }
-        daemon_server::run(&self.on_refresh)
+        daemon_server::run(&self.on_refresh).map_err(|()| DaemonError::Failure)
     }
 
     fn stop(&self) -> bool {
@@ -51,8 +50,7 @@ impl DaemonLifecyclePort for DaemonLifecycle {
     }
 
     fn get_status(&self) -> Option<DaemonStatus> {
-        DaemonClient::status_raw().map(|(pid, entries, uptime_secs, version)| DaemonStatus {
-            pid,
+        DaemonClient::status_raw().map(|(entries, uptime_secs, version)| DaemonStatus {
             entries,
             uptime_secs,
             version,

--- a/src/contexts/daemon/infrastructure/daemon_lifecycle.rs
+++ b/src/contexts/daemon/infrastructure/daemon_lifecycle.rs
@@ -56,4 +56,8 @@ impl DaemonLifecyclePort for DaemonLifecycle {
             version,
         })
     }
+
+    fn get_pid(&self) -> Option<u32> {
+        pid::read().filter(|&p| pid::is_alive(p))
+    }
 }

--- a/src/contexts/daemon/infrastructure/daemon_server.rs
+++ b/src/contexts/daemon/infrastructure/daemon_server.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Write};
 use std::os::unix::net::UnixListener;
 use std::path::PathBuf;
-use std::process::ExitCode;
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -90,17 +89,14 @@ type RefreshFn = Arc<dyn Fn(&str, &std::path::Path) + Send + Sync + 'static>;
 /// デーモンのメインループ。ソケットをバインドして接続を待ち受ける。
 ///
 /// `on_refresh` はキャッシュ更新が必要になったときにスレッドで呼ばれる。
-/// Stop リクエストで `ExitCode` を返す。
-pub fn run(on_refresh: &RefreshFn) -> ExitCode {
+/// Stop リクエストで `Ok(())` を返す。
+pub fn run(on_refresh: &RefreshFn) -> Result<(), ()> {
     let socket_path = paths::socket_path();
     if let Some(parent) = socket_path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
 
-    let listener = match bind_socket(&socket_path) {
-        Ok(l) => l,
-        Err(code) => return code,
-    };
+    let listener = bind_socket(&socket_path)?;
 
     pid::write(std::process::id());
 
@@ -112,7 +108,7 @@ pub fn run(on_refresh: &RefreshFn) -> ExitCode {
     }
 
     let state = Arc::new(Mutex::new(DaemonState::new()));
-    let (exit_tx, exit_rx) = mpsc::channel::<ExitCode>();
+    let (exit_tx, exit_rx) = mpsc::channel::<()>();
 
     // 定期バックグラウンドリフレッシュ
     // SCHEDULER_TICK_SECS ごとに各エントリのリフレッシュ間隔を個別に評価する
@@ -134,8 +130,8 @@ pub fn run(on_refresh: &RefreshFn) -> ExitCode {
     listener.set_nonblocking(true).ok();
 
     loop {
-        if let Ok(code) = exit_rx.try_recv() {
-            return code;
+        if exit_rx.try_recv().is_ok() {
+            return Ok(());
         }
 
         match listener.accept() {
@@ -156,15 +152,15 @@ pub fn run(on_refresh: &RefreshFn) -> ExitCode {
     }
 
     cleanup();
-    ExitCode::SUCCESS
+    Ok(())
 }
 
-fn bind_socket(socket_path: &std::path::Path) -> Result<UnixListener, ExitCode> {
+fn bind_socket(socket_path: &std::path::Path) -> Result<UnixListener, ()> {
     match pid::read() {
         Some(p) if pid::is_alive(p) => {
             log::error!("daemon is already running (pid {p})");
             eprintln!("merge-ready daemon is already running (pid {p})");
-            return Err(ExitCode::FAILURE);
+            return Err(());
         }
         _ => {
             let _ = std::fs::remove_file(socket_path);
@@ -178,7 +174,7 @@ fn bind_socket(socket_path: &std::path::Path) -> Result<UnixListener, ExitCode> 
             Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
                 if retries >= BIND_RETRY_MAX {
                     log::error!("socket already in use after retries, giving up");
-                    return Err(ExitCode::SUCCESS);
+                    return Err(());
                 }
                 retries += 1;
                 std::thread::sleep(Duration::from_millis(BIND_RETRY_INTERVAL_MS));
@@ -186,7 +182,7 @@ fn bind_socket(socket_path: &std::path::Path) -> Result<UnixListener, ExitCode> 
             Err(e) => {
                 log::error!("failed to bind socket: {e}");
                 eprintln!("merge-ready daemon: failed to bind socket: {e}");
-                return Err(ExitCode::FAILURE);
+                return Err(());
             }
         }
     }
@@ -196,7 +192,7 @@ fn handle_client(
     mut stream: std::os::unix::net::UnixStream,
     state: &Arc<Mutex<DaemonState>>,
     on_refresh: &RefreshFn,
-    exit_tx: &mpsc::Sender<ExitCode>,
+    exit_tx: &mpsc::Sender<()>,
 ) {
     let mut buf = String::new();
     {
@@ -232,14 +228,14 @@ fn handle_client(
         std::thread::sleep(Duration::from_millis(RESTART_GRACE_MS));
         cleanup();
         spawn_self_as_daemon();
-        let _ = exit_tx.send(ExitCode::SUCCESS);
+        let _ = exit_tx.send(());
         return;
     }
 
     if stop {
         cleanup();
         std::thread::sleep(Duration::from_millis(50));
-        let _ = exit_tx.send(ExitCode::SUCCESS);
+        let _ = exit_tx.send(());
     }
 }
 
@@ -308,7 +304,6 @@ fn process(request: &Request, state: &Arc<Mutex<DaemonState>>) -> ActionResult {
             let entries = s.entries.len();
             ActionResult {
                 response: Response::Status {
-                    pid: std::process::id(),
                     entries,
                     uptime_secs,
                     version: env!("CARGO_PKG_VERSION").to_owned(),

--- a/src/contexts/daemon/infrastructure/protocol.rs
+++ b/src/contexts/daemon/infrastructure/protocol.rs
@@ -58,7 +58,6 @@ pub enum Response {
     },
     Ok,
     Status {
-        pid: u32,
         entries: usize,
         uptime_secs: u64,
         version: String,

--- a/src/contexts/daemon/interface/cli/daemon.rs
+++ b/src/contexts/daemon/interface/cli/daemon.rs
@@ -129,9 +129,10 @@ fn stop(port: &impl Port) -> ExitCode {
 fn status(port: &impl Port) -> ExitCode {
     match lifecycle::get_status(port) {
         Some(s) => {
+            let pid = lifecycle::get_pid(port).map_or_else(|| "-".to_owned(), |p| p.to_string());
             println!(
-                "running  entries={}  uptime={}s  version={}",
-                s.entries, s.uptime_secs, s.version
+                "running  pid={}  entries={}  uptime={}s  version={}",
+                pid, s.entries, s.uptime_secs, s.version
             );
         }
         None => println!("not running"),

--- a/src/contexts/daemon/interface/cli/daemon.rs
+++ b/src/contexts/daemon/interface/cli/daemon.rs
@@ -46,7 +46,10 @@ pub fn run(subcommand: DaemonCommand, port: &impl Port) -> ExitCode {
 // 次回 prompt 呼び出し時に lazy_start() が再起動するため実害はない。
 fn start(port: &impl Port) -> ExitCode {
     if std::env::var(DAEMON_INNER_ENV).is_ok() {
-        return lifecycle::start(port);
+        return match lifecycle::start(port) {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(_) => ExitCode::FAILURE,
+        };
     }
     let Ok(exe) = std::env::current_exe() else {
         eprintln!("merge-ready: failed to locate executable");
@@ -127,8 +130,8 @@ fn status(port: &impl Port) -> ExitCode {
     match lifecycle::get_status(port) {
         Some(s) => {
             println!(
-                "running  pid={}  entries={}  uptime={}s  version={}",
-                s.pid, s.entries, s.uptime_secs, s.version
+                "running  entries={}  uptime={}s  version={}",
+                s.entries, s.uptime_secs, s.version
             );
         }
         None => println!("not running"),

--- a/tests/e2e/daemon/lifecycle.rs
+++ b/tests/e2e/daemon/lifecycle.rs
@@ -272,3 +272,20 @@ fn test_concurrent_prompt_starts_only_one_daemon() {
         .output()
         .ok();
 }
+
+// ── #16: daemon status の出力フォーマット ────────────────────────────────────
+
+/// #16: `daemon status`（起動中）→ "running pid=<数字> entries=<数字> uptime=<数字>s version=<文字列>"
+#[test]
+fn test_daemon_status_format() {
+    let env = TestEnv::new(OPEN_PR_VIEW_JSON, Some(CI_PASS_JSON));
+    let _daemon = DaemonHandle::start(&env);
+
+    let mut cmd = Command::cargo_bin(BIN).unwrap();
+    env.apply(&mut cmd);
+    cmd.args(["daemon", "status"]);
+    cmd.assert().success().stdout(
+        predicate::str::is_match(r"^running  pid=\d+  entries=\d+  uptime=\d+s  version=.+\n$")
+            .unwrap(),
+    );
+}


### PR DESCRIPTION
## Summary

- `DaemonLifecyclePort::start()` の戻り値を `std::process::ExitCode` から `Result<(), DaemonError>` に変更し、Domain 層を OS 固有型から分離
- `DaemonStatus` の `pid: u32` フィールドを除去（プロセス ID は OS 固有の概念でありドメインモデルに含めない）
- `daemon_server::run()` を `Result<(), ()>` に変更してインフラ内部に ExitCode を閉じ込め、`ExitCode` への変換は Interface 層（`cli/daemon.rs`）で行う
- IPC プロトコル `Response::Status` からも `pid` を削除し、整合性を保つ

## Test plan

- [x] `cargo test --workspace` — 168 テスト全通過
- [x] `cargo clippy --workspace -- -D warnings` — 警告なし
- [x] `cargo fmt --check --all` — フォーマット問題なし
- [x] `cargo deny check` — 依存監査通過
- [x] `bash scripts/check-layer-deps.sh` — レイヤー依存ルール通過
- [x] `bash scripts/check-no-mod-rs.sh` — mod.rs なし

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)