### PR TITLE
fix: daemon が複数起動する競合と中間プロセス問題を修正する

### DIFF
--- a/src/contexts/daemon/infrastructure/daemon_server.rs
+++ b/src/contexts/daemon/infrastructure/daemon_server.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Write};
 use std::os::unix::net::UnixListener;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -120,6 +121,7 @@ pub fn run(on_refresh: &RefreshFn) -> Result<(), DaemonError> {
 
     let state = Arc::new(Mutex::new(DaemonState::new()));
     let (exit_tx, exit_rx) = mpsc::channel::<()>();
+    let restart_started = Arc::new(AtomicBool::new(false));
 
     // 定期バックグラウンドリフレッシュ
     // SCHEDULER_TICK_SECS ごとに各エントリのリフレッシュ間隔を個別に評価する
@@ -150,7 +152,10 @@ pub fn run(on_refresh: &RefreshFn) -> Result<(), DaemonError> {
                 let state = Arc::clone(&state);
                 let on_refresh = Arc::clone(on_refresh);
                 let exit_tx = exit_tx.clone();
-                std::thread::spawn(move || handle_client(s, &state, &on_refresh, &exit_tx));
+                let restart_started = Arc::clone(&restart_started);
+                std::thread::spawn(move || {
+                    handle_client(s, &state, &on_refresh, &exit_tx, &restart_started);
+                });
             }
             Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                 std::thread::sleep(Duration::from_millis(10));
@@ -204,6 +209,7 @@ fn handle_client(
     state: &Arc<Mutex<DaemonState>>,
     on_refresh: &RefreshFn,
     exit_tx: &mpsc::Sender<()>,
+    restart_started: &Arc<AtomicBool>,
 ) {
     let mut buf = String::new();
     {
@@ -236,10 +242,15 @@ fn handle_client(
     }
 
     if restart_after_response {
-        std::thread::sleep(Duration::from_millis(RESTART_GRACE_MS));
-        cleanup();
-        spawn_self_as_daemon();
-        let _ = exit_tx.send(());
+        if restart_started
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            std::thread::sleep(Duration::from_millis(RESTART_GRACE_MS));
+            cleanup();
+            spawn_self_as_daemon();
+            let _ = exit_tx.send(());
+        }
         return;
     }
 
@@ -254,8 +265,10 @@ fn spawn_self_as_daemon() {
     let Ok(exe) = std::env::current_exe() else {
         return;
     };
+    // DAEMON_INNER_ENV を設定して outer wrapper をスキップし、直接 inner として起動する。
     let _ = std::process::Command::new(&exe)
         .args(["daemon", "start"])
+        .env(paths::DAEMON_INNER_ENV, "1")
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
@@ -773,6 +786,37 @@ mod tests {
         collect_background_refresh_targets(&state);
         let s = state.lock().unwrap();
         assert_eq!(s.entries["repo"].cold_refresh_count(), 4);
+    }
+
+    // ── restart_started AtomicBool ─────────────────────────────────────────────
+
+    #[test]
+    fn restart_executes_only_once_under_concurrent_threads() {
+        use std::sync::atomic::AtomicU32;
+        let restart_started = Arc::new(AtomicBool::new(false));
+        let count = Arc::new(AtomicU32::new(0));
+        let handles: Vec<_> = (0..10)
+            .map(|_| {
+                let rs = Arc::clone(&restart_started);
+                let c = Arc::clone(&count);
+                std::thread::spawn(move || {
+                    if rs
+                        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                        .is_ok()
+                    {
+                        c.fetch_add(1, Ordering::Relaxed);
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+        assert_eq!(
+            count.load(Ordering::Relaxed),
+            1,
+            "再起動は1回だけ実行されるはず"
+        );
     }
 
     #[test]

--- a/src/contexts/daemon/infrastructure/paths.rs
+++ b/src/contexts/daemon/infrastructure/paths.rs
@@ -1,5 +1,10 @@
 use std::path::PathBuf;
 
+/// 内側デーモンプロセスを識別する環境変数名。
+/// `interface::cli::daemon` の outer/inner 分岐および
+/// `daemon_server::spawn_self_as_daemon()` で参照する。
+pub const DAEMON_INNER_ENV: &str = "MERGE_READY_DAEMON_INNER";
+
 pub fn socket_path() -> PathBuf {
     base_dir().join("daemon.sock")
 }

--- a/src_prompt/main.rs
+++ b/src_prompt/main.rs
@@ -95,9 +95,12 @@ fn spawn_daemon() {
         .filter(|p| p.exists())
         .unwrap_or_else(|| PathBuf::from("merge-ready"));
 
+    // MERGE_READY_DAEMON_INNER=1 で outer wrapper をスキップして直接 inner として起動する。
+    // この文字列は infrastructure::paths::DAEMON_INNER_ENV と同一でなければならない。
     // fire-and-forget: blocking しない
     let _ = std::process::Command::new(&daemon_exe)
         .args(["daemon", "start"])
+        .env("MERGE_READY_DAEMON_INNER", "1")
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())

--- a/tests/e2e/daemon/lifecycle.rs
+++ b/tests/e2e/daemon/lifecycle.rs
@@ -273,9 +273,95 @@ fn test_concurrent_prompt_starts_only_one_daemon() {
         .ok();
 }
 
-// ── #16: daemon status の出力フォーマット ────────────────────────────────────
+// ── #16: バージョンミスマッチ並列再起動 ─────────────────────────────────────
 
-/// #16: `daemon status`（起動中）→ "running pid=<数字> entries=<数字> uptime=<数字>s version=<文字列>"
+/// #16: バージョン不一致の状態で複数の `merge-ready-prompt` を並列実行しても、
+/// 新デーモンは 1 プロセスだけ起動する
+#[test]
+fn test_concurrent_version_mismatch_starts_only_one_daemon() {
+    let env = TestEnv::new(OPEN_PR_VIEW_JSON, Some(CI_PASS_JSON));
+    let prompt_bin = assert_cmd::cargo::cargo_bin(PROMPT_BIN);
+
+    // バージョン不一致の fake daemon を起動
+    let _old = FakeDaemonHandle::start_versioned(&env, "0.0.0");
+
+    // 10 本の merge-ready-prompt を同時実行してバージョンミスマッチを並列でトリガーする
+    let handles: Vec<_> = (0..10)
+        .map(|_| {
+            let bin = prompt_bin.clone();
+            let path = env.path_env();
+            let home = env.home().to_path_buf();
+            let repo = env.repo_dir.path().to_path_buf();
+            std::thread::spawn(move || {
+                std::process::Command::new(&bin)
+                    .env("PATH", &path)
+                    .env("HOME", &home)
+                    .env("TMPDIR", &home)
+                    .current_dir(&repo)
+                    .output()
+            })
+        })
+        .collect();
+
+    for h in handles {
+        let _ = h.join();
+    }
+
+    // 新 daemon が起動するまでポーリング（最大 5 秒）
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(5000);
+    loop {
+        let out = Command::cargo_bin(BIN)
+            .unwrap()
+            .args(["daemon", "status"])
+            .env("PATH", env.path_env())
+            .env("HOME", env.home())
+            .env("TMPDIR", env.home())
+            .output()
+            .expect("status failed");
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        if stdout.contains(&format!("version={}", env!("CARGO_PKG_VERSION"))) {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "new daemon did not start within 5s: {stdout}"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+
+    // socket ファイルが存在すること（1 daemon だけが bind している）
+    let socket_path = env
+        .home_dir
+        .path()
+        .join(super::super::helpers::daemon_dir_name())
+        .join("daemon.sock");
+    assert!(socket_path.exists(), "daemon socket should exist");
+
+    // 現バージョンの daemon が応答しており、旧バージョンではないこと
+    let mut after = Command::cargo_bin(BIN).unwrap();
+    env.apply(&mut after);
+    after
+        .args(["daemon", "status"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "version={}",
+            env!("CARGO_PKG_VERSION")
+        )))
+        .stdout(predicate::str::contains("version=0.0.0").not());
+
+    // クリーンアップ
+    Command::cargo_bin(BIN)
+        .unwrap()
+        .args(["daemon", "stop"])
+        .env("TMPDIR", env.home())
+        .output()
+        .ok();
+}
+
+// ── #17: daemon status の出力フォーマット ────────────────────────────────────
+
+/// #17: `daemon status`（起動中）→ "running pid=<数字> entries=<数字> uptime=<数字>s version=<文字列>"
 #[test]
 fn test_daemon_status_format() {
     let env = TestEnv::new(OPEN_PR_VIEW_JSON, Some(CI_PASS_JSON));


### PR DESCRIPTION
## Summary

Closes #250

- **Bug 1 (重大)**: バージョンミスマッチ時、複数の `handle_client` スレッドが同時に `restart_after_response = true` を持つと、各スレッドが独立して `cleanup()` + `spawn_self_as_daemon()` を呼び出していた。後続スレッドの `cleanup()` が先に起動した新デーモンの PID ファイル・ソケットを削除し、オーファンプロセスが残る競合を `Arc<AtomicBool>` の CAS で修正。
- **Bug 2 (観察可能)**: `spawn_self_as_daemon()` と `spawn_daemon()` が `MERGE_READY_DAEMON_INNER` 環境変数なしで起動するため、outer wrapper プロセスが最大 2 秒間余分に見えていた。両関数に `MERGE_READY_DAEMON_INNER=1` を付与して中間プロセスを排除。

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `src/contexts/daemon/infrastructure/paths.rs` | `DAEMON_INNER_ENV` 定数を追加（インフラ層で共有） |
| `src/contexts/daemon/infrastructure/daemon_server.rs` | `Arc<AtomicBool>` による再起動排他制御、`spawn_self_as_daemon()` に env var 付与、ユニットテスト追加 |
| `src_prompt/main.rs` | `spawn_daemon()` に `MERGE_READY_DAEMON_INNER=1` を付与 |

## Test plan

- [x] `cargo test --workspace` — 227 tests passed
- [x] `cargo clippy --workspace -- -D warnings` — no issues
- [x] `cargo fmt --check --all` — passed
- [x] `bash scripts/check-layer-deps.sh` — no violations
- [x] `bash scripts/check-no-mod-rs.sh` — passed
- [x] 既存 E2E テスト (#14 バージョンミスマッチ、#15 並列起動) が通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)