### PR TITLE
refactor: replace multiple bool fields with enum state machines

### DIFF
--- a/src/contexts/daemon/domain/cache.rs
+++ b/src/contexts/daemon/domain/cache.rs
@@ -175,7 +175,10 @@ impl CacheEntry {
     }
 
     pub fn is_refreshing(&self) -> bool {
-        matches!(self.fetch_state, FetchState::Loading | FetchState::Refreshing)
+        matches!(
+            self.fetch_state,
+            FetchState::Loading | FetchState::Refreshing
+        )
     }
 
     pub fn cold_refresh_count(&self) -> u32 {

--- a/src/contexts/daemon/domain/cache.rs
+++ b/src/contexts/daemon/domain/cache.rs
@@ -45,13 +45,29 @@ impl std::fmt::Display for RepoId {
     }
 }
 
+/// `CacheEntry` のフェッチ状態を表す状態機械。
+///
+/// 有効な遷移:
+/// `Loading` → (`update`) → `Ready` → (`mark_refreshing`) → `Refreshing` → (`update`) → `Ready`
+/// `Loading` → (`clear_refresh_lock`) → `PendingRetry` → (`mark_refreshing`) → `Loading`
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FetchState {
+    /// 初回リフレッシュ進行中。データ未取得。
+    Loading,
+    /// 初回リフレッシュがタイムアウト。再スケジュール待ち。データ未取得。
+    PendingRetry,
+    /// データ取得済み。リフレッシュ不要。
+    Ready,
+    /// データ取得済み。再リフレッシュ進行中。
+    Refreshing,
+}
+
 /// キャッシュエントリのドメインエンティティ。
 pub struct CacheEntry {
     output: String,
-    has_fetched: bool,
+    fetch_state: FetchState,
     pub(crate) fetched_at: Instant,
     fetched_at_wall: SystemTime,
-    refreshing: bool,
     pub(crate) refresh_started_at: Option<Instant>,
     pub(crate) cwd: PathBuf,
     branch: String,
@@ -70,10 +86,9 @@ impl CacheEntry {
             .unwrap_or_else(Instant::now);
         Self {
             output: String::new(),
-            has_fetched: false,
+            fetch_state: FetchState::Loading,
             fetched_at: past,
             fetched_at_wall: SystemTime::now(),
-            refreshing: true,
             refresh_started_at: Some(Instant::now()),
             cwd,
             branch,
@@ -88,17 +103,19 @@ impl CacheEntry {
     /// バックグラウンドワーカーの取得結果でエントリを更新する。
     pub fn update(&mut self, output: String, refresh_mode: RefreshMode) {
         self.output = output;
-        self.has_fetched = true;
+        self.fetch_state = FetchState::Ready;
         self.fetched_at = Instant::now();
         self.fetched_at_wall = SystemTime::now();
-        self.refreshing = false;
         self.refresh_started_at = None;
         self.refresh_mode = refresh_mode;
     }
 
     /// リフレッシュ開始をマークする。
     pub fn mark_refreshing(&mut self) {
-        self.refreshing = true;
+        self.fetch_state = match self.fetch_state {
+            FetchState::Loading | FetchState::PendingRetry => FetchState::Loading,
+            FetchState::Ready | FetchState::Refreshing => FetchState::Refreshing,
+        };
         self.refresh_started_at = Some(Instant::now());
     }
 
@@ -124,7 +141,10 @@ impl CacheEntry {
 
     /// リフレッシュロックを解除する（タイムアウト時）。
     pub fn clear_refresh_lock(&mut self) {
-        self.refreshing = false;
+        self.fetch_state = match self.fetch_state {
+            FetchState::Loading | FetchState::PendingRetry => FetchState::PendingRetry,
+            FetchState::Ready | FetchState::Refreshing => FetchState::Ready,
+        };
         self.refresh_started_at = None;
     }
 
@@ -135,7 +155,7 @@ impl CacheEntry {
     }
 
     pub fn has_fetched(&self) -> bool {
-        self.has_fetched
+        matches!(self.fetch_state, FetchState::Ready | FetchState::Refreshing)
     }
 
     pub fn cwd(&self) -> &std::path::Path {
@@ -155,7 +175,7 @@ impl CacheEntry {
     }
 
     pub fn is_refreshing(&self) -> bool {
-        self.refreshing
+        matches!(self.fetch_state, FetchState::Loading | FetchState::Refreshing)
     }
 
     pub fn cold_refresh_count(&self) -> u32 {
@@ -429,6 +449,35 @@ mod tests {
         e.clear_refresh_lock();
         assert!(!e.is_refreshing());
         assert!(!e.refresh_lock_expired(120));
+    }
+
+    #[test]
+    fn clear_refresh_lock_from_loading_preserves_not_fetched() {
+        let mut e = CacheEntry::new(PathBuf::new(), String::new(), 5);
+        assert!(!e.has_fetched());
+        e.clear_refresh_lock();
+        assert!(!e.has_fetched(), "PendingRetry は未フェッチを保持する");
+    }
+
+    #[test]
+    fn mark_refreshing_from_pending_retry_returns_to_loading() {
+        let mut e = CacheEntry::new(PathBuf::new(), String::new(), 5);
+        e.clear_refresh_lock(); // Loading → PendingRetry
+        assert!(!e.is_refreshing());
+        assert!(!e.has_fetched());
+        e.mark_refreshing(); // PendingRetry → Loading
+        assert!(e.is_refreshing());
+        assert!(!e.has_fetched());
+    }
+
+    #[test]
+    fn mark_refreshing_from_ready_transitions_to_refreshing_with_fetched() {
+        let mut e = make_entry("out", RefreshMode::Warm);
+        assert!(e.has_fetched());
+        assert!(!e.is_refreshing());
+        e.mark_refreshing(); // Ready → Refreshing
+        assert!(e.is_refreshing());
+        assert!(e.has_fetched(), "Refreshing は取得済みを保持する");
     }
 
     // ── CacheEntry::branch ────────────────────────────────────────────────────

--- a/src/contexts/daemon/infrastructure/daemon_server.rs
+++ b/src/contexts/daemon/infrastructure/daemon_server.rs
@@ -386,8 +386,15 @@ fn process_query(
             let output = entry.output().to_owned();
             let has_fetched = entry.has_fetched();
             let stored_cwd = entry.cwd().to_path_buf();
-            let need_refresh = !entry.is_refreshing();
-            let refreshing_now = entry.is_refreshing();
+            let refresh_state = if entry.is_refreshing() {
+                RefreshState::Refreshing {
+                    restart_after: restart_after_response,
+                }
+            } else {
+                RefreshState::NeedsRefresh {
+                    restart_after: restart_after_response,
+                }
+            };
             let is_terminal = entry.refresh_mode() == RefreshMode::Terminal;
             // Query を受けたので last_queried_at を更新し Cold カウンタをリセット
             let was_cold = entry.is_cold_or_never_queried(policy.warm_to_cold_secs);
@@ -395,7 +402,7 @@ fn process_query(
                 entry.reset_cold_count();
             }
             entry.record_query();
-            if is_terminal && need_refresh {
+            if is_terminal && matches!(refresh_state, RefreshState::NeedsRefresh { .. }) {
                 // Terminal が stale になったらモードをリセットして再確認
                 entry.reset_to_warm();
             }
@@ -405,9 +412,7 @@ fn process_query(
                     output,
                     has_fetched,
                     stored_cwd,
-                    need_refresh,
-                    refreshing_now,
-                    restart_after_response,
+                    refresh_state,
                 },
                 entries,
             )
@@ -518,14 +523,17 @@ fn env_u64(key: &str, default: u64) -> u64 {
 
 // ── 内部処理ヘルパー ──────────────────────────────────────────────────────────
 
-#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone, Copy)]
+enum RefreshState {
+    NeedsRefresh { restart_after: bool },
+    Refreshing { restart_after: bool },
+}
+
 struct StaleQueryParams {
     output: String,
     has_fetched: bool,
     stored_cwd: PathBuf,
-    need_refresh: bool,
-    refreshing_now: bool,
-    restart_after_response: bool,
+    refresh_state: RefreshState,
 }
 
 fn process_stale_query(
@@ -537,52 +545,39 @@ fn process_stale_query(
         output,
         has_fetched,
         stored_cwd,
-        need_refresh,
-        refreshing_now,
-        restart_after_response,
+        refresh_state,
     } = params;
 
-    if output.is_empty() {
-        if refreshing_now && !has_fetched {
-            return ActionResult {
-                response: Response::Output {
-                    output: "? loading".to_owned(),
-                },
-                refresh_repo_id: None,
-                refresh_cwd: None,
-                stop: false,
-                restart_after_response,
-            };
-        }
-        if need_refresh {
+    match (refresh_state, has_fetched) {
+        (RefreshState::Refreshing { restart_after }, false) => ActionResult {
+            response: Response::Output {
+                output: "? loading".to_owned(),
+            },
+            refresh_repo_id: None,
+            refresh_cwd: None,
+            stop: false,
+            restart_after_response: restart_after,
+        },
+        (RefreshState::Refreshing { restart_after }, true) => ActionResult {
+            response: Response::Output { output },
+            refresh_repo_id: None,
+            refresh_cwd: None,
+            stop: false,
+            restart_after_response: restart_after,
+        },
+        (RefreshState::NeedsRefresh { restart_after }, _) => {
             entries
                 .get_mut(repo_id)
                 .expect("entry exists")
                 .mark_refreshing();
+            ActionResult {
+                response: Response::Output { output },
+                refresh_repo_id: Some(repo_id.to_owned()),
+                refresh_cwd: Some(stored_cwd),
+                stop: false,
+                restart_after_response: restart_after,
+            }
         }
-        return ActionResult {
-            response: Response::Output {
-                output: String::new(),
-            },
-            refresh_repo_id: need_refresh.then(|| repo_id.to_owned()),
-            refresh_cwd: need_refresh.then_some(stored_cwd),
-            stop: false,
-            restart_after_response,
-        };
-    }
-
-    if need_refresh {
-        entries
-            .get_mut(repo_id)
-            .expect("entry exists")
-            .mark_refreshing();
-    }
-    ActionResult {
-        response: Response::Output { output },
-        refresh_repo_id: need_refresh.then(|| repo_id.to_owned()),
-        refresh_cwd: need_refresh.then_some(stored_cwd),
-        stop: false,
-        restart_after_response,
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #224

`StaleQueryParams` の `#[allow(clippy::struct_excessive_bools)]` が示す設計問題を、根本から修正する。

### `CacheEntry` に `FetchState` enum を導入（`cache.rs`）

`has_fetched: bool` と `refreshing: bool` の 2 つの bool は `(false, false)` という到達不能な無効状態を型レベルで防げなかった。`FetchState` enum に置き換え、すべての有効な状態を明示的に表現する。

| 状態 | `has_fetched()` | `is_refreshing()` | 意味 |
|---|---|---|---|
| `Loading` | false | true | 初回リフレッシュ進行中 |
| `PendingRetry` | false | false | タイムアウト後、再スケジュール待ち |
| `Ready` | true | false | データ取得済み、アイドル |
| `Refreshing` | true | true | データ取得済み、再リフレッシュ中 |

`PendingRetry` は `clear_refresh_lock()` が `Loading` 状態から呼ばれる（初回フェッチのロックタイムアウト）際に生じていた `(false, false)` の無効状態を型として正しく表現するために導入した。

`has_fetched()` / `is_refreshing()` の公開 API は変更なし。

### `StaleQueryParams` に `RefreshState` enum を導入（`daemon_server.rs`）

`need_refresh`、`refreshing_now`、`restart_after_response` の 3 bool を `RefreshState::{ NeedsRefresh { restart_after }, Refreshing { restart_after } }` に統合し、`#[allow(clippy::struct_excessive_bools)]` を削除した。

## Test plan

- [x] `cargo test --workspace` — 226 tests passed（新規 3 件含む）
- [x] `cargo clippy --workspace -- -D warnings` — No issues
- [x] `cargo fmt --check --all` — Clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)