### PR TITLE
fix: gh に対応していないリポジトリではメッセージを表示しない

### DIFF
--- a/src/contexts/evaluation/application/errors.rs
+++ b/src/contexts/evaluation/application/errors.rs
@@ -9,13 +9,13 @@ pub struct ErrorToken {
     pub message: String,
 }
 
-/// `RepositoryError` をエラートークンに変換する。`NotFound` は表示不要なため `None` を返す。
+/// `RepositoryError` をエラートークンに変換する。表示不要な variant は `None` を返す。
 pub fn into_token<L: ErrorLogger>(e: RepositoryError, logger: &L) -> Option<ErrorToken> {
     match e {
         RepositoryError::Unauthenticated => Some(ErrorToken {
             message: "authentication required".to_owned(),
         }),
-        RepositoryError::NotFound => None,
+        RepositoryError::NotFound | RepositoryError::NotGithubRepository => None,
         RepositoryError::RateLimited => {
             logger.log(&LogRecord {
                 category: ErrorCategory::RateLimit,

--- a/src/contexts/evaluation/application/prompt.rs
+++ b/src/contexts/evaluation/application/prompt.rs
@@ -22,7 +22,9 @@ where
         Err(e) => match into_token(e, logger) {
             Some(token) => return Err(token),
             None => {
-                unreachable!("into_token returns None only for NotFound, which is handled above")
+                unreachable!(
+                    "into_token returns None only for NotFound/NotGithubRepository, which are handled above"
+                )
             }
         },
     };

--- a/src/contexts/evaluation/domain/error.rs
+++ b/src/contexts/evaluation/domain/error.rs
@@ -11,4 +11,6 @@ pub enum RepositoryError {
     RateLimited,
     /// 上記に当てはまらない予期しないエラー
     Unexpected,
+    /// GitHub リポジトリに対応していない（remote なし・GitHub 以外）
+    NotGithubRepository,
 }

--- a/src/contexts/evaluation/infrastructure/gh.rs
+++ b/src/contexts/evaluation/infrastructure/gh.rs
@@ -142,6 +142,9 @@ impl<L: ErrorLogger + Sync> PrRepository for GhClient<L> {
         let pr_view = match self.fetch_pr_view() {
             Ok(v) => v,
             Err(RepositoryError::NotFound) => return Ok(self.resolve_no_pr()),
+            Err(RepositoryError::NotGithubRepository) => {
+                return Ok(PrState::NotApplicable(NotApplicableState::NoRepository));
+            }
             Err(e) => return Err(e),
         };
 
@@ -308,6 +311,7 @@ enum GhError {
     NoPr,
     RateLimited,
     Timeout,
+    NotGithubRepository,
     ApiError(String),
 }
 
@@ -317,6 +321,7 @@ impl From<GhError> for RepositoryError {
             GhError::NotInstalled | GhError::AuthRequired => RepositoryError::Unauthenticated,
             GhError::NoPr => RepositoryError::NotFound,
             GhError::RateLimited => RepositoryError::RateLimited,
+            GhError::NotGithubRepository => RepositoryError::NotGithubRepository,
             GhError::Timeout | GhError::ApiError(_) => RepositoryError::Unexpected,
         }
     }
@@ -392,6 +397,13 @@ fn classify_gh_error(exit_code: i32, stderr: &str) -> GhError {
         GhError::NoPr
     } else if exit_code == 1 && stderr.contains("rate limit") {
         GhError::RateLimited
+    } else if exit_code == 1
+        && (stderr.contains("no git remotes found")
+            || stderr.contains(
+                "none of the git remotes configured for this repository point to a known GitHub host",
+            ))
+    {
+        GhError::NotGithubRepository
     } else {
         GhError::ApiError(stderr.to_owned())
     }

--- a/tests/e2e/scenarios/mod.rs
+++ b/tests/e2e/scenarios/mod.rs
@@ -2,6 +2,7 @@ mod cache_hit;
 mod default_branch;
 mod initial_load;
 mod multi_repo;
+mod no_github_remote;
 mod no_pr;
 mod no_repo;
 mod stale;

--- a/tests/e2e/scenarios/no_github_remote.rs
+++ b/tests/e2e/scenarios/no_github_remote.rs
@@ -1,0 +1,31 @@
+//! GitHub 非対応リポジトリシナリオ
+//!
+//! git リポジトリだが GitHub に接続されていない場合、何も表示しない。
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use rstest::rstest;
+
+use super::super::helpers::{DaemonHandle, TestEnv};
+
+const PROMPT_BIN: &str = "merge-ready-prompt";
+
+/// remote 未設定 / GitHub 以外の remote では何も表示しない
+#[rstest]
+#[case::no_remotes("no git remotes found")]
+#[case::non_github_remote(
+    "none of the git remotes configured for this repository point to a known GitHub host. \
+     To tell gh about a new GitHub host, please use `gh auth login`"
+)]
+fn test_non_github_repo_shows_nothing(#[case] stderr: &str) {
+    let env = TestEnv::with_error(stderr, 1);
+    let _daemon = DaemonHandle::start(&env);
+    DaemonHandle::wait_for_cache(&env, 5000);
+
+    let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
+    env.apply_with_cache(&mut cmd);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::is_empty())
+        .stderr("");
+}


### PR DESCRIPTION
## Summary

- GitHub に対応していないリポジトリ（remote 未設定 / GitHub 以外の remote）で `✗ unexpected error` が表示されていたバグを修正
- `gh` CLI が返す2種類のエラーメッセージを `GhError::NotGithubRepository` として分類し、`PrState::NotApplicable(NoRepository)` を返すことで表示を抑制

## Test plan

- [ ] `cargo test --workspace` がすべて通ること
- [ ] `cargo clippy --workspace -- -D warnings` が通ること
- [ ] remote 未設定の git リポジトリで実行して何も表示されないこと
- [ ] GitHub 以外の remote を持つ git リポジトリで実行して何も表示されないこと

closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)