### PR TITLE
refactor: TomlConfigRepository に path フィールドを持たせ unused_self を除去する

### DIFF
--- a/src/contexts/evaluation/infrastructure/toml_loader.rs
+++ b/src/contexts/evaluation/infrastructure/toml_loader.rs
@@ -5,12 +5,19 @@ use crate::contexts::evaluation::domain::display_config::{
     DisplayConfig, DisplayConfigRepository, ErrorConfig, TokenConfig,
 };
 
-pub struct TomlConfigRepository;
+pub struct TomlConfigRepository {
+    path: Option<PathBuf>,
+}
 
-#[allow(clippy::unused_self)]
+impl TomlConfigRepository {
+    pub fn new() -> Self {
+        Self { path: config_path() }
+    }
+}
+
 impl DisplayConfigRepository for TomlConfigRepository {
     fn load(&self) -> DisplayConfig {
-        let Some(path) = config_path() else {
+        let Some(ref path) = self.path else {
             return DisplayConfig::default();
         };
         let Ok(content) = std::fs::read_to_string(path) else {

--- a/src/contexts/evaluation/infrastructure/toml_loader.rs
+++ b/src/contexts/evaluation/infrastructure/toml_loader.rs
@@ -11,7 +11,9 @@ pub struct TomlConfigRepository {
 
 impl TomlConfigRepository {
     pub fn new() -> Self {
-        Self { path: config_path() }
+        Self {
+            path: config_path(),
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ fn build_daemon_lifecycle() -> DaemonLifecycle {
             let client = GhClient::new_in(cwd.to_path_buf(), Logger);
             let (output, hint) = contexts::evaluation::interface::prompt::render(
                 &client,
-                &TomlConfigRepository,
+                &TomlConfigRepository::new(),
                 &Logger,
             );
             let refresh_mode = cache_hint_to_refresh_mode(hint);


### PR DESCRIPTION
closes #222

## Summary

- `TomlConfigRepository` をユニット構造体から `path: Option<PathBuf>` フィールドを持つ構造体に変更
- `new()` コンストラクタで `config_path()` を評価し `self.path` に保持
- `load(&self)` が `self.path` を参照するため `#[allow(clippy::unused_self)]` を削除

## Test plan

- [ ] `cargo build` が通ること
- [ ] `cargo clippy --workspace -- -D warnings` が警告なしで通ること
- [ ] `cargo test --workspace` が全テスト通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)