### PR TITLE
feat: キャッシュエントリの最新ステータスを常時表示する watch コマンドを追加する

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,6 +291,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,10 +333,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
 
 [[package]]
 name = "either"
@@ -512,6 +579,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,6 +612,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "criterion",
+ "crossterm",
  "log",
  "nu-ansi-term",
  "predicates",
@@ -539,6 +622,18 @@ dependencies = [
  "simplelog",
  "tempfile",
  "toml",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -606,6 +701,29 @@ checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
 ]
 
 [[package]]
@@ -742,6 +860,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -843,6 +970,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -907,6 +1040,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simplelog"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,6 +1086,12 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "strsim"
@@ -1069,6 +1239,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1098,6 +1274,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 simplelog = "0.12"
 toml = "1.1.2"
+crossterm = "0.29.0"
 
 [lib]
 name = "merge_ready"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -23,11 +23,7 @@ pub enum Command {
     /// Manage the background cache daemon
     Daemon(DaemonArgs),
     /// Watch daemon cache entries in real time (Ctrl+C to stop)
-    Watch {
-        /// Print once and exit
-        #[arg(long)]
-        once: bool,
-    },
+    Watch,
 }
 
 #[must_use]
@@ -39,7 +35,7 @@ pub fn run(cli: &Cli) -> ExitCode {
             DaemonCommand::Stop => crate::daemon_stop_command(),
             DaemonCommand::Status => crate::daemon_status_command(),
         },
