### PR TITLE
chore: feat/fix/test 以外の PR でテストファイル変更時に警告を出す

### DIFF
--- a/scripts/check-e2e.sh
+++ b/scripts/check-e2e.sh
@@ -3,18 +3,34 @@ set -uo pipefail
 
 cd "${ROOT_DIR:-$(dirname "$0")/..}"
 
-if ! echo "$PR_TITLE" | grep -qE '^(feat|fix)(!)?:'; then
-  echo "PR title does not start with feat/fix; skipping E2E check."
+if echo "$PR_TITLE" | grep -qE '^(feat|fix)(!)?:'; then
+  changed=$(git diff --name-only "origin/${BASE_REF}...HEAD" -- tests/e2e/)
+  if [ -z "$changed" ]; then
+    printf "ERROR: PR title '%s' requires changes in tests/e2e/ but none were found.\n" "$PR_TITLE" >&2
+    exit 1
+  fi
+  echo "E2E changes detected:"
+  echo "$changed"
+  echo "OK"
   exit 0
 fi
 
-changed=$(git diff --name-only "origin/${BASE_REF}...HEAD" -- tests/e2e/)
-
-if [ -z "$changed" ]; then
-  printf "ERROR: PR title '%s' requires changes in tests/e2e/ but none were found.\n" "$PR_TITLE" >&2
-  exit 1
+if echo "$PR_TITLE" | grep -qE '^test(!)?:'; then
+  changed=$(git diff --name-only "origin/${BASE_REF}...HEAD" -- tests/)
+  if [ -z "$changed" ]; then
+    printf "ERROR: PR title '%s' requires changes in tests/ but none were found.\n" "$PR_TITLE" >&2
+    exit 1
+  fi
+  echo "Test changes detected:"
+  echo "$changed"
+  echo "OK"
+  exit 0
 fi
 
-echo "E2E changes detected:"
-echo "$changed"
-echo "OK"
+changed=$(git diff --name-only "origin/${BASE_REF}...HEAD" -- tests/)
+if [ -n "$changed" ]; then
+  printf "WARN: PR title '%s' is not feat/fix/test but test files were modified:\n" "$PR_TITLE"
+  echo "$changed"
+fi
+
+exit 0


### PR DESCRIPTION
## 概要

- `test:` PR タイプを新規サポート: `tests/` 配下の変更がなければ ERROR、あれば OK
- `feat`/`fix`/`test` 以外の PR（`chore`, `refactor` 等）で `tests/` 配下に変更があれば **WARN**（exit 0）

Closes #252

## 挙動一覧

| PR タイプ | テストファイルの変更 | 結果 |
|---|---|---|
| `feat` / `fix` | あり（`tests/e2e/`） | OK（既存） |
| `feat` / `fix` | なし | ERROR（既存） |
| `test` | あり（`tests/`） | OK（新規） |
| `test` | なし | ERROR（新規） |
| その他 | あり（`tests/`） | WARN・exit 0（新規） |
| その他 | なし | OK（既存） |

## テスト計画

- [ ] `feat: xxx` で `tests/e2e/` 変更なし → exit 1 (ERROR)
- [ ] `feat: xxx` で `tests/e2e/` 変更あり → exit 0 (OK)
- [ ] `test: xxx` で `tests/` 変更なし → exit 1 (ERROR)
- [ ] `test: xxx` で `tests/` 変更あり → exit 0 (OK)
- [ ] `chore: xxx` で `tests/` 変更なし → exit 0 (出力なし)
- [ ] `chore: xxx` で `tests/` 変更あり → exit 0 (WARN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)