### PR TITLE
ci: enforce E2E test coverage for feat/fix PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,3 +91,17 @@ jobs:
           fi
       - name: Run cargo-deny
         run: cargo deny check
+
+  check-e2e:
+    name: check-e2e
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Check E2E tests exist for feat/fix PRs
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          BASE_REF: ${{ github.base_ref }}
+        run: bash scripts/check-e2e.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,7 @@ cargo fmt --check --all              # formatting check
 cargo deny check                     # dependency audit
 bash scripts/check-layer-deps.sh     # DDD layer dependency rules
 bash scripts/check-no-mod-rs.sh      # forbid mod.rs (use Rust 2018+ style)
+bash scripts/check-e2e.sh           # feat/fix PR では tests/e2e/ の変更が必要（PR_TITLE と BASE_REF を設定）
 ```
 
 ## File Naming
@@ -83,6 +84,7 @@ PR checklist:
 - [ ] Each commit is atomic and passes tests on its own
 - [ ] Commit messages follow the convention above
 - [ ] New behaviour is covered by tests written before the implementation
+- [ ] `feat:` / `fix:` PR の場合、`tests/e2e/` 配下に変更が含まれている
 
 ## Release
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ cargo fmt --check --all              # formatting check
 cargo deny check                     # dependency audit
 bash scripts/check-layer-deps.sh     # DDD layer dependency rules
 bash scripts/check-no-mod-rs.sh      # forbid mod.rs (use Rust 2018+ style)
-bash scripts/check-e2e.sh           # feat/fix PR では tests/e2e/ の変更が必要（PR_TITLE と BASE_REF を設定）
+bash scripts/check-e2e.sh           # feat/fix PRs must include changes under tests/e2e/ (set PR_TITLE and BASE_REF)
 ```
 
 ## File Naming
@@ -84,7 +84,7 @@ PR checklist:
 - [ ] Each commit is atomic and passes tests on its own
 - [ ] Commit messages follow the convention above
 - [ ] New behaviour is covered by tests written before the implementation
-- [ ] `feat:` / `fix:` PR の場合、`tests/e2e/` 配下に変更が含まれている
+- [ ] `feat:` / `fix:` PRs include changes under `tests/e2e/`
 
 ## Release
 

--- a/scripts/check-e2e.sh
+++ b/scripts/check-e2e.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+cd "${ROOT_DIR:-$(dirname "$0")/..}"
+
+if ! echo "$PR_TITLE" | grep -qE '^(feat|fix)(!)?:'; then
+  echo "PR title does not start with feat/fix; skipping E2E check."
+  exit 0
+fi
+
+changed=$(git diff --name-only "origin/${BASE_REF}...HEAD" -- tests/e2e/)
+
+if [ -z "$changed" ]; then
+  printf "ERROR: PR title '%s' requires changes in tests/e2e/ but none were found.\n" "$PR_TITLE" >&2
+  exit 1
+fi
+
+echo "E2E changes detected:"
+echo "$changed"
+echo "OK"


### PR DESCRIPTION
Closes #237

## Summary

- Add `scripts/check-e2e.sh`: fails if a PR title starts with `feat:` / `fix:` (including breaking `!` variants) but has no changes under `tests/e2e/`
- Add `check-e2e` CI job in `.github/workflows/ci.yml`: runs only on `pull_request` events
- Update `CONTRIBUTING.md`: document the new script in Build & Test and add a PR checklist item

## Test plan

- [ ] `chore:` / `docs:` / other non-feat/fix titles → job skips with exit 0
- [ ] `feat:` / `fix:` / `feat!:` / `fix!:` titles with no `tests/e2e/` diff → job fails with clear error
- [ ] `feat:` / `fix:` titles with `tests/e2e/` diff → job passes
- [ ] Push to `main` (no PR) → `check-e2e` job is skipped entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)