### PR TITLE
docs: README の出力トークン記述を実装に合わせて修正する

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ merge-ready-prompt
 Example output:
 
 ```text
-⚠ review
+⚠ Resolve review
 ```
 
 `merge-ready-prompt` returns:

--- a/README.md
+++ b/README.md
@@ -42,13 +42,7 @@ Example output:
 ⚠ Resolve review
 ```
 
-`merge-ready-prompt` returns:
-
-- `0` when mergeable (`✓ merge-ready`)
-- `1` when blocked (`⚠ ...` or `✗ ...`)
-- `2` when state cannot be determined (`? ...`)
-
-This makes it easy to use from shell scripts and prompt hooks.
+`merge-ready-prompt` prints a single status token to stdout and always exits with code `0`. Use the printed token text for conditional logic in shell scripts and prompt hooks.
 
 ## Output Tokens
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Example output:
 - `✗ Resolve conflict` - merge conflicts exist
 - `✗ Update branch` - branch is behind base branch
 - `? Check branch sync` - branch sync status is unknown
+- `? Check merge blocker` - PR is blocked for an unknown reason
 - `⧖ Wait for status` - GitHub is calculating merge status
 - `? loading` - cache miss; daemon is fetching in the background
 


### PR DESCRIPTION
## Summary

- `⚠ review` という古い example output を現在の出力形式 `⚠ Resolve review` に修正する (#209)
- `merge-ready-prompt` の exit code に関する誤った記述（0/1/2 を返すという仕様）を削除し、実際の動作（常に exit code `0`）を正確に記述する (#210)
- Output Tokens 一覧に `? Check merge blocker` を追加する（`blocked_unknown` トークンが実装・設定例には存在するが一覧から抜けていた）(#211)

## Test plan

- [ ] README を通読して記述の整合性を確認する
- [ ] `display_config.rs` のデフォルト値と Output Tokens 一覧・設定例が一致していることを確認する
- [ ] `src_prompt/main.rs` の実装と exit code の記述が一致していることを確認する

Closes #209
Closes #210
Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)