### PR TITLE
feat: add completions subcommand via clap_complete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "660c0520455b1013b9bcb0393d5f643d7e4454fb69c915b8d6d2aa0e9a45acc3"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,6 +622,7 @@ version = "0.7.0"
 dependencies = [
  "assert_cmd",
  "clap",
+ "clap_complete",
  "criterion",
  "crossterm",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ simplelog = "0.12"
 toml = "1.1.2"
 crossterm = "0.29.0"
 
-
 [lib]
 name = "merge_ready"
 path = "src/lib.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,14 @@ pedantic = "warn"
 [dependencies]
 nu-ansi-term = "0.50"
 clap = { version = "4.6.1", features = ["derive", "cargo"] }
+clap_complete = "4.6.1"
 log = "0.4"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 simplelog = "0.12"
 toml = "1.1.2"
 crossterm = "0.29.0"
+
 
 [lib]
 name = "merge_ready"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,48 +1,20 @@
+use std::io;
 use std::process::ExitCode;
 
-use clap::{Args, CommandFactory, Parser, Subcommand};
+use clap::CommandFactory;
+use clap_complete::generate;
 
-#[derive(Parser)]
-#[command(
-    name = "merge-ready",
-    about = "PR merge status for your shell prompt",
-    version
-)]
-pub struct Cli {
-    #[command(subcommand)]
-    pub command: Option<Command>,
-}
-
-#[derive(Subcommand)]
-pub enum Command {
-    /// Open the configuration file in an editor (creates it with defaults if absent)
-    Config,
-    /// Manage the background cache daemon
-    Daemon(DaemonArgs),
-    /// Watch daemon cache entries in real time (Ctrl+C to stop)
-    Watch,
-}
-
-#[derive(Args, Clone, Copy)]
-pub struct DaemonArgs {
-    #[command(subcommand)]
-    pub subcommand: DaemonCommand,
-}
-
-#[derive(Subcommand, Clone, Copy)]
-pub enum DaemonCommand {
-    /// Start the background cache daemon
-    Start,
-    /// Stop the running daemon
-    Stop,
-    /// Show daemon status
-    Status,
-}
+pub use crate::cli_args::{Cli, Command, DaemonCommand};
 
 #[must_use]
 pub fn run(cli: &Cli) -> ExitCode {
     match &cli.command {
         Some(Command::Config) => merge_ready::config_command(),
+        Some(Command::Completions { shell }) => {
+            let mut cmd = Cli::command();
+            generate(*shell, &mut cmd, "merge-ready", &mut io::stdout());
+            ExitCode::SUCCESS
+        }
         Some(Command::Daemon(args)) => match args.subcommand {
             DaemonCommand::Start => merge_ready::daemon_start_command(),
             DaemonCommand::Stop => merge_ready::daemon_stop_command(),

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -1,0 +1,44 @@
+use clap::{Args, Parser, Subcommand};
+use clap_complete::Shell;
+
+#[derive(Parser)]
+#[command(
+    name = "merge-ready",
+    about = "PR merge status for your shell prompt",
+    version
+)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Option<Command>,
+}
+
+#[derive(Subcommand)]
+pub enum Command {
+    /// Open the configuration file in an editor (creates it with defaults if absent)
+    Config,
+    /// Generate shell completion scripts
+    Completions {
+        /// The shell to generate completions for
+        shell: Shell,
+    },
+    /// Manage the background cache daemon
+    Daemon(DaemonArgs),
+    /// Watch daemon cache entries in real time (Ctrl+C to stop)
+    Watch,
+}
+
+#[derive(Args, Clone, Copy)]
+pub struct DaemonArgs {
+    #[command(subcommand)]
+    pub subcommand: DaemonCommand,
+}
+
+#[derive(Subcommand, Clone, Copy)]
+pub enum DaemonCommand {
+    /// Start the background cache daemon
+    Start,
+    /// Stop the running daemon
+    Stop,
+    /// Show daemon status
+    Status,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod cli;
+mod cli_args;
 
 use std::process::ExitCode;
 

--- a/tests/e2e/cli/completions.rs
+++ b/tests/e2e/cli/completions.rs
@@ -1,0 +1,64 @@
+use assert_cmd::Command;
+
+use super::super::helpers::TestEnv;
+
+const MERGE_READY_PR_VIEW_JSON: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED"}"#;
+const MERGE_READY_PR_CHECKS_JSON: &str = r#"[{"bucket":"pass","state":"SUCCESS"}]"#;
+
+const BIN: &str = "merge-ready";
+
+fn cmd(env: &TestEnv) -> Command {
+    let mut c = Command::cargo_bin(BIN).unwrap();
+    env.apply(&mut c);
+    c
+}
+
+/// `completions bash` → 成功し、bash 補完スクリプトを stdout に出力する
+#[test]
+fn test_completions_bash() {
+    let env = TestEnv::new(MERGE_READY_PR_VIEW_JSON, Some(MERGE_READY_PR_CHECKS_JSON));
+    cmd(&env)
+        .args(["completions", "bash"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("merge-ready"));
+}
+
+/// `completions zsh` → 成功し、zsh 補完スクリプトを stdout に出力する
+#[test]
+fn test_completions_zsh() {
+    let env = TestEnv::new(MERGE_READY_PR_VIEW_JSON, Some(MERGE_READY_PR_CHECKS_JSON));
+    cmd(&env)
+        .args(["completions", "zsh"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("merge-ready"));
+}
+
+/// `completions fish` → 成功し、fish 補完スクリプトを stdout に出力する
+#[test]
+fn test_completions_fish() {
+    let env = TestEnv::new(MERGE_READY_PR_VIEW_JSON, Some(MERGE_READY_PR_CHECKS_JSON));
+    cmd(&env)
+        .args(["completions", "fish"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("merge-ready"));
+}
+
+/// `completions` (シェル引数なし) → 失敗する
+#[test]
+fn test_completions_no_shell_fails() {
+    let env = TestEnv::new(MERGE_READY_PR_VIEW_JSON, Some(MERGE_READY_PR_CHECKS_JSON));
+    cmd(&env).arg("completions").assert().failure();
+}
+
+/// `completions unknown-shell` → 失敗する
+#[test]
+fn test_completions_unknown_shell_fails() {
+    let env = TestEnv::new(MERGE_READY_PR_VIEW_JSON, Some(MERGE_READY_PR_CHECKS_JSON));
+    cmd(&env)
+        .args(["completions", "unknown-shell"])
+        .assert()
+        .failure();
+}

--- a/tests/e2e/cli/mod.rs
+++ b/tests/e2e/cli/mod.rs
@@ -1,1 +1,2 @@
+mod completions;
 mod flags;


### PR DESCRIPTION
## Summary

- `clap_complete` を導入し、`completions <shell>` サブコマンドを追加
- Bash / Zsh / Fish / PowerShell / Elvish 向け補完スクリプトを stdout に出力
- CLI 構造体定義を `src/cli_args.rs` に分離し `src/cli.rs` から re-export
- `clap_mangen` は情報量が少ないため導入しないと判断（Issue #216 コメント参照）

## Usage

```bash
# zsh の場合
merge-ready completions zsh > ~/.zfunc/_merge-ready

# bash の場合
merge-ready completions bash > /etc/bash_completion.d/merge-ready
```

## Test plan

- [x] `completions bash` / `zsh` / `fish` が成功し補完スクリプトを stdout に出力する
- [x] `completions`（引数なし）が失敗する
- [x] `completions unknown-shell` が失敗する
- [x] `cargo clippy --workspace -- -D warnings` がクリーン
- [x] 既存テスト全通過

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)