### PR TITLE
refactor!: CLI 型をバイナリ側に移動し contexts から clap 依存を除去する

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,9 +1,6 @@
 use std::process::ExitCode;
 
-use clap::{CommandFactory, Parser, Subcommand};
-
-use crate::contexts::daemon::interface::cli::DaemonArgs;
-use crate::contexts::daemon::interface::cli::daemon::DaemonCommand;
+use clap::{Args, CommandFactory, Parser, Subcommand};
 
 #[derive(Parser)]
 #[command(
@@ -26,16 +23,32 @@ pub enum Command {
     Watch,
 }
 
+#[derive(Args, Clone, Copy)]
+pub struct DaemonArgs {
+    #[command(subcommand)]
+    pub subcommand: DaemonCommand,
+}
+
+#[derive(Subcommand, Clone, Copy)]
+pub enum DaemonCommand {
+    /// Start the background cache daemon
+    Start,
+    /// Stop the running daemon
+    Stop,
+    /// Show daemon status
+    Status,
+}
+
 #[must_use]
 pub fn run(cli: &Cli) -> ExitCode {
     match &cli.command {
-        Some(Command::Config) => crate::config_command(),
+        Some(Command::Config) => merge_ready::config_command(),
         Some(Command::Daemon(args)) => match args.subcommand {
-            DaemonCommand::Start => crate::daemon_start_command(),
-            DaemonCommand::Stop => crate::daemon_stop_command(),
-            DaemonCommand::Status => crate::daemon_status_command(),
+            DaemonCommand::Start => merge_ready::daemon_start_command(),
+            DaemonCommand::Stop => merge_ready::daemon_stop_command(),
+            DaemonCommand::Status => merge_ready::daemon_status_command(),
         },
-        Some(Command::Watch) => crate::watch_command(),
+        Some(Command::Watch) => merge_ready::watch_command(),
         None => {
             let _ = Cli::command().print_help();
             ExitCode::SUCCESS

--- a/src/contexts/daemon/interface/cli.rs
+++ b/src/contexts/daemon/interface/cli.rs
@@ -1,4 +1,2 @@
 pub mod daemon;
 pub mod watch;
-
-pub use daemon::DaemonArgs;

--- a/src/contexts/daemon/interface/cli/daemon.rs
+++ b/src/contexts/daemon/interface/cli/daemon.rs
@@ -3,36 +3,10 @@ use std::process::{ExitCode, Stdio};
 use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
-use clap::{Args, Subcommand};
-
 use crate::contexts::daemon::application::lifecycle::{self, Port};
 
 const DAEMON_INNER_ENV: &str = "MERGE_READY_DAEMON_INNER";
 const START_TIMEOUT_SECS: u64 = 2;
-
-#[derive(Subcommand, Clone, Copy)]
-pub enum DaemonCommand {
-    /// Start the background cache daemon
-    Start,
-    /// Stop the running daemon
-    Stop,
-    /// Show daemon status
-    Status,
-}
-
-#[derive(Args, Clone, Copy)]
-pub struct DaemonArgs {
-    #[command(subcommand)]
-    pub subcommand: DaemonCommand,
-}
-
-pub fn run(subcommand: DaemonCommand, port: &impl Port) -> ExitCode {
-    match subcommand {
-        DaemonCommand::Start => start(port),
-        DaemonCommand::Stop => stop(port),
-        DaemonCommand::Status => status(port),
-    }
-}
 
 // Why double-spawn instead of alternatives:
 //
@@ -44,7 +18,7 @@ pub fn run(subcommand: DaemonCommand, port: &impl Port) -> ExitCode {
 // 欠点は setsid() を呼べないため SIGHUP を受ける可能性があること。
 // ただしプロンプト統合の用途では端末クローズ時にデーモンが終了しても
 // 次回 prompt 呼び出し時に lazy_start() が再起動するため実害はない。
-fn start(port: &impl Port) -> ExitCode {
+pub(crate) fn start(port: &impl Port) -> ExitCode {
     if std::env::var(DAEMON_INNER_ENV).is_ok() {
         return match lifecycle::start(port) {
             Ok(()) => ExitCode::SUCCESS,
@@ -117,7 +91,7 @@ fn start(port: &impl Port) -> ExitCode {
     }
 }
 
-fn stop(port: &impl Port) -> ExitCode {
+pub(crate) fn stop(port: &impl Port) -> ExitCode {
     if lifecycle::stop(port) {
         println!("daemon stopped");
     } else {
@@ -126,7 +100,7 @@ fn stop(port: &impl Port) -> ExitCode {
     ExitCode::SUCCESS
 }
 
-fn status(port: &impl Port) -> ExitCode {
+pub(crate) fn status(port: &impl Port) -> ExitCode {
     match lifecycle::get_status(port) {
         Some(s) => {
             let pid = lifecycle::get_pid(port).map_or_else(|| "-".to_owned(), |p| p.to_string());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 //! merge-ready — Show pull request merge blockers as concise prompt tokens.
 
-pub mod cli;
 pub(crate) mod contexts;
 
 use std::process::ExitCode;
@@ -9,7 +8,6 @@ use crate::contexts::daemon::application::cache as daemon_cache_app;
 use crate::contexts::daemon::domain::cache::{RefreshMode, RepoId};
 use crate::contexts::daemon::infrastructure::daemon_client::DaemonClient;
 use crate::contexts::daemon::infrastructure::daemon_lifecycle::DaemonLifecycle;
-use crate::contexts::daemon::interface::cli::daemon::DaemonCommand;
 use crate::contexts::evaluation::infrastructure::toml_loader::TomlConfigRepository;
 use crate::contexts::evaluation::infrastructure::{gh::GhClient, logger::Logger};
 use crate::contexts::evaluation::interface::prompt::CacheHint;
@@ -58,7 +56,7 @@ pub fn config_command() -> ExitCode {
 pub fn daemon_start_command() -> ExitCode {
     contexts::evaluation::infrastructure::logger::init();
     let lifecycle = build_daemon_lifecycle();
-    contexts::daemon::interface::cli::daemon::run(DaemonCommand::Start, &lifecycle)
+    contexts::daemon::interface::cli::daemon::start(&lifecycle)
 }
 
 /// Stops the running background cache daemon.
@@ -66,7 +64,7 @@ pub fn daemon_start_command() -> ExitCode {
 pub fn daemon_stop_command() -> ExitCode {
     contexts::evaluation::infrastructure::logger::init();
     let lifecycle = build_daemon_lifecycle();
-    contexts::daemon::interface::cli::daemon::run(DaemonCommand::Stop, &lifecycle)
+    contexts::daemon::interface::cli::daemon::stop(&lifecycle)
 }
 
 /// Shows the current status of the background cache daemon.
@@ -74,7 +72,7 @@ pub fn daemon_stop_command() -> ExitCode {
 pub fn daemon_status_command() -> ExitCode {
     contexts::evaluation::infrastructure::logger::init();
     let lifecycle = build_daemon_lifecycle();
-    contexts::daemon::interface::cli::daemon::run(DaemonCommand::Status, &lifecycle)
+    contexts::daemon::interface::cli::daemon::status(&lifecycle)
 }
 
 /// Watches daemon cache entries in real time.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,10 @@
+mod cli;
+
 use std::process::ExitCode;
 
 use clap::Parser;
 
 fn main() -> ExitCode {
-    let cli = merge_ready::cli::Cli::parse();
-    merge_ready::cli::run(&cli)
+    let cli = cli::Cli::parse();
+    cli::run(&cli)
 }


### PR DESCRIPTION
## Breaking Change

`merge_ready::cli` モジュールを削除。ライブラリとして `merge_ready::cli::Cli` / `merge_ready::cli::Command` 等を直接使用していたコードはコンパイル不可になる。

## 背景

`src/cli.rs` が `pub mod cli` としてライブラリ API に露出しており、clap のパース構造（CLI 実装の詳細）が外部に公開されていた。また `contexts/daemon/interface/cli/daemon.rs` に `DaemonArgs` / `DaemonCommand` という clap 型が混入しており、ドメイン層が CLI アダプタの型に依存していた。

## 変更内容

| ファイル | 変更内容 |
|---|---|
| `src/cli.rs` | `DaemonArgs`/`DaemonCommand` をここで定義。`crate::contexts::` 依存を除去し `merge_ready::` 経由に |
| `src/main.rs` | `mod cli;` を追加してバイナリ専用モジュールとして取り込み |
| `src/lib.rs` | `pub mod cli` 削除。各 `daemon_*_command()` が `daemon::start/stop/status()` を直接呼ぶよう変更 |
| `contexts/.../cli/daemon.rs` | `DaemonArgs`/`DaemonCommand`/`run()` 削除。clap 除去。`start`/`stop`/`status` を `pub(crate)` に |
| `contexts/.../cli.rs` | `pub use daemon::DaemonArgs` 削除 |

## 結果

- clap はライブラリに一切含まれない
- contexts 層が CLI 型から分離される
- ライブラリの公開 API は `config_command()` / `daemon_start_command()` 等のコマンド関数のみ

## Test plan

- [x] `cargo build` — クリーンビルド確認済み
- [x] `cargo test --workspace` — 226 tests passed
- [x] `cargo clippy --workspace -- -D warnings` — 警告なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)