### PR TITLE
feat: format フィールドで Starship 風の色・スタイル指定をサポートする

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,6 +527,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 name = "merge-ready"
 version = "0.5.3"
 dependencies = [
+ "anstyle",
  "assert_cmd",
  "clap",
  "criterion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,11 +527,11 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 name = "merge-ready"
 version = "0.5.3"
 dependencies = [
- "anstyle",
  "assert_cmd",
  "clap",
  "criterion",
  "log",
+ "nu-ansi-term",
  "predicates",
  "rstest",
  "serde",
@@ -546,6 +546,15 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "num-conv"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ unsafe_code = "forbid"
 pedantic = "warn"
 
 [dependencies]
+anstyle = "1"
 clap = { version = "4.6.1", features = ["derive", "cargo"] }
 log = "0.4"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ unsafe_code = "forbid"
 pedantic = "warn"
 
 [dependencies]
-anstyle = "1"
+nu-ansi-term = "0.50"
 clap = { version = "4.6.1", features = ["derive", "cargo"] }
 log = "0.4"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -112,71 +112,71 @@ All fields are optional — omitting any field falls back to the default shown b
 [merge_ready]
 symbol = "✓"
 label = "Ready for merge"
-# format = "$symbol $label"
+format = "[$symbol $label](bold green)"
 
 [no_pull_request]
 symbol = "+"
 label = "Create PR"
-# format = "$symbol $label"
+format = "[$symbol $label](cyan)"
 
 [conflict]
 symbol = "✗"
 label = "Resolve conflict"
-# format = "$symbol $label"
+format = "[$symbol $label](bold red)"
 
 [update_branch]
 symbol = "✗"
 label = "Update branch"
-# format = "$symbol $label"
+format = "[$symbol $label](yellow)"
 
-[sync_unknown]
-symbol = "?"
-label = "Check branch sync"
-# format = "$symbol $label"
+# [sync_unknown]
+# symbol = "?"
+# label = "Check branch sync"
+# format = "[$symbol $label](yellow)"
 
 [ci_fail]
 symbol = "✗"
 label = "Fix CI failure"
-# format = "$symbol $label"
+format = "[$symbol $label](bold red)"
 
-[ci_action]
-symbol = "⚠"
-label = "Run CI action"
-# format = "$symbol $label"
+# [ci_action]
+# symbol = "⚠"
+# label = "Run CI action"
+# format = "[$symbol $label](yellow)"
 
 [ci_pending]
 symbol = "⧖"
 label = "Wait for CI"
-# format = "$symbol $label"
+format = "[$symbol $label](cyan)"
 
 [changes_requested]
 symbol = "⚠"
 label = "Resolve review"
-# format = "$symbol $label"
+format = "[$symbol $label](yellow)"
 
 [review_required]
 symbol = "@"
 label = "Assign reviewer"
-# format = "$symbol $label"
+format = "[$symbol $label](cyan)"
 
 [draft]
 symbol = "✎"
 label = "Ready for review"
-# format = "$symbol $label"
+format = "[$symbol $label](dimmed)"
 
-[status_calculating]
-symbol = "⧖"
-label = "Wait for status"
-# format = "$symbol $label"
+# [status_calculating]
+# symbol = "⧖"
+# label = "Wait for status"
+# format = "[$symbol $label](dimmed)"
 
-[blocked_unknown]
-symbol = "?"
-label = "Check merge blocker"
-# format = "$symbol $label"
+# [blocked_unknown]
+# symbol = "?"
+# label = "Check merge blocker"
+# format = "[$symbol $label](yellow)"
 
 [error]
 symbol = "✗"
-# format = "$symbol $message"
+format = "[$symbol $message](bold red)"
 ```
 
 Each token supports three optional fields:

--- a/README.md
+++ b/README.md
@@ -87,13 +87,14 @@ command = "merge-ready-prompt"
 when = true
 require_repo = true
 shell = ["/bin/zsh"]
-format = "[$output]($style) "
-style = "bold yellow"
+format = "($output )"
 ```
 
 `require_repo = true` limits the module to git repositories without any shell command overhead. `merge-ready-prompt` itself returns `+ Create PR` when no pull request exists for the branch, so no additional filtering is needed.
 
 If your environment sets `STARSHIP_SHELL` to a slower shell (for example `fish`), custom modules can be noticeably slower due to shell startup cost. Pinning `shell = ["/bin/zsh"]` (or another lightweight shell on your system) keeps prompt latency low.
+
+> **Note:** Do not set `style` in the Starship custom module when using the `[text](style)` syntax in merge-ready's `format` field. Starship's `style` wraps the entire output in its own ANSI codes, and merge-ready's internal reset sequences will break that outer styling, causing subsequent prompt modules (e.g. `cmd_duration`) to lose their color.
 
 ## Configuration
 
@@ -192,6 +193,33 @@ The `[error]` section uses `$message` instead of `$label`. The message is set au
 |-------|-------------|---------|
 | `symbol` | Leading symbol | `"✗"` |
 | `format` | Output template | `"$symbol $message"` |
+
+### Style Strings
+
+The `format` field supports a [Starship-inspired](https://starship.rs/config/#style-strings) `[text](style)` syntax to apply ANSI colors and attributes:
+
+```toml
+[merge_ready]
+format = "[$symbol $label](bold green)"
+
+[ci_fail]
+format = "[$symbol](bold red) $label"
+
+[changes_requested]
+format = "[$symbol](yellow) $label"
+```
+
+Supported style specifiers:
+
+| Specifier | Examples |
+|-----------|---------|
+| Color names | `red`, `green`, `yellow`, `blue`, `cyan`, `purple`, `white`, `black` |
+| Bright colors | `bright-red`, `bright-green`, … |
+| Attributes | `bold`, `italic`, `underline`, `dimmed`, `inverted`, `blink`, `hidden`, `strikethrough` |
+| 256-color / truecolor | `fg:123`, `bg:255`, `fg:#ff8700` |
+| Disable all styles | `none` |
+
+Specifiers are case-insensitive and order-independent. Multiple specifiers are separated by spaces (e.g. `bold bright-green`).
 
 ## Requirements
 

--- a/src/contexts/evaluation/domain.rs
+++ b/src/contexts/evaluation/domain.rs
@@ -1,3 +1,5 @@
 pub mod display_config;
 pub mod error;
+pub(crate) mod format_parser;
 pub mod pr_state;
+pub(crate) mod style_spec;

--- a/src/contexts/evaluation/domain/display_config.rs
+++ b/src/contexts/evaluation/domain/display_config.rs
@@ -237,4 +237,46 @@ mod tests {
         let config = ErrorConfig::default();
         assert_eq!(render_error_token(&config, "oops"), "✗ oops");
     }
+
+    #[test]
+    fn render_token_text_after_style_is_reset() {
+        // `[$symbol](bold green) $label` のとき、$label はスタイルを引き継がない。
+        // nu-ansi-term は styled 部分の末尾に reset (\x1b[0m) を挿入するため
+        // それ以降の文字はデフォルトカラーになる。
+        let tok = TokenConfig {
+            symbol: "✓".to_owned(),
+            label: "Ready".to_owned(),
+            format: "[$symbol](bold green) $label".to_owned(),
+        };
+        let out = render_token(&tok);
+        let reset = "\x1b[0m";
+        let reset_pos = out
+            .find(reset)
+            .expect("reset sequence must exist after styled segment");
+        let label_pos = out.find("Ready").expect("label must exist in output");
+        assert!(
+            reset_pos < label_pos,
+            "reset must appear before the plain-text label: {out:?}"
+        );
+        let after_reset = &out[reset_pos + reset.len()..];
+        assert!(
+            !after_reset.contains("\x1b["),
+            "no ANSI codes should follow the reset: {out:?}"
+        );
+    }
+
+    #[test]
+    fn render_token_plain_format_identical_to_simple_replace() {
+        // 後方互換: スタイル構文なしの format は単純置換と完全一致する。
+        let tok = TokenConfig {
+            symbol: "✓".to_owned(),
+            label: "Ready for merge".to_owned(),
+            format: "$symbol $label".to_owned(),
+        };
+        let expected = tok
+            .format
+            .replace("$symbol", &tok.symbol)
+            .replace("$label", &tok.label);
+        assert_eq!(render_token(&tok), expected);
+    }
 }

--- a/src/contexts/evaluation/domain/display_config.rs
+++ b/src/contexts/evaluation/domain/display_config.rs
@@ -1,5 +1,8 @@
 use serde::Serialize;
 
+use super::format_parser::{Segment, parse_segments};
+use super::style_spec::StyleSpec;
+
 const DEFAULT_FORMAT: &str = "$symbol $label";
 const DEFAULT_ERROR_FORMAT: &str = "$symbol $message";
 
@@ -60,10 +63,11 @@ pub struct TokenConfig {
 
 #[must_use]
 pub fn render_token(token: &TokenConfig) -> String {
-    token
+    let substituted = token
         .format
         .replace("$symbol", &token.symbol)
-        .replace("$label", &token.label)
+        .replace("$label", &token.label);
+    render_segments(&substituted)
 }
 
 #[derive(Serialize)]
@@ -83,10 +87,34 @@ impl Default for ErrorConfig {
 
 #[must_use]
 pub fn render_error_token(config: &ErrorConfig, message: &str) -> String {
-    config
+    let substituted = config
         .format
         .replace("$symbol", &config.symbol)
-        .replace("$message", message)
+        .replace("$message", message);
+    render_segments(&substituted)
+}
+
+fn render_segments(s: &str) -> String {
+    let segments = parse_segments(s);
+    if segments.iter().all(|seg| matches!(seg, Segment::Text(_))) {
+        return segments
+            .into_iter()
+            .map(|seg| match seg {
+                Segment::Text(t) => t,
+                Segment::Styled { .. } => unreachable!(),
+            })
+            .collect();
+    }
+    segments
+        .into_iter()
+        .map(|seg| match seg {
+            Segment::Text(t) => t,
+            Segment::Styled { content, style_str } => {
+                let style = StyleSpec::parse(&style_str).to_ansi_style();
+                format!("{}{}{}", style.render(), content, style.render_reset())
+            }
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -161,5 +189,62 @@ mod tests {
             render_error_token(&config, "authentication required"),
             "[!] authentication required"
         );
+    }
+
+    // ── スタイル構文のテスト ─────────────────────────────────────────────────
+
+    #[test]
+    fn render_token_plain_format_unaffected() {
+        let tok = TokenConfig {
+            symbol: "✓".to_owned(),
+            label: "Ready".to_owned(),
+            format: "$symbol $label".to_owned(),
+        };
+        assert_eq!(render_token(&tok), "✓ Ready");
+    }
+
+    #[test]
+    fn render_token_styled_contains_ansi() {
+        let tok = TokenConfig {
+            symbol: "✓".to_owned(),
+            label: "Ready".to_owned(),
+            format: "[$symbol](bold green) $label".to_owned(),
+        };
+        let out = render_token(&tok);
+        assert!(out.contains("\x1b["), "expected ANSI codes in: {out:?}");
+        assert!(out.contains("✓"));
+        assert!(out.contains("Ready"));
+    }
+
+    #[test]
+    fn render_token_placeholder_substituted_before_style() {
+        let tok = TokenConfig {
+            symbol: "✓".to_owned(),
+            label: "Ready".to_owned(),
+            format: "[$symbol $label](green)".to_owned(),
+        };
+        let out = render_token(&tok);
+        assert!(
+            out.contains("✓ Ready"),
+            "placeholder must be substituted: {out:?}"
+        );
+    }
+
+    #[test]
+    fn render_error_token_styled_contains_ansi() {
+        let config = ErrorConfig {
+            symbol: "✗".to_owned(),
+            format: "[$symbol](bold red) $message".to_owned(),
+        };
+        let out = render_error_token(&config, "failed");
+        assert!(out.contains("\x1b["), "expected ANSI codes in: {out:?}");
+        assert!(out.contains("✗"));
+        assert!(out.contains("failed"));
+    }
+
+    #[test]
+    fn render_error_token_plain_format_unaffected() {
+        let config = ErrorConfig::default();
+        assert_eq!(render_error_token(&config, "oops"), "✗ oops");
     }
 }

--- a/src/contexts/evaluation/domain/display_config.rs
+++ b/src/contexts/evaluation/domain/display_config.rs
@@ -95,24 +95,14 @@ pub fn render_error_token(config: &ErrorConfig, message: &str) -> String {
 }
 
 fn render_segments(s: &str) -> String {
-    let segments = parse_segments(s);
-    if segments.iter().all(|seg| matches!(seg, Segment::Text(_))) {
-        return segments
-            .into_iter()
-            .map(|seg| match seg {
-                Segment::Text(t) => t,
-                Segment::Styled { .. } => unreachable!(),
-            })
-            .collect();
-    }
-    segments
+    parse_segments(s)
         .into_iter()
         .map(|seg| match seg {
             Segment::Text(t) => t,
-            Segment::Styled { content, style_str } => {
-                let style = StyleSpec::parse(&style_str).to_ansi_style();
-                format!("{}{}{}", style.render(), content, style.render_reset())
-            }
+            Segment::Styled { content, style_str } => StyleSpec::parse(&style_str)
+                .to_ansi_style()
+                .paint(content)
+                .to_string(),
         })
         .collect()
 }

--- a/src/contexts/evaluation/domain/format_parser.rs
+++ b/src/contexts/evaluation/domain/format_parser.rs
@@ -4,41 +4,49 @@ pub(crate) enum Segment {
     Styled { content: String, style_str: String },
 }
 
+/// `[text](style)` 構文を `Segment` 列に分解する。
+///
+/// `]` の直後が `(` でない場合は Styled として扱わず Text に含める（後方互換）。
+/// ASCII の `[` `]` `(` `)` はすべて 1 バイトなので `str::find` でバイト操作しても安全。
 pub(crate) fn parse_segments(format: &str) -> Vec<Segment> {
     let mut segments = Vec::new();
-    let mut text_buf = String::new();
-    let chars: Vec<char> = format.chars().collect();
-    let mut i = 0;
+    let mut remaining = format;
+    let mut text_acc = String::new();
 
-    while i < chars.len() {
-        if chars[i] == '[' {
-            // `]` を探す
-            if let Some(close) = chars[i + 1..].iter().position(|&c| c == ']') {
-                let close = close + i + 1;
-                // `]` の直後が `(` か確認
-                if close + 1 < chars.len() && chars[close + 1] == '(' {
-                    // `)` を探す
-                    if let Some(paren_close) = chars[close + 2..].iter().position(|&c| c == ')') {
-                        let paren_close = paren_close + close + 2;
-                        if !text_buf.is_empty() {
-                            segments.push(Segment::Text(text_buf.clone()));
-                            text_buf.clear();
-                        }
-                        let content: String = chars[i + 1..close].iter().collect();
-                        let style_str: String = chars[close + 2..paren_close].iter().collect();
-                        segments.push(Segment::Styled { content, style_str });
-                        i = paren_close + 1;
-                        continue;
+    while !remaining.is_empty() {
+        if let Some(open) = remaining.find('[') {
+            let after_open = &remaining[open + 1..];
+
+            if let Some(close_bracket) = after_open.find(']') {
+                let after_bracket = &after_open[close_bracket + 1..];
+
+                if let Some(after_paren) = after_bracket.strip_prefix('(')
+                    && let Some(paren_close) = after_paren.find(')')
+                {
+                    text_acc.push_str(&remaining[..open]);
+                    if !text_acc.is_empty() {
+                        segments.push(Segment::Text(std::mem::take(&mut text_acc)));
                     }
+                    segments.push(Segment::Styled {
+                        content: after_open[..close_bracket].to_owned(),
+                        style_str: after_paren[..paren_close].to_owned(),
+                    });
+                    remaining = &after_paren[paren_close + 1..];
+                    continue;
                 }
             }
+
+            // `[` はスタイル構文の開始ではない — テキストとして蓄積
+            text_acc.push_str(&remaining[..=open]);
+            remaining = &remaining[open + 1..];
+        } else {
+            text_acc.push_str(remaining);
+            remaining = "";
         }
-        text_buf.push(chars[i]);
-        i += 1;
     }
 
-    if !text_buf.is_empty() {
-        segments.push(Segment::Text(text_buf));
+    if !text_acc.is_empty() {
+        segments.push(Segment::Text(text_acc));
     }
 
     segments
@@ -46,84 +54,50 @@ pub(crate) fn parse_segments(format: &str) -> Vec<Segment> {
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use super::*;
 
-    #[test]
-    fn plain_text_returns_single_text_segment() {
-        let segs = parse_segments("$symbol $label");
-        assert_eq!(segs, vec![Segment::Text("$symbol $label".to_owned())]);
+    // ── プレーンテキスト（Styled 構文なし）───────────────────────────────────
+
+    #[rstest]
+    #[case("$symbol $label", vec![Segment::Text("$symbol $label".to_owned())])]
+    #[case("[$symbol] $label", vec![Segment::Text("[$symbol] $label".to_owned())])]
+    #[case("", vec![])]
+    fn plain_text_cases(#[case] input: &str, #[case] expected: Vec<Segment>) {
+        assert_eq!(parse_segments(input), expected);
     }
 
-    #[test]
-    fn styled_segment_is_parsed() {
-        let segs = parse_segments("[$symbol](bold green) $label");
-        assert_eq!(
-            segs,
-            vec![
-                Segment::Styled {
-                    content: "$symbol".to_owned(),
-                    style_str: "bold green".to_owned(),
-                },
-                Segment::Text(" $label".to_owned()),
-            ]
-        );
-    }
+    // ── Styled セグメントのパース ────────────────────────────────────────────
 
-    #[test]
-    fn unclosed_bracket_treated_as_text() {
-        let segs = parse_segments("[$symbol] $label");
-        assert_eq!(segs, vec![Segment::Text("[$symbol] $label".to_owned())]);
-    }
-
-    #[test]
-    fn empty_style_is_styled_with_empty_str() {
-        let segs = parse_segments("[$symbol]()");
-        assert_eq!(
-            segs,
-            vec![Segment::Styled {
-                content: "$symbol".to_owned(),
-                style_str: String::new(),
-            }]
-        );
-    }
-
-    #[test]
-    fn multiple_styled_segments() {
-        let segs = parse_segments("[$symbol](bold red) [$label](green)");
-        assert_eq!(
-            segs,
-            vec![
-                Segment::Styled {
-                    content: "$symbol".to_owned(),
-                    style_str: "bold red".to_owned(),
-                },
-                Segment::Text(" ".to_owned()),
-                Segment::Styled {
-                    content: "$label".to_owned(),
-                    style_str: "green".to_owned(),
-                },
-            ]
-        );
-    }
-
-    #[test]
-    fn empty_string_returns_empty_vec() {
-        let segs = parse_segments("");
-        assert_eq!(segs, vec![]);
-    }
-
-    #[test]
-    fn text_before_styled_segment() {
-        let segs = parse_segments("prefix [$symbol](red)");
-        assert_eq!(
-            segs,
-            vec![
-                Segment::Text("prefix ".to_owned()),
-                Segment::Styled {
-                    content: "$symbol".to_owned(),
-                    style_str: "red".to_owned(),
-                },
-            ]
-        );
+    #[rstest]
+    #[case(
+        "[$symbol](bold green) $label",
+        vec![
+            Segment::Styled { content: "$symbol".to_owned(), style_str: "bold green".to_owned() },
+            Segment::Text(" $label".to_owned()),
+        ]
+    )]
+    #[case(
+        "[$symbol]()",
+        vec![Segment::Styled { content: "$symbol".to_owned(), style_str: String::new() }]
+    )]
+    #[case(
+        "prefix [$symbol](red)",
+        vec![
+            Segment::Text("prefix ".to_owned()),
+            Segment::Styled { content: "$symbol".to_owned(), style_str: "red".to_owned() },
+        ]
+    )]
+    #[case(
+        "[$symbol](bold red) [$label](green)",
+        vec![
+            Segment::Styled { content: "$symbol".to_owned(), style_str: "bold red".to_owned() },
+            Segment::Text(" ".to_owned()),
+            Segment::Styled { content: "$label".to_owned(), style_str: "green".to_owned() },
+        ]
+    )]
+    fn styled_segment_cases(#[case] input: &str, #[case] expected: Vec<Segment>) {
+        assert_eq!(parse_segments(input), expected);
     }
 }

--- a/src/contexts/evaluation/domain/format_parser.rs
+++ b/src/contexts/evaluation/domain/format_parser.rs
@@ -1,0 +1,129 @@
+#[derive(Debug, PartialEq)]
+pub(crate) enum Segment {
+    Text(String),
+    Styled { content: String, style_str: String },
+}
+
+pub(crate) fn parse_segments(format: &str) -> Vec<Segment> {
+    let mut segments = Vec::new();
+    let mut text_buf = String::new();
+    let chars: Vec<char> = format.chars().collect();
+    let mut i = 0;
+
+    while i < chars.len() {
+        if chars[i] == '[' {
+            // `]` を探す
+            if let Some(close) = chars[i + 1..].iter().position(|&c| c == ']') {
+                let close = close + i + 1;
+                // `]` の直後が `(` か確認
+                if close + 1 < chars.len() && chars[close + 1] == '(' {
+                    // `)` を探す
+                    if let Some(paren_close) = chars[close + 2..].iter().position(|&c| c == ')') {
+                        let paren_close = paren_close + close + 2;
+                        if !text_buf.is_empty() {
+                            segments.push(Segment::Text(text_buf.clone()));
+                            text_buf.clear();
+                        }
+                        let content: String = chars[i + 1..close].iter().collect();
+                        let style_str: String = chars[close + 2..paren_close].iter().collect();
+                        segments.push(Segment::Styled { content, style_str });
+                        i = paren_close + 1;
+                        continue;
+                    }
+                }
+            }
+        }
+        text_buf.push(chars[i]);
+        i += 1;
+    }
+
+    if !text_buf.is_empty() {
+        segments.push(Segment::Text(text_buf));
+    }
+
+    segments
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_text_returns_single_text_segment() {
+        let segs = parse_segments("$symbol $label");
+        assert_eq!(segs, vec![Segment::Text("$symbol $label".to_owned())]);
+    }
+
+    #[test]
+    fn styled_segment_is_parsed() {
+        let segs = parse_segments("[$symbol](bold green) $label");
+        assert_eq!(
+            segs,
+            vec![
+                Segment::Styled {
+                    content: "$symbol".to_owned(),
+                    style_str: "bold green".to_owned(),
+                },
+                Segment::Text(" $label".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn unclosed_bracket_treated_as_text() {
+        let segs = parse_segments("[$symbol] $label");
+        assert_eq!(segs, vec![Segment::Text("[$symbol] $label".to_owned())]);
+    }
+
+    #[test]
+    fn empty_style_is_styled_with_empty_str() {
+        let segs = parse_segments("[$symbol]()");
+        assert_eq!(
+            segs,
+            vec![Segment::Styled {
+                content: "$symbol".to_owned(),
+                style_str: String::new(),
+            }]
+        );
+    }
+
+    #[test]
+    fn multiple_styled_segments() {
+        let segs = parse_segments("[$symbol](bold red) [$label](green)");
+        assert_eq!(
+            segs,
+            vec![
+                Segment::Styled {
+                    content: "$symbol".to_owned(),
+                    style_str: "bold red".to_owned(),
+                },
+                Segment::Text(" ".to_owned()),
+                Segment::Styled {
+                    content: "$label".to_owned(),
+                    style_str: "green".to_owned(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn empty_string_returns_empty_vec() {
+        let segs = parse_segments("");
+        assert_eq!(segs, vec![]);
+    }
+
+    #[test]
+    fn text_before_styled_segment() {
+        let segs = parse_segments("prefix [$symbol](red)");
+        assert_eq!(
+            segs,
+            vec![
+                Segment::Text("prefix ".to_owned()),
+                Segment::Styled {
+                    content: "$symbol".to_owned(),
+                    style_str: "red".to_owned(),
+                },
+            ]
+        );
+    }
+}

--- a/src/contexts/evaluation/domain/style_spec.rs
+++ b/src/contexts/evaluation/domain/style_spec.rs
@@ -62,10 +62,14 @@ impl StyleSpec {
                     spec.fg = Some(ColorSpec::Named(parse_named_color(name).unwrap()));
                 }
                 s if s.starts_with("fg:") => {
-                    spec.fg = parse_color_value(&s["fg:".len()..]);
+                    if let Some(color) = parse_color_value(&s["fg:".len()..]) {
+                        spec.fg = Some(color);
+                    }
                 }
                 s if s.starts_with("bg:") => {
-                    spec.bg = parse_color_value(&s["bg:".len()..]);
+                    if let Some(color) = parse_color_value(&s["bg:".len()..]) {
+                        spec.bg = Some(color);
+                    }
                 }
                 _ => {}
             }
@@ -231,6 +235,18 @@ mod tests {
         let s = StyleSpec::parse("bold xyzzy green");
         assert!(s.bold);
         assert_eq!(s.fg, Some(ColorSpec::Named(NamedColor::Green)));
+    }
+
+    #[test]
+    fn invalid_fg_prefix_does_not_clear_prior_color() {
+        let s = StyleSpec::parse("green fg:typo");
+        assert_eq!(s.fg, Some(ColorSpec::Named(NamedColor::Green)));
+    }
+
+    #[test]
+    fn invalid_bg_prefix_does_not_clear_prior_color() {
+        let s = StyleSpec::parse("bg:red bg:typo");
+        assert_eq!(s.bg, Some(ColorSpec::Named(NamedColor::Red)));
     }
 
     #[test]

--- a/src/contexts/evaluation/domain/style_spec.rs
+++ b/src/contexts/evaluation/domain/style_spec.rs
@@ -182,7 +182,49 @@ fn color_spec_to_nu(spec: &ColorSpec) -> Color {
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use super::*;
+
+    // ── fg カラー解析 ────────────────────────────────────────────────────────
+
+    #[rstest]
+    #[case("green",        Some(ColorSpec::Named(NamedColor::Green)))]
+    #[case("GREEN",        Some(ColorSpec::Named(NamedColor::Green)))]
+    #[case("bright-cyan",  Some(ColorSpec::Named(NamedColor::BrightCyan)))]
+    #[case("fg:blue",      Some(ColorSpec::Named(NamedColor::Blue)))]
+    #[case("fg:196",       Some(ColorSpec::Ansi256(196)))]
+    #[case("fg:#ff8800",   Some(ColorSpec::Rgb(0xff, 0x88, 0x00)))]
+    fn fg_color_cases(#[case] input: &str, #[case] expected: Option<ColorSpec>) {
+        assert_eq!(StyleSpec::parse(input).fg, expected);
+    }
+
+    // ── bg カラー解析 ────────────────────────────────────────────────────────
+
+    #[rstest]
+    #[case("bg:red",     Some(ColorSpec::Named(NamedColor::Red)))]
+    #[case("bg:208",     Some(ColorSpec::Ansi256(208)))]
+    #[case("bg:#001122", Some(ColorSpec::Rgb(0x00, 0x11, 0x22)))]
+    fn bg_color_cases(#[case] input: &str, #[case] expected: Option<ColorSpec>) {
+        assert_eq!(StyleSpec::parse(input).bg, expected);
+    }
+
+    // ── 不正・未知指定子が有効な色を上書きしない ─────────────────────────────
+
+    #[rstest]
+    #[case("bold xyzzy green", Some(ColorSpec::Named(NamedColor::Green)))]
+    #[case("green fg:typo",    Some(ColorSpec::Named(NamedColor::Green)))]
+    fn invalid_token_does_not_clear_fg(#[case] input: &str, #[case] expected: Option<ColorSpec>) {
+        assert_eq!(StyleSpec::parse(input).fg, expected);
+    }
+
+    #[rstest]
+    #[case("bg:red bg:typo", Some(ColorSpec::Named(NamedColor::Red)))]
+    fn invalid_token_does_not_clear_bg(#[case] input: &str, #[case] expected: Option<ColorSpec>) {
+        assert_eq!(StyleSpec::parse(input).bg, expected);
+    }
+
+    // ── その他 ───────────────────────────────────────────────────────────────
 
     #[test]
     fn parse_bold_green() {
@@ -192,61 +234,11 @@ mod tests {
     }
 
     #[test]
-    fn parse_fg_256() {
-        let s = StyleSpec::parse("fg:196");
-        assert_eq!(s.fg, Some(ColorSpec::Ansi256(196)));
-    }
-
-    #[test]
-    fn parse_fg_hex() {
-        let s = StyleSpec::parse("fg:#ff8800");
-        assert_eq!(s.fg, Some(ColorSpec::Rgb(0xff, 0x88, 0x00)));
-    }
-
-    #[test]
-    fn parse_bg_named() {
-        let s = StyleSpec::parse("bg:red");
-        assert_eq!(s.bg, Some(ColorSpec::Named(NamedColor::Red)));
-    }
-
-    #[test]
-    fn parse_bright_modifier() {
-        let s = StyleSpec::parse("bright-cyan");
-        assert_eq!(s.fg, Some(ColorSpec::Named(NamedColor::BrightCyan)));
-    }
-
-    #[test]
     fn parse_none() {
         let s = StyleSpec::parse("none");
         assert!(s.none);
         assert!(!s.bold);
         assert!(s.fg.is_none());
-    }
-
-    #[test]
-    fn parse_case_insensitive() {
-        let s = StyleSpec::parse("BOLD GREEN");
-        assert!(s.bold);
-        assert_eq!(s.fg, Some(ColorSpec::Named(NamedColor::Green)));
-    }
-
-    #[test]
-    fn unknown_token_is_ignored() {
-        let s = StyleSpec::parse("bold xyzzy green");
-        assert!(s.bold);
-        assert_eq!(s.fg, Some(ColorSpec::Named(NamedColor::Green)));
-    }
-
-    #[test]
-    fn invalid_fg_prefix_does_not_clear_prior_color() {
-        let s = StyleSpec::parse("green fg:typo");
-        assert_eq!(s.fg, Some(ColorSpec::Named(NamedColor::Green)));
-    }
-
-    #[test]
-    fn invalid_bg_prefix_does_not_clear_prior_color() {
-        let s = StyleSpec::parse("bg:red bg:typo");
-        assert_eq!(s.bg, Some(ColorSpec::Named(NamedColor::Red)));
     }
 
     #[test]
@@ -259,24 +251,6 @@ mod tests {
         assert!(s.blink);
         assert!(s.hidden);
         assert!(s.strikethrough);
-    }
-
-    #[test]
-    fn parse_fg_prefix_named() {
-        let s = StyleSpec::parse("fg:blue");
-        assert_eq!(s.fg, Some(ColorSpec::Named(NamedColor::Blue)));
-    }
-
-    #[test]
-    fn parse_bg_256() {
-        let s = StyleSpec::parse("bg:208");
-        assert_eq!(s.bg, Some(ColorSpec::Ansi256(208)));
-    }
-
-    #[test]
-    fn parse_bg_hex() {
-        let s = StyleSpec::parse("bg:#001122");
-        assert_eq!(s.bg, Some(ColorSpec::Rgb(0x00, 0x11, 0x22)));
     }
 
     #[test]

--- a/src/contexts/evaluation/domain/style_spec.rs
+++ b/src/contexts/evaluation/domain/style_spec.rs
@@ -189,12 +189,12 @@ mod tests {
     // ── fg カラー解析 ────────────────────────────────────────────────────────
 
     #[rstest]
-    #[case("green",        Some(ColorSpec::Named(NamedColor::Green)))]
-    #[case("GREEN",        Some(ColorSpec::Named(NamedColor::Green)))]
-    #[case("bright-cyan",  Some(ColorSpec::Named(NamedColor::BrightCyan)))]
-    #[case("fg:blue",      Some(ColorSpec::Named(NamedColor::Blue)))]
-    #[case("fg:196",       Some(ColorSpec::Ansi256(196)))]
-    #[case("fg:#ff8800",   Some(ColorSpec::Rgb(0xff, 0x88, 0x00)))]
+    #[case("green", Some(ColorSpec::Named(NamedColor::Green)))]
+    #[case("GREEN", Some(ColorSpec::Named(NamedColor::Green)))]
+    #[case("bright-cyan", Some(ColorSpec::Named(NamedColor::BrightCyan)))]
+    #[case("fg:blue", Some(ColorSpec::Named(NamedColor::Blue)))]
+    #[case("fg:196", Some(ColorSpec::Ansi256(196)))]
+    #[case("fg:#ff8800", Some(ColorSpec::Rgb(0xff, 0x88, 0x00)))]
     fn fg_color_cases(#[case] input: &str, #[case] expected: Option<ColorSpec>) {
         assert_eq!(StyleSpec::parse(input).fg, expected);
     }
@@ -202,8 +202,8 @@ mod tests {
     // ── bg カラー解析 ────────────────────────────────────────────────────────
 
     #[rstest]
-    #[case("bg:red",     Some(ColorSpec::Named(NamedColor::Red)))]
-    #[case("bg:208",     Some(ColorSpec::Ansi256(208)))]
+    #[case("bg:red", Some(ColorSpec::Named(NamedColor::Red)))]
+    #[case("bg:208", Some(ColorSpec::Ansi256(208)))]
     #[case("bg:#001122", Some(ColorSpec::Rgb(0x00, 0x11, 0x22)))]
     fn bg_color_cases(#[case] input: &str, #[case] expected: Option<ColorSpec>) {
         assert_eq!(StyleSpec::parse(input).bg, expected);
@@ -213,7 +213,7 @@ mod tests {
 
     #[rstest]
     #[case("bold xyzzy green", Some(ColorSpec::Named(NamedColor::Green)))]
-    #[case("green fg:typo",    Some(ColorSpec::Named(NamedColor::Green)))]
+    #[case("green fg:typo", Some(ColorSpec::Named(NamedColor::Green)))]
     fn invalid_token_does_not_clear_fg(#[case] input: &str, #[case] expected: Option<ColorSpec>) {
         assert_eq!(StyleSpec::parse(input).fg, expected);
     }

--- a/src/contexts/evaluation/domain/style_spec.rs
+++ b/src/contexts/evaluation/domain/style_spec.rs
@@ -1,0 +1,286 @@
+use anstyle::{AnsiColor, Color, Effects, RgbColor, Style};
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum NamedColor {
+    Black,
+    Red,
+    Green,
+    Yellow,
+    Blue,
+    Purple,
+    Cyan,
+    White,
+    BrightBlack,
+    BrightRed,
+    BrightGreen,
+    BrightYellow,
+    BrightBlue,
+    BrightPurple,
+    BrightCyan,
+    BrightWhite,
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum ColorSpec {
+    Named(NamedColor),
+    Ansi256(u8),
+    Rgb(u8, u8, u8),
+}
+
+#[derive(Debug, PartialEq, Default)]
+#[allow(clippy::struct_excessive_bools)]
+pub(crate) struct StyleSpec {
+    pub fg: Option<ColorSpec>,
+    pub bg: Option<ColorSpec>,
+    pub bold: bool,
+    pub italic: bool,
+    pub underline: bool,
+    pub dimmed: bool,
+    pub inverted: bool,
+    pub blink: bool,
+    pub hidden: bool,
+    pub strikethrough: bool,
+    pub none: bool,
+}
+
+impl StyleSpec {
+    pub(crate) fn parse(s: &str) -> Self {
+        let mut spec = Self::default();
+        for token in s.split_whitespace() {
+            let lower = token.to_ascii_lowercase();
+            match lower.as_str() {
+                "bold" => spec.bold = true,
+                "italic" => spec.italic = true,
+                "underline" => spec.underline = true,
+                "dimmed" => spec.dimmed = true,
+                "inverted" => spec.inverted = true,
+                "blink" => spec.blink = true,
+                "hidden" => spec.hidden = true,
+                "strikethrough" => spec.strikethrough = true,
+                "none" => spec.none = true,
+                // 色名（前景色として扱う）
+                name if parse_named_color(name).is_some() => {
+                    spec.fg = Some(ColorSpec::Named(parse_named_color(name).unwrap()));
+                }
+                // fg:... / bg:...
+                s if s.starts_with("fg:") => {
+                    spec.fg = parse_color_value(&s["fg:".len()..]);
+                }
+                s if s.starts_with("bg:") => {
+                    spec.bg = parse_color_value(&s["bg:".len()..]);
+                }
+                _ => {}
+            }
+        }
+        spec
+    }
+
+    pub(crate) fn to_ansi_style(&self) -> Style {
+        if self.none {
+            return Style::new();
+        }
+        let mut style = Style::new();
+        if let Some(fg) = &self.fg {
+            style = style.fg_color(Some(color_spec_to_anstyle(fg)));
+        }
+        if let Some(bg) = &self.bg {
+            style = style.bg_color(Some(color_spec_to_anstyle(bg)));
+        }
+        let mut effects = Effects::new();
+        if self.bold {
+            effects |= Effects::BOLD;
+        }
+        if self.italic {
+            effects |= Effects::ITALIC;
+        }
+        if self.underline {
+            effects |= Effects::UNDERLINE;
+        }
+        if self.dimmed {
+            effects |= Effects::DIMMED;
+        }
+        if self.inverted {
+            effects |= Effects::INVERT;
+        }
+        if self.blink {
+            effects |= Effects::BLINK;
+        }
+        if self.hidden {
+            effects |= Effects::HIDDEN;
+        }
+        if self.strikethrough {
+            effects |= Effects::STRIKETHROUGH;
+        }
+        style.effects(effects)
+    }
+}
+
+fn parse_named_color(s: &str) -> Option<NamedColor> {
+    match s {
+        "black" => Some(NamedColor::Black),
+        "red" => Some(NamedColor::Red),
+        "green" => Some(NamedColor::Green),
+        "yellow" => Some(NamedColor::Yellow),
+        "blue" => Some(NamedColor::Blue),
+        "purple" => Some(NamedColor::Purple),
+        "cyan" => Some(NamedColor::Cyan),
+        "white" => Some(NamedColor::White),
+        "bright-black" => Some(NamedColor::BrightBlack),
+        "bright-red" => Some(NamedColor::BrightRed),
+        "bright-green" => Some(NamedColor::BrightGreen),
+        "bright-yellow" => Some(NamedColor::BrightYellow),
+        "bright-blue" => Some(NamedColor::BrightBlue),
+        "bright-purple" => Some(NamedColor::BrightPurple),
+        "bright-cyan" => Some(NamedColor::BrightCyan),
+        "bright-white" => Some(NamedColor::BrightWhite),
+        _ => None,
+    }
+}
+
+fn parse_color_value(s: &str) -> Option<ColorSpec> {
+    // #rrggbb
+    if let Some(hex) = s.strip_prefix('#').filter(|h| h.len() == 6) {
+        let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
+        let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
+        let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
+        return Some(ColorSpec::Rgb(r, g, b));
+    }
+    // 数値（0–255）
+    if let Ok(n) = s.parse::<u8>() {
+        return Some(ColorSpec::Ansi256(n));
+    }
+    // 色名
+    parse_named_color(s).map(ColorSpec::Named)
+}
+
+fn named_color_to_ansi(c: &NamedColor) -> AnsiColor {
+    match c {
+        NamedColor::Black => AnsiColor::Black,
+        NamedColor::Red => AnsiColor::Red,
+        NamedColor::Green => AnsiColor::Green,
+        NamedColor::Yellow => AnsiColor::Yellow,
+        NamedColor::Blue => AnsiColor::Blue,
+        NamedColor::Purple => AnsiColor::Magenta,
+        NamedColor::Cyan => AnsiColor::Cyan,
+        NamedColor::White => AnsiColor::White,
+        NamedColor::BrightBlack => AnsiColor::BrightBlack,
+        NamedColor::BrightRed => AnsiColor::BrightRed,
+        NamedColor::BrightGreen => AnsiColor::BrightGreen,
+        NamedColor::BrightYellow => AnsiColor::BrightYellow,
+        NamedColor::BrightBlue => AnsiColor::BrightBlue,
+        NamedColor::BrightPurple => AnsiColor::BrightMagenta,
+        NamedColor::BrightCyan => AnsiColor::BrightCyan,
+        NamedColor::BrightWhite => AnsiColor::BrightWhite,
+    }
+}
+
+fn color_spec_to_anstyle(spec: &ColorSpec) -> Color {
+    match spec {
+        ColorSpec::Named(n) => Color::Ansi(named_color_to_ansi(n)),
+        ColorSpec::Ansi256(n) => Color::Ansi256(anstyle::Ansi256Color(*n)),
+        ColorSpec::Rgb(r, g, b) => Color::Rgb(RgbColor(*r, *g, *b)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_bold_green() {
+        let s = StyleSpec::parse("bold green");
+        assert!(s.bold);
+        assert_eq!(s.fg, Some(ColorSpec::Named(NamedColor::Green)));
+    }
+
+    #[test]
+    fn parse_fg_256() {
+        let s = StyleSpec::parse("fg:196");
+        assert_eq!(s.fg, Some(ColorSpec::Ansi256(196)));
+    }
+
+    #[test]
+    fn parse_fg_hex() {
+        let s = StyleSpec::parse("fg:#ff8800");
+        assert_eq!(s.fg, Some(ColorSpec::Rgb(0xff, 0x88, 0x00)));
+    }
+
+    #[test]
+    fn parse_bg_named() {
+        let s = StyleSpec::parse("bg:red");
+        assert_eq!(s.bg, Some(ColorSpec::Named(NamedColor::Red)));
+    }
+
+    #[test]
+    fn parse_bright_modifier() {
+        let s = StyleSpec::parse("bright-cyan");
+        assert_eq!(s.fg, Some(ColorSpec::Named(NamedColor::BrightCyan)));
+    }
+
+    #[test]
+    fn parse_none() {
+        let s = StyleSpec::parse("none");
+        assert!(s.none);
+        assert!(!s.bold);
+        assert!(s.fg.is_none());
+    }
+
+    #[test]
+    fn parse_case_insensitive() {
+        let s = StyleSpec::parse("BOLD GREEN");
+        assert!(s.bold);
+        assert_eq!(s.fg, Some(ColorSpec::Named(NamedColor::Green)));
+    }
+
+    #[test]
+    fn unknown_token_is_ignored() {
+        let s = StyleSpec::parse("bold xyzzy green");
+        assert!(s.bold);
+        assert_eq!(s.fg, Some(ColorSpec::Named(NamedColor::Green)));
+    }
+
+    #[test]
+    fn parse_all_attributes() {
+        let s = StyleSpec::parse("italic underline dimmed inverted blink hidden strikethrough");
+        assert!(s.italic);
+        assert!(s.underline);
+        assert!(s.dimmed);
+        assert!(s.inverted);
+        assert!(s.blink);
+        assert!(s.hidden);
+        assert!(s.strikethrough);
+    }
+
+    #[test]
+    fn parse_fg_prefix_named() {
+        let s = StyleSpec::parse("fg:blue");
+        assert_eq!(s.fg, Some(ColorSpec::Named(NamedColor::Blue)));
+    }
+
+    #[test]
+    fn parse_bg_256() {
+        let s = StyleSpec::parse("bg:208");
+        assert_eq!(s.bg, Some(ColorSpec::Ansi256(208)));
+    }
+
+    #[test]
+    fn parse_bg_hex() {
+        let s = StyleSpec::parse("bg:#001122");
+        assert_eq!(s.bg, Some(ColorSpec::Rgb(0x00, 0x11, 0x22)));
+    }
+
+    #[test]
+    fn to_ansi_style_bold_green_has_effects_and_color() {
+        let s = StyleSpec::parse("bold green");
+        let style = s.to_ansi_style();
+        assert!(style.get_effects().contains(Effects::BOLD));
+        assert_eq!(style.get_fg_color(), Some(Color::Ansi(AnsiColor::Green)));
+    }
+
+    #[test]
+    fn to_ansi_style_none_returns_empty_style() {
+        let s = StyleSpec::parse("none");
+        let style = s.to_ansi_style();
+        assert_eq!(style, Style::new());
+    }
+}

--- a/src/contexts/evaluation/domain/style_spec.rs
+++ b/src/contexts/evaluation/domain/style_spec.rs
@@ -1,4 +1,4 @@
-use anstyle::{AnsiColor, Color, Effects, RgbColor, Style};
+use nu_ansi_term::{Color, Style};
 
 #[derive(Debug, PartialEq)]
 pub(crate) enum NamedColor {
@@ -58,11 +58,9 @@ impl StyleSpec {
                 "hidden" => spec.hidden = true,
                 "strikethrough" => spec.strikethrough = true,
                 "none" => spec.none = true,
-                // 色名（前景色として扱う）
                 name if parse_named_color(name).is_some() => {
                     spec.fg = Some(ColorSpec::Named(parse_named_color(name).unwrap()));
                 }
-                // fg:... / bg:...
                 s if s.starts_with("fg:") => {
                     spec.fg = parse_color_value(&s["fg:".len()..]);
                 }
@@ -81,37 +79,36 @@ impl StyleSpec {
         }
         let mut style = Style::new();
         if let Some(fg) = &self.fg {
-            style = style.fg_color(Some(color_spec_to_anstyle(fg)));
+            style = style.fg(color_spec_to_nu(fg));
         }
         if let Some(bg) = &self.bg {
-            style = style.bg_color(Some(color_spec_to_anstyle(bg)));
+            style = style.on(color_spec_to_nu(bg));
         }
-        let mut effects = Effects::new();
         if self.bold {
-            effects |= Effects::BOLD;
+            style = style.bold();
         }
         if self.italic {
-            effects |= Effects::ITALIC;
+            style = style.italic();
         }
         if self.underline {
-            effects |= Effects::UNDERLINE;
+            style = style.underline();
         }
         if self.dimmed {
-            effects |= Effects::DIMMED;
+            style = style.dimmed();
         }
         if self.inverted {
-            effects |= Effects::INVERT;
+            style = style.reverse();
         }
         if self.blink {
-            effects |= Effects::BLINK;
+            style = style.blink();
         }
         if self.hidden {
-            effects |= Effects::HIDDEN;
+            style = style.hidden();
         }
         if self.strikethrough {
-            effects |= Effects::STRIKETHROUGH;
+            style = style.strikethrough();
         }
-        style.effects(effects)
+        style
     }
 }
 
@@ -138,47 +135,44 @@ fn parse_named_color(s: &str) -> Option<NamedColor> {
 }
 
 fn parse_color_value(s: &str) -> Option<ColorSpec> {
-    // #rrggbb
     if let Some(hex) = s.strip_prefix('#').filter(|h| h.len() == 6) {
         let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
         let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
         let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
         return Some(ColorSpec::Rgb(r, g, b));
     }
-    // 数値（0–255）
     if let Ok(n) = s.parse::<u8>() {
         return Some(ColorSpec::Ansi256(n));
     }
-    // 色名
     parse_named_color(s).map(ColorSpec::Named)
 }
 
-fn named_color_to_ansi(c: &NamedColor) -> AnsiColor {
+fn named_color_to_nu(c: &NamedColor) -> Color {
     match c {
-        NamedColor::Black => AnsiColor::Black,
-        NamedColor::Red => AnsiColor::Red,
-        NamedColor::Green => AnsiColor::Green,
-        NamedColor::Yellow => AnsiColor::Yellow,
-        NamedColor::Blue => AnsiColor::Blue,
-        NamedColor::Purple => AnsiColor::Magenta,
-        NamedColor::Cyan => AnsiColor::Cyan,
-        NamedColor::White => AnsiColor::White,
-        NamedColor::BrightBlack => AnsiColor::BrightBlack,
-        NamedColor::BrightRed => AnsiColor::BrightRed,
-        NamedColor::BrightGreen => AnsiColor::BrightGreen,
-        NamedColor::BrightYellow => AnsiColor::BrightYellow,
-        NamedColor::BrightBlue => AnsiColor::BrightBlue,
-        NamedColor::BrightPurple => AnsiColor::BrightMagenta,
-        NamedColor::BrightCyan => AnsiColor::BrightCyan,
-        NamedColor::BrightWhite => AnsiColor::BrightWhite,
+        NamedColor::Black => Color::Black,
+        NamedColor::Red => Color::Red,
+        NamedColor::Green => Color::Green,
+        NamedColor::Yellow => Color::Yellow,
+        NamedColor::Blue => Color::Blue,
+        NamedColor::Purple => Color::Purple,
+        NamedColor::Cyan => Color::Cyan,
+        NamedColor::White => Color::White,
+        NamedColor::BrightBlack => Color::DarkGray,
+        NamedColor::BrightRed => Color::LightRed,
+        NamedColor::BrightGreen => Color::LightGreen,
+        NamedColor::BrightYellow => Color::LightYellow,
+        NamedColor::BrightBlue => Color::LightBlue,
+        NamedColor::BrightPurple => Color::LightPurple,
+        NamedColor::BrightCyan => Color::LightCyan,
+        NamedColor::BrightWhite => Color::LightGray,
     }
 }
 
-fn color_spec_to_anstyle(spec: &ColorSpec) -> Color {
+fn color_spec_to_nu(spec: &ColorSpec) -> Color {
     match spec {
-        ColorSpec::Named(n) => Color::Ansi(named_color_to_ansi(n)),
-        ColorSpec::Ansi256(n) => Color::Ansi256(anstyle::Ansi256Color(*n)),
-        ColorSpec::Rgb(r, g, b) => Color::Rgb(RgbColor(*r, *g, *b)),
+        ColorSpec::Named(n) => named_color_to_nu(n),
+        ColorSpec::Ansi256(n) => Color::Fixed(*n),
+        ColorSpec::Rgb(r, g, b) => Color::Rgb(*r, *g, *b),
     }
 }
 
@@ -273,8 +267,8 @@ mod tests {
     fn to_ansi_style_bold_green_has_effects_and_color() {
         let s = StyleSpec::parse("bold green");
         let style = s.to_ansi_style();
-        assert!(style.get_effects().contains(Effects::BOLD));
-        assert_eq!(style.get_fg_color(), Some(Color::Ansi(AnsiColor::Green)));
+        assert!(style.is_bold);
+        assert_eq!(style.foreground, Some(Color::Green));
     }
 
     #[test]

--- a/tests/e2e/prompt/mod.rs
+++ b/tests/e2e/prompt/mod.rs
@@ -4,3 +4,4 @@ mod errors;
 mod merge_ready;
 mod pr_state;
 mod review;
+mod style;

--- a/tests/e2e/prompt/style.rs
+++ b/tests/e2e/prompt/style.rs
@@ -41,3 +41,22 @@ fn plain_format_produces_no_ansi() {
         .stdout(predicate::str::diff("✓ Ready for merge"))
         .stderr("");
 }
+
+/// スタイル適用後のテキストに色が漏れない（reset が挿入される）。
+/// `[$symbol](bold green) $label` の $label 部分はデフォルトカラーで出力される。
+#[test]
+fn text_after_styled_segment_is_not_colored() {
+    let env = TestEnv::new(MERGE_READY_JSON, Some(CHECKS_PASS_JSON));
+    env.write_config("[merge_ready]\nformat = \"[$symbol](bold green) $label\"");
+
+    let _daemon = DaemonHandle::start(&env);
+    DaemonHandle::wait_for_cache(&env, 5000);
+
+    let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
+    env.apply_with_cache(&mut cmd);
+    // $label ("Ready for merge") がプレーンテキストとして末尾にある。
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::ends_with("Ready for merge"))
+        .stderr("");
+}

--- a/tests/e2e/prompt/style.rs
+++ b/tests/e2e/prompt/style.rs
@@ -1,0 +1,43 @@
+//! スタイル構文（`[text](style)`）の E2E テスト
+
+const PROMPT_BIN: &str = "merge-ready-prompt";
+const MERGE_READY_JSON: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED"}"#;
+const CHECKS_PASS_JSON: &str = r#"[{"bucket":"pass","state":"SUCCESS"}]"#;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+use super::super::helpers::{DaemonHandle, TestEnv};
+
+/// スタイル構文付き format を設定した場合、ANSI エスケープコードが出力に含まれる。
+#[test]
+fn styled_format_produces_ansi_in_output() {
+    let env = TestEnv::new(MERGE_READY_JSON, Some(CHECKS_PASS_JSON));
+    env.write_config("[merge_ready]\nformat = \"[$symbol](bold green) $label\"");
+
+    let _daemon = DaemonHandle::start(&env);
+    DaemonHandle::wait_for_cache(&env, 5000);
+
+    let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
+    env.apply_with_cache(&mut cmd);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("\x1b["))
+        .stderr("");
+}
+
+/// スタイル構文なしの format（デフォルト）では ANSI コードを出力しない（後方互換）。
+#[test]
+fn plain_format_produces_no_ansi() {
+    let env = TestEnv::new(MERGE_READY_JSON, Some(CHECKS_PASS_JSON));
+
+    let _daemon = DaemonHandle::start(&env);
+    DaemonHandle::wait_for_cache(&env, 5000);
+
+    let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
+    env.apply_with_cache(&mut cmd);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::diff("✓ Ready for merge"))
+        .stderr("");
+}


### PR DESCRIPTION
## Summary

- `format` フィールドで `[text](style)` 構文を使い、ANSI 色・スタイルを指定できるようにする
- Starship の style strings 仕様に準拠。色制御ロジックは持たず常に ANSI コードを出力する（Starship と同じ挙動）
- `render_token` / `render_error_token` のシグネチャは変更なし（後方互換）

## Changes

### 新規ファイル
- `domain/format_parser.rs` — `[text](style)` 構文を `Segment` 列に分解するパーサー（手書きステートマシン、regex 不使用）
- `domain/style_spec.rs` — スタイル文字列を解析して `nu-ansi-term::Style` に変換する型

### 変更ファイル
- `Cargo.toml` — `nu-ansi-term = "0.50"` を直接依存に追加（Starship と同じクレート）
- `domain/display_config.rs` — `render_segments` ヘルパーを追加し `render_token` / `render_error_token` の内部実装を拡張
- `tests/e2e/prompt/style.rs` — スタイル構文の E2E テストを追加

### レビュー対応（PR #231）
- `style_spec.rs` — `fg:/bg:` に不正値が渡された場合、既存の有効な色指定を上書きしないよう修正（`None` をそのまま代入していたバグ）
- `style_spec.rs` — rstest によるパラメタライズドテストに整理しカバレッジを向上
- `README.md` — Starship 統合例から `style = "bold yellow"` を削除。merge-ready の `[text](style)` 構文と Starship の `style` を同時に使うと、内側の `\x1b[0m` が外側スタイルをリセットし後続モジュール（`cmd_duration` 等）の色が消えるため。注意書きを追加。
- `README.md` — Style Strings セクションを新設し、構文・使用例・サポート指定子一覧を追記
- `README.md` — サンプル設定に推奨カラーを設定。出現頻度の低いトークン（`sync_unknown` 等）はブロック単位でコメントアウト

## サポートするスタイル指定子

| 種別 | 例 |
|------|-----|
| 色名 | `black`, `red`, `green`, `yellow`, `blue`, `purple`, `cyan`, `white` |
| 輝度修飾 | `bright-red`, `bright-green`, … |
| 属性 | `bold`, `italic`, `underline`, `dimmed`, `inverted`, `blink`, `hidden`, `strikethrough` |
| スタイル無効化 | `none` |
| 前景色 | `fg:色名`, `fg:N`（0–255）, `fg:#rrggbb` |
| 背景色 | `bg:色名`, `bg:N`（0–255）, `bg:#rrggbb` |
| 組み合わせ | スペース区切り・順不同・大文字小文字不問 |

## Test plan

- [x] `cargo test --workspace` — 全テスト Green
- [x] `cargo clippy --workspace -- -D warnings` — 警告なし
- [x] `cargo fmt --check --all` — フォーマット通過
- [x] `bash scripts/check-layer-deps.sh` — DDD 層ルール通過
- [x] `bash scripts/check-no-mod-rs.sh` — mod.rs 禁止ルール通過

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)