### PR TITLE
fix: remove needless pass-by-value allow in cli::run

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,11 +24,10 @@ pub enum Command {
 }
 
 #[must_use]
-#[allow(clippy::needless_pass_by_value)]
-pub fn run(cli: Cli) -> ExitCode {
-    match cli.command {
+pub fn run(cli: &Cli) -> ExitCode {
+    match &cli.command {
         Some(Command::Config) => crate::config_command(),
-        Some(Command::Daemon(args)) => crate::daemon_command(args),
+        Some(Command::Daemon(args)) => crate::daemon_command(*args),
         None => {
             let _ = Cli::command().print_help();
             ExitCode::SUCCESS

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,5 +4,5 @@ use clap::Parser;
 
 fn main() -> ExitCode {
     let cli = merge_ready::cli::Cli::parse();
-    merge_ready::cli::run(cli)
+    merge_ready::cli::run(&cli)
 }


### PR DESCRIPTION
## Summary
- Change `cli::run` signature from `run(cli: Cli)` to `run(cli: &Cli)`.
- Match against `&cli.command` and pass through daemon args without ownership transfer.
- Update `main` entrypoint to call `merge_ready::cli::run(&cli)` and remove the now-unnecessary Clippy allow.

## Test plan
- [x] `cargo clippy --all-targets --all-features`
- [x] `cargo test`

Closes #221

Made with [Cursor](https://cursor.com)