-        Some(Command::Watch { once }) => crate::watch_command(*once),
+        Some(Command::Watch) => crate::watch_command(),
         None => {
             let _ = Cli::command().print_help();
             ExitCode::SUCCESS

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,6 +22,12 @@ pub enum Command {
     Config,
     /// Manage the background cache daemon
     Daemon(DaemonArgs),
+    /// Watch daemon cache entries in real time (Ctrl+C to stop)
+    Watch {
+        /// Print once and exit
+        #[arg(long)]
+        once: bool,
+    },
 }
 
 #[must_use]
@@ -33,6 +39,7 @@ pub fn run(cli: &Cli) -> ExitCode {
             DaemonCommand::Stop => crate::daemon_stop_command(),
             DaemonCommand::Status => crate::daemon_status_command(),
         },
+        Some(Command::Watch { once }) => crate::watch_command(*once),
         None => {
             let _ = Cli::command().print_help();
             ExitCode::SUCCESS

--- a/src/contexts/daemon/application.rs
+++ b/src/contexts/daemon/application.rs
@@ -1,2 +1,4 @@
 pub mod cache;
 pub mod lifecycle;
+pub mod port;
+pub mod watch;

--- a/src/contexts/daemon/application/port.rs
+++ b/src/contexts/daemon/application/port.rs
@@ -1,0 +1,12 @@
+/// キャッシュエントリの表示用ビューモデル。
+pub struct EntryView {
+    pub cwd: String,
+    pub branch: String,
+    pub output: String,
+    pub cached_at_secs: u64,
+}
+
+/// `watch` ユースケースが必要とするアダプタポート。
+pub trait WatchPort {
+    fn entries(&self) -> Option<Vec<EntryView>>;
+}

--- a/src/contexts/daemon/application/watch.rs
+++ b/src/contexts/daemon/application/watch.rs
@@ -1,0 +1,6 @@
+use super::port::{EntryView, WatchPort};
+
+/// キャッシュエントリ一覧を取得するユースケース。
+pub fn entries(port: &impl WatchPort) -> Option<Vec<EntryView>> {
+    port.entries()
+}

--- a/src/contexts/daemon/domain/cache.rs
+++ b/src/contexts/daemon/domain/cache.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 
 /// daemon がキャッシュエントリのリフレッシュ頻度を制御するモード。
 /// evaluation コンテキストの知識（CI 状態・終端状態）を抽象化した daemon 固有の概念。
@@ -50,9 +50,11 @@ pub struct CacheEntry {
     output: String,
     has_fetched: bool,
     pub(crate) fetched_at: Instant,
+    fetched_at_wall: SystemTime,
     refreshing: bool,
     pub(crate) refresh_started_at: Option<Instant>,
     pub(crate) cwd: PathBuf,
+    branch: String,
     refresh_mode: RefreshMode,
     pub(crate) last_queried_at: Option<Instant>,
     pub(crate) cold_refresh_count: u32,
@@ -62,7 +64,7 @@ impl CacheEntry {
     /// 初回ミス時に生成する新規エントリ。即リフレッシュ済み状態でマークする。
     ///
     /// `stale_ttl` は `fetched_at` を TTL 超過済みの過去時刻にセットするために使う。
-    pub fn new(cwd: PathBuf, stale_ttl: u64) -> Self {
+    pub fn new(cwd: PathBuf, branch: String, stale_ttl: u64) -> Self {
         let past = Instant::now()
             .checked_sub(Duration::from_secs(stale_ttl.saturating_add(1)))
             .unwrap_or_else(Instant::now);
@@ -70,9 +72,11 @@ impl CacheEntry {
             output: String::new(),
             has_fetched: false,
             fetched_at: past,
+            fetched_at_wall: SystemTime::now(),
             refreshing: true,
             refresh_started_at: Some(Instant::now()),
             cwd,
+            branch,
             refresh_mode: RefreshMode::Warm,
             last_queried_at: Some(Instant::now()),
             cold_refresh_count: 0,
@@ -86,6 +90,7 @@ impl CacheEntry {
         self.output = output;
         self.has_fetched = true;
         self.fetched_at = Instant::now();
+        self.fetched_at_wall = SystemTime::now();
         self.refreshing = false;
         self.refresh_started_at = None;
         self.refresh_mode = refresh_mode;
@@ -135,6 +140,14 @@ impl CacheEntry {
 
     pub fn cwd(&self) -> &std::path::Path {
         &self.cwd
+    }
+
+    pub fn branch(&self) -> &str {
+        &self.branch
+    }
+
+    pub fn fetched_at_wall(&self) -> SystemTime {
+        self.fetched_at_wall
     }
 
     pub fn refresh_mode(&self) -> RefreshMode {
@@ -204,10 +217,10 @@ pub trait CachePort {
 mod tests {
     use super::*;
     use std::path::PathBuf;
-    use std::time::{Duration, Instant};
+    use std::time::{Duration, Instant, SystemTime};
 
     fn make_entry(output: &str, refresh_mode: RefreshMode) -> CacheEntry {
-        let mut e = CacheEntry::new(PathBuf::new(), 5);
+        let mut e = CacheEntry::new(PathBuf::new(), String::new(), 5);
         e.update(output.to_owned(), refresh_mode);
         e.record_query();
         e
@@ -247,19 +260,19 @@ mod tests {
 
     #[test]
     fn new_entry_starts_refreshing() {
-        let e = CacheEntry::new(PathBuf::new(), 5);
+        let e = CacheEntry::new(PathBuf::new(), String::new(), 5);
         assert!(e.is_refreshing());
     }
 
     #[test]
     fn new_entry_has_not_fetched() {
-        let e = CacheEntry::new(PathBuf::new(), 5);
+        let e = CacheEntry::new(PathBuf::new(), String::new(), 5);
         assert!(!e.has_fetched());
     }
 
     #[test]
     fn new_entry_is_stale() {
-        let e = CacheEntry::new(PathBuf::new(), 5);
+        let e = CacheEntry::new(PathBuf::new(), String::new(), 5);
         assert!(!e.is_fresh(5));
     }
 
@@ -267,7 +280,7 @@ mod tests {
 
     #[test]
     fn update_clears_refreshing_and_sets_has_fetched() {
-        let mut e = CacheEntry::new(PathBuf::new(), 5);
+        let mut e = CacheEntry::new(PathBuf::new(), String::new(), 5);
         e.update("out".to_owned(), RefreshMode::Warm);
         assert!(!e.is_refreshing());
         assert!(e.has_fetched());
@@ -275,7 +288,7 @@ mod tests {
 
     #[test]
     fn update_sets_fresh() {
-        let mut e = CacheEntry::new(PathBuf::new(), 5);
+        let mut e = CacheEntry::new(PathBuf::new(), String::new(), 5);
         e.update("out".to_owned(), RefreshMode::Warm);
         assert!(e.is_fresh(5));
     }
@@ -354,13 +367,13 @@ mod tests {
 
     #[test]
     fn fresh_lock_is_not_expired() {
-        let e = CacheEntry::new(PathBuf::new(), 5);
+        let e = CacheEntry::new(PathBuf::new(), String::new(), 5);
         assert!(!e.refresh_lock_expired(120));
     }
 
     #[test]
     fn old_lock_is_expired() {
-        let mut e = CacheEntry::new(PathBuf::new(), 5);
+        let mut e = CacheEntry::new(PathBuf::new(), String::new(), 5);
         e.refresh_started_at = Some(
             Instant::now()
                 .checked_sub(Duration::from_secs(121))
@@ -373,7 +386,7 @@ mod tests {
 
     #[test]
     fn never_queried_is_cold() {
-        let mut e = CacheEntry::new(PathBuf::new(), 5);
+        let mut e = CacheEntry::new(PathBuf::new(), String::new(), 5);
         e.last_queried_at = None;
         assert!(e.is_cold_or_never_queried(1800));
     }
@@ -411,10 +424,39 @@ mod tests {
 
     #[test]
     fn clear_refresh_lock_resets_refreshing() {
-        let mut e = CacheEntry::new(PathBuf::new(), 5);
+        let mut e = CacheEntry::new(PathBuf::new(), String::new(), 5);
         assert!(e.is_refreshing());
         e.clear_refresh_lock();
         assert!(!e.is_refreshing());
         assert!(!e.refresh_lock_expired(120));
+    }
+
+    // ── CacheEntry::branch ────────────────────────────────────────────────────
+
+    #[test]
+    fn new_entry_stores_branch() {
+        let e = CacheEntry::new(PathBuf::new(), "feat/123".to_owned(), 5);
+        assert_eq!(e.branch(), "feat/123");
+    }
+
+    // ── CacheEntry::fetched_at_wall ───────────────────────────────────────────
+
+    #[test]
+    fn new_entry_sets_fetched_at_wall() {
+        let before = SystemTime::now();
+        let e = CacheEntry::new(PathBuf::new(), String::new(), 5);
+        let after = SystemTime::now();
+        assert!(e.fetched_at_wall() >= before);
+        assert!(e.fetched_at_wall() <= after);
+    }
+
+    #[test]
+    fn update_refreshes_fetched_at_wall() {
+        let mut e = CacheEntry::new(PathBuf::new(), String::new(), 5);
+        let before = SystemTime::now();
+        e.update("out".to_owned(), RefreshMode::Warm);
+        let after = SystemTime::now();
+        assert!(e.fetched_at_wall() >= before);
+        assert!(e.fetched_at_wall() <= after);
     }
 }

--- a/src/contexts/daemon/domain/refresh_policy.rs
+++ b/src/contexts/daemon/domain/refresh_policy.rs
@@ -84,7 +84,7 @@ mod tests {
     }
 
     fn make_entry(output: &str, refresh_mode: RefreshMode) -> CacheEntry {
-        let mut e = CacheEntry::new(PathBuf::new(), 5);
+        let mut e = CacheEntry::new(PathBuf::new(), String::new(), 5);
         e.update(output.to_owned(), refresh_mode);
         e.record_query();
         e

--- a/src/contexts/daemon/infrastructure/daemon_client.rs
+++ b/src/contexts/daemon/infrastructure/daemon_client.rs
@@ -3,7 +3,7 @@ use std::os::unix::net::UnixStream;
 use std::time::Duration;
 
 use super::paths;
-use super::protocol::{RefreshModeDto, Request, Response};
+use super::protocol::{EntryDto, RefreshModeDto, Request, Response};
 use crate::contexts::daemon::domain::cache::{CachePort, RefreshMode, RepoId};
 
 /// デーモンソケットへの接続タイムアウト（ms）
@@ -43,6 +43,13 @@ impl DaemonClient {
                 uptime_secs,
                 version,
             }) => Some((entries, uptime_secs, version)),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn entries_raw() -> Option<Vec<EntryDto>> {
+        match Self::send(&Request::Entries) {
+            Ok(Response::Entries { entries }) => Some(entries),
             _ => None,
         }
     }

--- a/src/contexts/daemon/infrastructure/daemon_lifecycle.rs
+++ b/src/contexts/daemon/infrastructure/daemon_lifecycle.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::contexts::daemon::application::port::{EntryView, WatchPort};
 use crate::contexts::daemon::domain::daemon::{DaemonError, DaemonLifecyclePort, DaemonStatus};
 
 use super::{daemon_client::DaemonClient, daemon_server, pid};
@@ -59,5 +60,20 @@ impl DaemonLifecyclePort for DaemonLifecycle {
 
     fn get_pid(&self) -> Option<u32> {
         pid::read().filter(|&p| pid::is_alive(p))
+    }
+}
+
+impl WatchPort for DaemonLifecycle {
+    fn entries(&self) -> Option<Vec<EntryView>> {
+        DaemonClient::entries_raw().map(|dtos| {
+            dtos.into_iter()
+                .map(|dto| EntryView {
+                    cwd: dto.cwd,
+                    branch: dto.branch,
+                    output: dto.output,
+                    cached_at_secs: dto.cached_at_secs,
+                })
+                .collect()
+        })
     }
 }

--- a/src/contexts/daemon/infrastructure/daemon_server.rs
+++ b/src/contexts/daemon/infrastructure/daemon_server.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 
 use super::paths;
 use super::pid;
-use super::protocol::{RefreshModeDto, Request, Response};
+use super::protocol::{EntryDto, RefreshModeDto, Request, Response};
 use super::repo_id;
 use crate::contexts::daemon::domain::cache::{CacheEntry, RefreshMode};
 use crate::contexts::daemon::domain::daemon::DaemonError;
@@ -330,6 +330,30 @@ fn process(request: &Request, state: &Arc<Mutex<DaemonState>>) -> ActionResult {
                 restart_after_response: false,
             }
         }
+        Request::Entries => {
+            use std::time::UNIX_EPOCH;
+            let dtos: Vec<EntryDto> = s
+                .entries
+                .values()
+                .map(|entry| EntryDto {
+                    cwd: entry.cwd().to_string_lossy().into_owned(),
+                    branch: entry.branch().to_owned(),
+                    output: entry.output().to_owned(),
+                    cached_at_secs: entry
+                        .fetched_at_wall()
+                        .duration_since(UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_secs(),
+                })
+                .collect();
+            ActionResult {
+                response: Response::Entries { entries: dtos },
+                refresh_repo_id: None,
+                refresh_cwd: None,
+                stop: false,
+                restart_after_response: false,
+            }
+        }
     }
 }
 
@@ -388,7 +412,14 @@ fn process_query(
         }
         None => {
             // 初回 Miss → エントリを作成してリフレッシュ予約
-            entries.insert(repo_id.to_owned(), CacheEntry::new(cwd_path.clone(), ttl));
+            let branch = cwd_path
+                .to_str()
+                .map(repo_id::branch_from_cwd)
+                .unwrap_or_default();
+            entries.insert(
+                repo_id.to_owned(),
+                CacheEntry::new(cwd_path.clone(), branch, ttl),
+            );
             ActionResult {
                 response: Response::Output {
                     output: "? loading".to_owned(),
@@ -619,7 +650,7 @@ mod tests {
     use super::*;
 
     fn make_entry(output: &str, refresh_mode: RefreshMode) -> CacheEntry {
-        let mut e = CacheEntry::new(PathBuf::new(), 5);
+        let mut e = CacheEntry::new(PathBuf::new(), String::new(), 5);
         e.update(output.to_owned(), refresh_mode);
         e.record_query();
         e

--- a/src/contexts/daemon/infrastructure/protocol.rs
+++ b/src/contexts/daemon/infrastructure/protocol.rs
@@ -10,6 +10,15 @@ pub enum RefreshModeDto {
     Terminal,
 }
 
+/// キャッシュエントリの表示用 DTO。
+#[derive(Debug, Serialize, Deserialize)]
+pub struct EntryDto {
+    pub cwd: String,
+    pub branch: String,
+    pub output: String,
+    pub cached_at_secs: u64,
+}
+
 /// デーモンへ送信するリクエスト
 #[derive(Serialize, Deserialize)]
 #[serde(tag = "action", rename_all = "snake_case")]
@@ -28,6 +37,7 @@ pub enum Request {
     },
     Stop,
     Status,
+    Entries,
 }
 
 /// デーモンから返却されるレスポンス
@@ -45,4 +55,25 @@ pub enum Response {
         uptime_secs: u64,
         version: String,
     },
+    Entries {
+        entries: Vec<EntryDto>,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn entry_dto_serializes() {
+        let dto = EntryDto {
+            cwd: "/tmp".into(),
+            branch: "main".into(),
+            output: "✓ Ready".into(),
+            cached_at_secs: 1_000,
+        };
+        let json = serde_json::to_string(&dto).unwrap();
+        assert!(json.contains("cached_at_secs"));
+        assert!(json.contains("/tmp"));
+    }
 }

--- a/src/contexts/daemon/infrastructure/repo_id.rs
+++ b/src/contexts/daemon/infrastructure/repo_id.rs
@@ -12,6 +12,14 @@ pub fn repo_id_from_cwd(cwd: &str) -> Option<String> {
     Some(path_to_id(&format!("{}\0{}", toplevel.display(), branch)))
 }
 
+/// `cwd` から現在のブランチ名だけを返す（`repo_id` ハッシュ不要な用途向け）。
+pub fn branch_from_cwd(cwd: &str) -> String {
+    let start = Path::new(cwd);
+    find_git_dir(start)
+        .and_then(|(_, git_dir)| read_head(&git_dir))
+        .unwrap_or_default()
+}
+
 /// カレントディレクトリから上に向かって `.git` を探す。
 ///
 /// worktree またはサブモジュールの場合 `.git` はファイル（`"gitdir: <path>"` 形式）。

--- a/src/contexts/daemon/interface/cli.rs
+++ b/src/contexts/daemon/interface/cli.rs
@@ -1,3 +1,4 @@
 pub mod daemon;
+pub mod watch;
 
 pub use daemon::DaemonArgs;

--- a/src/contexts/daemon/interface/cli/watch.rs
+++ b/src/contexts/daemon/interface/cli/watch.rs
@@ -1,0 +1,204 @@
+use std::process::ExitCode;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use crossterm::{
+    cursor, execute,
+    terminal::{self, ClearType},
+};
+
+use crate::contexts::daemon::application::port::{EntryView, WatchPort};
+use crate::contexts::daemon::application::watch;
+
+const POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+pub fn run(once: bool, port: &impl WatchPort) -> ExitCode {
+    if once {
+        return run_once(port);
+    }
+
+    loop {
+        let mut stdout = std::io::stdout();
+        let _ = execute!(
+            stdout,
+            terminal::Clear(ClearType::All),
+            cursor::MoveTo(0, 0)
+        );
+        let code = run_once(port);
+        if code != ExitCode::SUCCESS {
+            return code;
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
+}
+
+fn run_once(port: &impl WatchPort) -> ExitCode {
+    match watch::entries(port) {
+        None => {
+            println!("daemon is not running");
+            ExitCode::FAILURE
+        }
+        Some(entries) => {
+            print!("{}", format_table(&entries));
+            ExitCode::SUCCESS
+        }
+    }
+}
+
+fn format_table(entries: &[EntryView]) -> String {
+    if entries.is_empty() {
+        return "no entries cached\n".to_owned();
+    }
+
+    let header = ("CWD", "BRANCH", "STATUS", "CACHED AT");
+    let rows: Vec<(String, String, String, String)> = entries
+        .iter()
+        .map(|e| {
+            (
+                e.cwd.clone(),
+                e.branch.clone(),
+                e.output.clone(),
+                format_cached_at(e.cached_at_secs),
+            )
+        })
+        .collect();
+
+    let w0 = rows
+        .iter()
+        .map(|r| r.0.len())
+        .max()
+        .unwrap_or(0)
+        .max(header.0.len());
+    let w1 = rows
+        .iter()
+        .map(|r| r.1.len())
+        .max()
+        .unwrap_or(0)
+        .max(header.1.len());
+    let w2 = rows
+        .iter()
+        .map(|r| visible_len(&r.2))
+        .max()
+        .unwrap_or(0)
+        .max(header.2.len());
+
+    let mut out = String::new();
+    out.push_str(&format!(
+        "{:<w0$}  {:<w1$}  {:<w2$}  {}\n",
+        header.0, header.1, header.2, header.3,
+    ));
+    for row in &rows {
+        let pad = w2 - visible_len(&row.2) + row.2.len();
+        out.push_str(&format!(
+            "{:<w0$}  {:<w1$}  {:<pad$}  {}\n",
+            row.0, row.1, row.2, row.3,
+        ));
+    }
+    out
+}
+
+fn visible_len(s: &str) -> usize {
+    // ANSI エスケープシーケンス（ESC [ ... m）を除いた表示幅
+    let mut len = 0;
+    let mut in_escape = false;
+    for c in s.chars() {
+        if c == '\x1b' {
+            in_escape = true;
+        } else if in_escape {
+            if c == 'm' {
+                in_escape = false;
+            }
+        } else {
+            len += 1;
+        }
+    }
+    len
+}
+
+fn format_cached_at(cached_at_secs: u64) -> String {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let elapsed = now.saturating_sub(cached_at_secs);
+    if elapsed < 60 {
+        format!("{elapsed}s ago")
+    } else if elapsed < 3600 {
+        format!("{}m ago", elapsed / 60)
+    } else {
+        format!("{}h ago", elapsed / 3600)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_view(cwd: &str, branch: &str, output: &str, age_secs: u64) -> EntryView {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        EntryView {
+            cwd: cwd.to_owned(),
+            branch: branch.to_owned(),
+            output: output.to_owned(),
+            cached_at_secs: now.saturating_sub(age_secs),
+        }
+    }
+
+    #[test]
+    fn format_table_empty_returns_no_entries_message() {
+        let table = format_table(&[]);
+        assert!(table.contains("no entries cached"));
+    }
+
+    #[test]
+    fn format_table_shows_header() {
+        let view = make_view("/repo", "main", "✓ Ready", 5);
+        let table = format_table(&[view]);
+        assert!(table.contains("CWD"));
+        assert!(table.contains("BRANCH"));
+        assert!(table.contains("STATUS"));
+        assert!(table.contains("CACHED AT"));
+    }
+
+    #[test]
+    fn format_table_shows_all_columns() {
+        let view = make_view("/repo/myapp", "feat/123", "✓ Ready for merge", 10);
+        let table = format_table(&[view]);
+        assert!(table.contains("/repo/myapp"));
+        assert!(table.contains("feat/123"));
+        assert!(table.contains("✓ Ready for merge"));
+        assert!(table.contains("ago"));
+    }
+
+    #[test]
+    fn format_cached_at_seconds() {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let s = format_cached_at(now.saturating_sub(5));
+        assert!(s.ends_with("s ago"));
+    }
+
+    #[test]
+    fn format_cached_at_minutes() {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let s = format_cached_at(now.saturating_sub(90));
+        assert!(s.ends_with("m ago"));
+    }
+
+    #[test]
+    fn format_cached_at_hours() {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let s = format_cached_at(now.saturating_sub(7200));
+        assert!(s.ends_with("h ago"));
+    }
+}

--- a/src/contexts/daemon/interface/cli/watch.rs
+++ b/src/contexts/daemon/interface/cli/watch.rs
@@ -11,35 +11,34 @@ use crate::contexts::daemon::application::watch;
 
 const POLL_INTERVAL: Duration = Duration::from_secs(1);
 
-pub fn run(once: bool, port: &impl WatchPort) -> ExitCode {
-    if once {
-        return run_once(port);
-    }
-
+pub fn run(port: &impl WatchPort) -> ExitCode {
     loop {
-        let mut stdout = std::io::stdout();
-        let _ = execute!(
-            stdout,
-            terminal::Clear(ClearType::All),
-            cursor::MoveTo(0, 0)
-        );
-        let code = run_once(port);
-        if code != ExitCode::SUCCESS {
-            return code;
+        clear_screen();
+        if !draw(port) {
+            return ExitCode::FAILURE;
         }
         std::thread::sleep(POLL_INTERVAL);
     }
 }
 
-fn run_once(port: &impl WatchPort) -> ExitCode {
+fn clear_screen() {
+    let mut stdout = std::io::stdout();
+    let _ = execute!(
+        stdout,
+        terminal::Clear(ClearType::All),
+        cursor::MoveTo(0, 0)
+    );
+}
+
+fn draw(port: &impl WatchPort) -> bool {
     match watch::entries(port) {
         None => {
             println!("daemon is not running");
-            ExitCode::FAILURE
+            false
         }
         Some(entries) => {
             print!("{}", format_table(&entries));
-            ExitCode::SUCCESS
+            true
         }
     }
 }

--- a/src/contexts/daemon/interface/cli/watch.rs
+++ b/src/contexts/daemon/interface/cli/watch.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write as _;
 use std::process::ExitCode;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -81,16 +82,18 @@ fn format_table(entries: &[EntryView]) -> String {
         .max(header.2.len());
 
     let mut out = String::new();
-    out.push_str(&format!(
-        "{:<w0$}  {:<w1$}  {:<w2$}  {}\n",
+    let _ = writeln!(
+        out,
+        "{:<w0$}  {:<w1$}  {:<w2$}  {}",
         header.0, header.1, header.2, header.3,
-    ));
+    );
     for row in &rows {
         let pad = w2 - visible_len(&row.2) + row.2.len();
-        out.push_str(&format!(
-            "{:<w0$}  {:<w1$}  {:<pad$}  {}\n",
-            row.0, row.1, row.2, row.3,
-        ));
+        let _ = writeln!(
+            out,
+            "{:<w0$}  {:<w1$}  {:<pad$}  {}",
+            row.0, row.1, row.2, row.3
+        );
     }
     out
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,3 +76,10 @@ pub fn daemon_status_command() -> ExitCode {
     let lifecycle = build_daemon_lifecycle();
     contexts::daemon::interface::cli::daemon::run(DaemonCommand::Status, &lifecycle)
 }
+
+/// Watches daemon cache entries in real time.
+#[must_use]
+pub fn watch_command(once: bool) -> ExitCode {
+    let lifecycle = build_daemon_lifecycle();
+    contexts::daemon::interface::cli::watch::run(once, &lifecycle)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ pub fn daemon_status_command() -> ExitCode {
 
 /// Watches daemon cache entries in real time.
 #[must_use]
-pub fn watch_command(once: bool) -> ExitCode {
+pub fn watch_command() -> ExitCode {
     let lifecycle = build_daemon_lifecycle();
-    contexts::daemon::interface::cli::watch::run(once, &lifecycle)
+    contexts::daemon::interface::cli::watch::run(&lifecycle)
 }

--- a/tests/e2e/daemon/mod.rs
+++ b/tests/e2e/daemon/mod.rs
@@ -1,1 +1,2 @@
 mod lifecycle;
+mod watch;

--- a/tests/e2e/daemon/watch.rs
+++ b/tests/e2e/daemon/watch.rs
@@ -1,5 +1,10 @@
 //! `merge-ready watch` コマンドの E2E テスト（シナリオ #W1–#W3）
 
+use std::io::{BufRead, BufReader};
+use std::process::Stdio;
+use std::sync::mpsc;
+use std::time::Duration;
+
 use assert_cmd::Command;
 use predicates::prelude::*;
 
@@ -9,16 +14,59 @@ const BIN: &str = "merge-ready";
 const OPEN_PR_VIEW_JSON: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}"#;
 const CI_PASS_JSON: &str = r#"[{"bucket":"pass","state":"SUCCESS","name":"ci","link":""}]"#;
 
+/// `merge-ready watch` を起動し、`n` 行分の stdout を最大 `timeout` で読んで返す。
+/// 読み取り後に SIGINT を送りプロセスを終了させる。
+fn spawn_watch_and_read(env: &TestEnv, n: usize, timeout: Duration) -> String {
+    let bin = assert_cmd::cargo::cargo_bin(BIN);
+    let mut child = std::process::Command::new(bin)
+        .args(["watch"])
+        .env("PATH", env.path_env())
+        .env("HOME", env.home())
+        .env("TMPDIR", env.home())
+        .env("XDG_CONFIG_HOME", env.home().join(".config"))
+        .current_dir(env.repo_dir.path())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn merge-ready watch");
+
+    let stdout = child.stdout.take().expect("stdout not captured");
+    let (tx, rx) = mpsc::channel::<String>();
+    std::thread::spawn(move || {
+        let reader = BufReader::new(stdout);
+        let mut out = String::new();
+        for line in reader.lines().take(n) {
+            match line {
+                Ok(l) => {
+                    out.push_str(&l);
+                    out.push('\n');
+                }
+                Err(_) => break,
+            }
+        }
+        let _ = tx.send(out);
+    });
+
+    let output = rx.recv_timeout(timeout).unwrap_or_default();
+
+    let _ = std::process::Command::new("kill")
+        .args(["-INT", &child.id().to_string()])
+        .status();
+    let _ = child.wait();
+
+    output
+}
+
 // ── #W1: daemon 未起動 ────────────────────────────────────────────────────────
 
-/// #W1: daemon 未起動時に `watch --once` → "not running" を出力して exit 非 0
+/// #W1: daemon 未起動時に `watch` → "not running" を出力して exit 非 0
 #[test]
-fn test_watch_once_daemon_not_running() {
+fn test_watch_daemon_not_running() {
     let env = TestEnv::new(OPEN_PR_VIEW_JSON, Some(CI_PASS_JSON));
 
     let mut cmd = Command::cargo_bin(BIN).unwrap();
     env.apply(&mut cmd);
-    cmd.args(["watch", "--once"]);
+    cmd.args(["watch"]);
     cmd.assert()
         .failure()
         .stdout(predicate::str::contains("not running"));
@@ -26,32 +74,32 @@ fn test_watch_once_daemon_not_running() {
 
 // ── #W2: daemon 起動後、ヘッダ表示 ───────────────────────────────────────────
 
-/// #W2: daemon 起動後に `watch --once` → テーブルヘッダを含む出力
+/// #W2: daemon 起動後に `watch` → テーブルヘッダを含む出力（Ctrl+C で終了）
 #[test]
-fn test_watch_once_shows_header_when_daemon_running() {
+fn test_watch_shows_header_when_daemon_running() {
     let env = TestEnv::new(OPEN_PR_VIEW_JSON, Some(CI_PASS_JSON));
     let _daemon = DaemonHandle::start(&env);
 
-    let mut cmd = Command::cargo_bin(BIN).unwrap();
-    env.apply(&mut cmd);
-    cmd.args(["watch", "--once"]);
-    cmd.assert()
-        .success()
-        .stdout(predicate::str::contains("CWD").or(predicate::str::contains("no entries cached")));
+    let output = spawn_watch_and_read(&env, 1, Duration::from_secs(5));
+
+    assert!(
+        output.contains("CWD") || output.contains("no entries cached"),
+        "unexpected output: {output:?}"
+    );
 }
 
 // ── #W3: エントリが存在しない場合 ─────────────────────────────────────────────
 
 /// #W3: daemon 起動直後（エントリなし）は "no entries cached" を表示
 #[test]
-fn test_watch_once_shows_no_entries_when_empty() {
+fn test_watch_shows_no_entries_when_empty() {
     let env = TestEnv::new(OPEN_PR_VIEW_JSON, Some(CI_PASS_JSON));
     let _daemon = DaemonHandle::start(&env);
 
-    let mut cmd = Command::cargo_bin(BIN).unwrap();
-    env.apply(&mut cmd);
-    cmd.args(["watch", "--once"]);
-    cmd.assert()
-        .success()
-        .stdout(predicate::str::contains("no entries cached"));
+    let output = spawn_watch_and_read(&env, 1, Duration::from_secs(5));
+
+    assert!(
+        output.contains("no entries cached"),
+        "unexpected output: {output:?}"
+    );
 }

--- a/tests/e2e/daemon/watch.rs
+++ b/tests/e2e/daemon/watch.rs
@@ -1,0 +1,57 @@
+//! `merge-ready watch` コマンドの E2E テスト（シナリオ #W1–#W3）
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+use super::super::helpers::{DaemonHandle, TestEnv};
+
+const BIN: &str = "merge-ready";
+const OPEN_PR_VIEW_JSON: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}"#;
+const CI_PASS_JSON: &str = r#"[{"bucket":"pass","state":"SUCCESS","name":"ci","link":""}]"#;
+
+// ── #W1: daemon 未起動 ────────────────────────────────────────────────────────
+
+/// #W1: daemon 未起動時に `watch --once` → "not running" を出力して exit 非 0
+#[test]
+fn test_watch_once_daemon_not_running() {
+    let env = TestEnv::new(OPEN_PR_VIEW_JSON, Some(CI_PASS_JSON));
+
+    let mut cmd = Command::cargo_bin(BIN).unwrap();
+    env.apply(&mut cmd);
+    cmd.args(["watch", "--once"]);
+    cmd.assert()
+        .failure()
+        .stdout(predicate::str::contains("not running"));
+}
+
+// ── #W2: daemon 起動後、ヘッダ表示 ───────────────────────────────────────────
+
+/// #W2: daemon 起動後に `watch --once` → テーブルヘッダを含む出力
+#[test]
+fn test_watch_once_shows_header_when_daemon_running() {
+    let env = TestEnv::new(OPEN_PR_VIEW_JSON, Some(CI_PASS_JSON));
+    let _daemon = DaemonHandle::start(&env);
+
+    let mut cmd = Command::cargo_bin(BIN).unwrap();
+    env.apply(&mut cmd);
+    cmd.args(["watch", "--once"]);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("CWD").or(predicate::str::contains("no entries cached")));
+}
+
+// ── #W3: エントリが存在しない場合 ─────────────────────────────────────────────
+
+/// #W3: daemon 起動直後（エントリなし）は "no entries cached" を表示
+#[test]
+fn test_watch_once_shows_no_entries_when_empty() {
+    let env = TestEnv::new(OPEN_PR_VIEW_JSON, Some(CI_PASS_JSON));
+    let _daemon = DaemonHandle::start(&env);
+
+    let mut cmd = Command::cargo_bin(BIN).unwrap();
+    env.apply(&mut cmd);
+    cmd.args(["watch", "--once"]);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("no entries cached"));
+}


### PR DESCRIPTION
Closes #217

## Summary

- `merge-ready watch` コマンドを追加。daemon が保持するキャッシュエントリを 1 秒間隔でポーリングし、crossterm で画面クリア＋再描画
- `CacheEntry` に `branch: String`・`fetched_at_wall: SystemTime` を追加し、エントリ生成時にブランチ名とウォールクロック時刻を保持
- IPC プロトコルに `Request::Entries` / `Response::Entries` / `EntryDto` を追加
- DDD 層規則に従い `application/port.rs` に `WatchPort` トレイト・`EntryView` を定義し、`interface` → `infrastructure` の直接依存を排除
- E2E テストは spawn + `kill -INT` 方式で実装（ユーザーインターフェースに `--once` フラグを追加しない）

## Test plan

- [x] `cargo test --workspace`（220 テスト全通過）
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo fmt --check --all`
- [x] `cargo deny check`
- [x] `bash scripts/check-layer-deps.sh`
- [x] `bash scripts/check-no-mod-rs.sh`
- [x] E2E テスト: daemon 未起動時に exit 非ゼロ・"not running" 表示（#W1）
- [x] E2E テスト: daemon 起動中に "no entries cached" または "CWD" ヘッダ表示（#W2/#W3）

🤖 Generated with [Claude Code](https://claude.ai/claude-code)