### PR TITLE
refactor: PrState::Unknown を廃止し全パターンを既存バリアントに収束させる

### DIFF
--- a/src/contexts/evaluation/application/prompt.rs
+++ b/src/contexts/evaluation/application/prompt.rs
@@ -18,10 +18,12 @@ where
 {
     let state = match repo.fetch() {
         Ok(s) => s,
-        Err(RepositoryError::NotFound) => PrState::Unknown,
+        Err(RepositoryError::NotFound) => PrState::NoPr,
         Err(e) => match into_token(e, logger) {
             Some(token) => return Err(token),
-            None => PrState::Unknown,
+            None => {
+                unreachable!("into_token returns None only for NotFound, which is handled above")
+            }
         },
     };
     let is_terminal = state.is_terminal();

--- a/src/contexts/evaluation/application/prompt/display_item.rs
+++ b/src/contexts/evaluation/application/prompt/display_item.rs
@@ -32,7 +32,7 @@ pub fn from_pr_state(state: PrState) -> Vec<DisplayItem> {
         PrState::NotApplicable(NotApplicableState::Calculating) => {
             vec![DisplayItem::StatusCalculating]
         }
-        PrState::NotApplicable(_) | PrState::Unknown => vec![],
+        PrState::NotApplicable(_) => vec![],
     }
 }
 

--- a/src/contexts/evaluation/domain/pr_state.rs
+++ b/src/contexts/evaluation/domain/pr_state.rs
@@ -3,6 +3,7 @@ pub mod not_applicable;
 pub mod unblocked;
 
 use blocked::BlockedState;
+use blocked::GenericBlockedState;
 use blocked::branch_sync::BranchSyncState;
 use blocked::ci::CiState;
 use blocked::review::ReviewState;
@@ -23,8 +24,6 @@ pub enum PrState {
     Unblocked(UnblockedState),
     /// 評価対象外（理由を保持）
     NotApplicable(NotApplicableState),
-    /// 全パターン不一致の暫定状態（#157 解決後に廃止予定）
-    Unknown,
 }
 
 impl PrState {
@@ -49,7 +48,7 @@ pub trait PrRepository {
 /// PR の評価状態を決定するビジネスルール
 ///
 /// blocker が1つでもあれば `Blocked`、なければ `Unblocked`（`unblocked` の値による）、
-/// それ以外は `Unknown`。
+/// それ以外は blocker 不明として `Blocked(BlockedUnknown)`。
 #[must_use]
 pub fn evaluate(
     branch_sync: Option<BranchSyncState>,
@@ -67,13 +66,19 @@ pub fn evaluate(
     } else if let Some(u) = unblocked {
         PrState::Unblocked(u)
     } else {
-        PrState::Unknown
+        PrState::Blocked(BlockedState {
+            branch_sync: None,
+            ci: None,
+            review: None,
+            generic: Some(GenericBlockedState::BlockedUnknown),
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use blocked::GenericBlockedState;
     use blocked::branch_sync::BranchSyncState;
     use blocked::ci::CiState;
     use blocked::review::ReviewState;
@@ -95,9 +100,15 @@ mod tests {
     }
 
     #[test]
-    fn returns_unknown_when_no_blockers_and_not_ready() {
+    fn returns_blocked_unknown_when_no_blockers_and_not_ready() {
         let state = evaluate(None, None, None, None);
-        assert!(matches!(state, PrState::Unknown));
+        let PrState::Blocked(blocked) = state else {
+            panic!("expected Blocked");
+        };
+        assert_eq!(blocked.generic, Some(GenericBlockedState::BlockedUnknown));
+        assert!(blocked.branch_sync.is_none());
+        assert!(blocked.ci.is_none());
+        assert!(blocked.review.is_none());
     }
 
     #[test]

--- a/src/contexts/evaluation/infrastructure/gh.rs
+++ b/src/contexts/evaluation/infrastructure/gh.rs
@@ -12,7 +12,6 @@ use schema::{
 
 use crate::contexts::evaluation::application::port::{ErrorCategory, ErrorLogger, LogRecord};
 use crate::contexts::evaluation::domain::error::RepositoryError;
-use crate::contexts::evaluation::domain::pr_state::blocked::GenericBlockedState;
 use crate::contexts::evaluation::domain::pr_state::blocked::branch_sync::BranchSyncState;
 use crate::contexts::evaluation::domain::pr_state::blocked::ci::CiState;
 use crate::contexts::evaluation::domain::pr_state::blocked::review::ReviewState;
@@ -157,27 +156,19 @@ impl<L: ErrorLogger + Sync> PrRepository for GhClient<L> {
         });
 
         let ci = ci_result?;
+
+        // GitHub がまだマージ可能性を計算中（他のシグナルより優先）
+        if matches!(
+            pr_view.merge_state_status.as_str(),
+            "MERGE_STATE_UNKNOWN" | "UNKNOWN"
+        ) {
+            return Ok(PrState::NotApplicable(NotApplicableState::Calculating));
+        }
+
         let review = translate_review(pr_view.review_decision.as_deref());
         let unblocked = translate_unblocked(pr_view.is_draft, &pr_view.merge_state_status);
 
-        let state = evaluate(branch_sync, ci, review, unblocked);
-        if matches!(state, PrState::Unknown) {
-            return Ok(match pr_view.merge_state_status.as_str() {
-                "MERGE_STATE_UNKNOWN" | "UNKNOWN" => {
-                    PrState::NotApplicable(NotApplicableState::Calculating)
-                }
-                "BLOCKED" => PrState::Blocked(
-                    crate::contexts::evaluation::domain::pr_state::blocked::BlockedState {
-                        branch_sync: None,
-                        ci: None,
-                        review: None,
-                        generic: Some(GenericBlockedState::BlockedUnknown),
-                    },
-                ),
-                _ => state,
-            });
-        }
-        Ok(state)
+        Ok(evaluate(branch_sync, ci, review, unblocked))
     }
 }
 


### PR DESCRIPTION
Closes #195

## Summary

- `PrState::Unknown` バリアントをコードベースから完全に削除した
- 全シグナルが `None` の場合（全パターン不一致）を `BlockedUnknown` に収束させた
- `MERGE_STATE_UNKNOWN` / `UNKNOWN` ステータスは `gh.rs` で早期リターンして `Calculating` を返すよう明示化した
- `RepositoryError::NotFound` を `prompt.rs` で `PrState::NoPr` に変換するよう修正した（意味的に正確）

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `domain/pr_state.rs` | `Unknown` バリアント削除・`evaluate()` の末尾を `BlockedUnknown` に変更・テスト更新 |
| `infrastructure/gh.rs` | `MERGE_STATE_UNKNOWN`/`UNKNOWN` を早期リターンで `Calculating` に・Unknown 再分類ブロック削除 |
| `application/prompt.rs` | `NotFound → PrState::NoPr`・`None → unreachable!()` に変更 |
| `application/prompt/display_item.rs` | `PrState::Unknown` パターン削除 |

## Test plan

- [x] `cargo test --workspace` — 171 tests passed
- [x] `cargo clippy --workspace -- -D warnings` — 警告ゼロ
- [x] `cargo fmt --check --all` — フォーマット OK
- [x] `cargo deny check` — 依存関係監査 OK
- [x] `bash scripts/check-layer-deps.sh` — DDD レイヤー依存 OK
- [x] `bash scripts/check-no-mod-rs.sh` — mod.rs 禁止 OK
- [x] `grep -rn "PrState::Unknown" src/` — 残存ゼロ確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)