### PR TITLE
fix: daemon_server::run の Result<(), ()> を DaemonError に置き換える

### DIFF
--- a/src/contexts/daemon/infrastructure/daemon_lifecycle.rs
+++ b/src/contexts/daemon/infrastructure/daemon_lifecycle.rs
@@ -28,7 +28,7 @@ impl DaemonLifecyclePort for DaemonLifecycle {
             }
             pid::remove();
         }
-        daemon_server::run(&self.on_refresh).map_err(|()| DaemonError::Failure)
+        daemon_server::run(&self.on_refresh)
     }
 
     fn stop(&self) -> bool {

--- a/src/contexts/daemon/infrastructure/daemon_server.rs
+++ b/src/contexts/daemon/infrastructure/daemon_server.rs
@@ -11,6 +11,7 @@ use super::pid;
 use super::protocol::{RefreshModeDto, Request, Response};
 use super::repo_id;
 use crate::contexts::daemon::domain::cache::{CacheEntry, RefreshMode};
+use crate::contexts::daemon::domain::daemon::DaemonError;
 use crate::contexts::daemon::domain::refresh_policy::RefreshPolicy;
 
 const DEFAULT_STALE_TTL_SECS: u64 = 5;
@@ -100,7 +101,7 @@ type RefreshFn = Arc<dyn Fn(&str, &std::path::Path) + Send + Sync + 'static>;
 ///
 /// `on_refresh` はキャッシュ更新が必要になったときにスレッドで呼ばれる。
 /// Stop リクエストで `Ok(())` を返す。
-pub fn run(on_refresh: &RefreshFn) -> Result<(), ()> {
+pub fn run(on_refresh: &RefreshFn) -> Result<(), DaemonError> {
     let socket_path = paths::socket_path();
     if let Some(parent) = socket_path.parent() {
         let _ = std::fs::create_dir_all(parent);
@@ -165,12 +166,12 @@ pub fn run(on_refresh: &RefreshFn) -> Result<(), ()> {
     Ok(())
 }
 
-fn bind_socket(socket_path: &std::path::Path) -> Result<UnixListener, ()> {
+fn bind_socket(socket_path: &std::path::Path) -> Result<UnixListener, DaemonError> {
     match pid::read() {
         Some(p) if pid::is_alive(p) => {
             log::error!("daemon is already running (pid {p})");
             eprintln!("merge-ready daemon is already running (pid {p})");
-            return Err(());
+            return Err(DaemonError::AlreadyRunning);
         }
         _ => {
             let _ = std::fs::remove_file(socket_path);
@@ -184,7 +185,7 @@ fn bind_socket(socket_path: &std::path::Path) -> Result<UnixListener, ()> {
             Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
                 if retries >= BIND_RETRY_MAX {
                     log::error!("socket already in use after retries, giving up");
-                    return Err(());
+                    return Err(DaemonError::AlreadyRunning);
                 }
                 retries += 1;
                 std::thread::sleep(Duration::from_millis(BIND_RETRY_INTERVAL_MS));
@@ -192,7 +193,7 @@ fn bind_socket(socket_path: &std::path::Path) -> Result<UnixListener, ()> {
             Err(e) => {
                 log::error!("failed to bind socket: {e}");
                 eprintln!("merge-ready daemon: failed to bind socket: {e}");
-                return Err(());
+                return Err(DaemonError::Failure);
             }
         }
     }


### PR DESCRIPTION
## Summary

- `daemon_server::run` の戻り型を `Result<(), ()>` → `Result<(), DaemonError>` に変更
- `bind_socket` の戻り型を `Result<UnixListener, ()>` → `Result<UnixListener, DaemonError>` に変更（`AlreadyRunning` / `Failure` を適切に使い分け）
- `daemon_lifecycle.rs` の `.map_err(|()| DaemonError::Failure)` を削除（不要になったため）

Closes #220

## Test plan

- [ ] `cargo build` が通ること
- [ ] `cargo clippy --workspace -- -D warnings` で警告なし
- [ ] `cargo test --workspace` で全 205 テスト通過
- [ ] `cargo fmt --check --all` がクリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)