### PR TITLE
refactor: IPC Protocol の Domain 型依存を DTO レイヤーで分離する

### DIFF
--- a/src/contexts/daemon/infrastructure/daemon_client.rs
+++ b/src/contexts/daemon/infrastructure/daemon_client.rs
@@ -3,25 +3,30 @@ use std::os::unix::net::UnixStream;
 use std::time::Duration;
 
 use super::paths;
-use super::protocol::{Request, Response};
-use crate::contexts::daemon::domain::cache::{CachePort, RepoId};
+use super::protocol::{RefreshModeDto, Request, Response};
+use crate::contexts::daemon::domain::cache::{CachePort, RefreshMode, RepoId};
 
 /// デーモンソケットへの接続タイムアウト（ms）
 const READ_TIMEOUT_MS: u64 = 500;
 
 pub struct DaemonClient;
 
+impl From<RefreshMode> for RefreshModeDto {
+    fn from(m: RefreshMode) -> Self {
+        match m {
+            RefreshMode::Hot => RefreshModeDto::Hot,
+            RefreshMode::Warm => RefreshModeDto::Warm,
+            RefreshMode::Terminal => RefreshModeDto::Terminal,
+        }
+    }
+}
+
 impl CachePort for DaemonClient {
-    fn update(
-        &self,
-        repo_id: &RepoId,
-        output: &str,
-        refresh_mode: crate::contexts::daemon::domain::cache::RefreshMode,
-    ) {
+    fn update(&self, repo_id: &RepoId, output: &str, refresh_mode: RefreshMode) {
         let _ = Self::send(&Request::Update {
             repo_id: repo_id.as_str().to_owned(),
             output: output.to_owned(),
-            refresh_mode,
+            refresh_mode: RefreshModeDto::from(refresh_mode),
         });
     }
 }

--- a/src/contexts/daemon/infrastructure/daemon_server.rs
+++ b/src/contexts/daemon/infrastructure/daemon_server.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 
 use super::paths;
 use super::pid;
-use super::protocol::{Request, Response};
+use super::protocol::{RefreshModeDto, Request, Response};
 use super::repo_id;
 use crate::contexts::daemon::domain::cache::{CacheEntry, RefreshMode};
 use crate::contexts::daemon::domain::refresh_policy::RefreshPolicy;
@@ -48,6 +48,16 @@ const DEFAULT_COLD_EARLY_LIMIT: u32 = 10;
 // ── エントリ寿命 ──────────────────────────────────────────────────────────────
 /// 最終 Query から この秒数が経過したエントリを削除する（2 日）
 const DEFAULT_ENTRY_MAX_AGE_SECS: u64 = 2 * 24 * 60 * 60;
+
+impl From<RefreshModeDto> for RefreshMode {
+    fn from(dto: RefreshModeDto) -> Self {
+        match dto {
+            RefreshModeDto::Hot => RefreshMode::Hot,
+            RefreshModeDto::Warm => RefreshMode::Warm,
+            RefreshModeDto::Terminal => RefreshMode::Terminal,
+        }
+    }
+}
 
 struct DaemonState {
     entries: HashMap<String, CacheEntry>,
@@ -291,7 +301,12 @@ fn process(request: &Request, state: &Arc<Mutex<DaemonState>>) -> ActionResult {
             repo_id,
             output,
             refresh_mode,
-        } => process_update(repo_id, output, *refresh_mode, &mut s.entries),
+        } => process_update(
+            repo_id,
+            output,
+            RefreshMode::from(*refresh_mode),
+            &mut s.entries,
+        ),
         Request::Stop => ActionResult {
             response: Response::Ok,
             refresh_repo_id: None,

--- a/src/contexts/daemon/infrastructure/protocol.rs
+++ b/src/contexts/daemon/infrastructure/protocol.rs
@@ -1,30 +1,13 @@
 use serde::{Deserialize, Serialize};
 
-use crate::contexts::daemon::domain::cache::RefreshMode;
-
-impl Serialize for RefreshMode {
-    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
-        match self {
-            RefreshMode::Hot => s.serialize_str("hot"),
-            RefreshMode::Warm => s.serialize_str("warm"),
-            RefreshMode::Terminal => s.serialize_str("terminal"),
-        }
-    }
-}
-
-impl<'de> Deserialize<'de> for RefreshMode {
-    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
-        let s = String::deserialize(d)?;
-        match s.as_str() {
-            "hot" => Ok(RefreshMode::Hot),
-            "warm" => Ok(RefreshMode::Warm),
-            "terminal" => Ok(RefreshMode::Terminal),
-            _ => Err(serde::de::Error::unknown_variant(
-                &s,
-                &["hot", "warm", "terminal"],
-            )),
-        }
-    }
+/// IPC ワイヤフォーマット上のリフレッシュモード DTO。
+/// Domain 層の `RefreshMode` とは独立して定義する。
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RefreshModeDto {
+    Hot,
+    Warm,
+    Terminal,
 }
 
 /// デーモンへ送信するリクエスト
@@ -41,7 +24,7 @@ pub enum Request {
     Update {
         repo_id: String,
         output: String,
-        refresh_mode: RefreshMode,
+        refresh_mode: RefreshModeDto,
     },
     Stop,
     Status,


### PR DESCRIPTION
Closes #203

## Summary

- `protocol.rs` に `RefreshModeDto` を追加し、Domain 層の `RefreshMode` への直接 import と serde 実装を除去
- `DaemonClient` に `From<RefreshMode> for RefreshModeDto` を実装し、Domain → IPC DTO 変換を明示化
- `DaemonServer` に `From<RefreshModeDto> for RefreshMode` を実装し、IPC DTO → Domain 変換を明示化

## Test plan

- [x] `cargo build` — コンパイル成功
- [x] `cargo test --workspace` — 169 テスト全通過
- [x] `cargo clippy --workspace -- -D warnings` — 警告なし
- [x] `cargo fmt --check --all` — フォーマット一致
- [x] `bash scripts/check-layer-deps.sh` — レイヤー依存ルール違反なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)