### PR TITLE
feat: #260 conditional format strings のサポート

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,20 @@ Example output:
 - `⧖ Wait for status` - GitHub is calculating merge status
 - `? loading` - cache miss; daemon is fetching in the background
 
+### Multiple Pull Requests
+
+When a branch has **multiple open pull requests**, all statuses are displayed in PR-number ascending order, each suffixed with `#<number>`:
+
+```text
+✓ Ready for merge #200 ✎ Ready for review #201
+```
+
+When there is only one open pull request, the `#<number>` suffix is omitted:
+
+```text
+✓ Ready for merge
+```
+
 ## Background Daemon
 
 `merge-ready` uses a background daemon to cache GitHub API results and serve prompt queries with near-zero latency.
@@ -211,6 +225,49 @@ The `[error]` section uses `$message` instead of `$label`. The message is set au
 |-------|-------------|---------|
 | `symbol` | Leading symbol | `"✗"` |
 | `format` | Output template | `"$symbol $message"` |
+
+### Format Variables
+
+The following variables are available in `format` templates:
+
+| Variable | Description | Available in |
+|----------|-------------|--------------|
+| `$symbol` | Leading symbol | all tokens |
+| `$label` | Status text | PR state tokens, `no_pull_request` |
+| `$pr_id` | PR number string; empty `""` when only one open PR exists | PR state tokens (12 types) |
+| `$message` | Error message | `[error]` only |
+
+`$pr_id` is not present in `no_pull_request` or `[error]` tokens. Writing `$pr_id` in those format strings leaves the literal text `$pr_id` in the output.
+
+### Conditional Format Strings
+
+The `format` field supports a `(...)` syntax that hides the block when all variables inside are empty. This follows [Starship's conditional format strings](https://starship.rs/config/#conditional-format-strings).
+
+```toml
+# `( #$pr_id)` is shown only when $pr_id is non-empty (i.e., multiple PRs on the branch)
+[merge_ready]
+format = "$symbol $label( #$pr_id)"
+```
+
+| `$pr_id` value | Output |
+|----------------|--------|
+| `"200"` (multiple PRs) | `✓ Ready for merge #200` |
+| `""` (single PR) | `✓ Ready for merge` |
+
+Rules:
+
+- All variables in `(...)` are empty → block is hidden
+- At least one variable is non-empty → block is rendered normally
+- No variables in `(...)` → block is always hidden
+
+Conditional blocks can also appear inside a `[text](style)` block:
+
+```toml
+[merge_ready]
+format = "[$symbol $label( #$pr_id)](bold green)"
+```
+
+This applies the style to the whole output while still hiding `( #$pr_id)` when `$pr_id` is empty.
 
 ### Style Strings
 

--- a/src/contexts/evaluation/domain/display_config.rs
+++ b/src/contexts/evaluation/domain/display_config.rs
@@ -114,7 +114,7 @@ fn eval_segment(seg: &Segment, vars: &[(&str, &str)]) -> String {
         Segment::Text(t) => substitute_vars(t, vars),
         Segment::Styled { content, style_str } => StyleSpec::parse(style_str)
             .to_ansi_style()
-            .paint(substitute_vars(content, vars))
+            .paint(eval_segments(&parse_segments(content), vars))
             .to_string(),
         Segment::Conditional(inner) => eval_conditional(inner, vars),
     }

--- a/src/contexts/evaluation/domain/display_config.rs
+++ b/src/contexts/evaluation/domain/display_config.rs
@@ -3,8 +3,8 @@ use serde::Serialize;
 use super::format_parser::{Segment, parse_segments};
 use super::style_spec::StyleSpec;
 
-/// PR 状態トークン 12 種のデフォルトフォーマット。`$pr_id` を含む。
-const DEFAULT_PR_FORMAT: &str = "$symbol $label #$pr_id";
+/// PR 状態トークン 12 種のデフォルトフォーマット。`( #$pr_id)` は複数 PR 時のみ展開される。
+const DEFAULT_PR_FORMAT: &str = "$symbol $label( #$pr_id)";
 /// `no_pull_request` / `error` トークンのデフォルトフォーマット。
 const DEFAULT_FORMAT: &str = "$symbol $label";
 const DEFAULT_ERROR_FORMAT: &str = "$symbol $message";
@@ -70,16 +70,14 @@ pub struct TokenConfig {
 }
 
 /// `pr_id` が `Some` の場合は `$pr_id` を置換する。`None` の場合は `$pr_id` を literal のまま残す。
+/// `(...)` ブロック内の変数がすべて空の場合、そのブロックは出力されない。
 #[must_use]
 pub fn render_token(token: &TokenConfig, pr_id: Option<&str>) -> String {
-    let mut substituted = token
-        .format
-        .replace("$symbol", &token.symbol)
-        .replace("$label", &token.label);
+    let mut vars: Vec<(&str, &str)> = vec![("symbol", &token.symbol), ("label", &token.label)];
     if let Some(id) = pr_id {
-        substituted = substituted.replace("$pr_id", id);
+        vars.push(("pr_id", id));
     }
-    render_segments(&substituted)
+    render_with_vars(&token.format, &vars)
 }
 
 #[derive(Serialize)]
@@ -99,24 +97,115 @@ impl Default for ErrorConfig {
 
 #[must_use]
 pub fn render_error_token(config: &ErrorConfig, message: &str) -> String {
-    let substituted = config
-        .format
-        .replace("$symbol", &config.symbol)
-        .replace("$message", message);
-    render_segments(&substituted)
+    let vars: Vec<(&str, &str)> = vec![("symbol", &config.symbol), ("message", message)];
+    render_with_vars(&config.format, &vars)
 }
 
-fn render_segments(s: &str) -> String {
-    parse_segments(s)
-        .into_iter()
-        .map(|seg| match seg {
-            Segment::Text(t) => t,
-            Segment::Styled { content, style_str } => StyleSpec::parse(&style_str)
-                .to_ansi_style()
-                .paint(content)
-                .to_string(),
-        })
-        .collect()
+fn render_with_vars(format: &str, vars: &[(&str, &str)]) -> String {
+    eval_segments(&parse_segments(format), vars)
+}
+
+fn eval_segments(segs: &[Segment], vars: &[(&str, &str)]) -> String {
+    segs.iter().map(|s| eval_segment(s, vars)).collect()
+}
+
+fn eval_segment(seg: &Segment, vars: &[(&str, &str)]) -> String {
+    match seg {
+        Segment::Text(t) => substitute_vars(t, vars),
+        Segment::Styled { content, style_str } => StyleSpec::parse(style_str)
+            .to_ansi_style()
+            .paint(substitute_vars(content, vars))
+            .to_string(),
+        Segment::Conditional(inner) => eval_conditional(inner, vars),
+    }
+}
+
+/// `(...)` ブロックの評価: 内包する変数がすべて空（またはマップにない）場合は非表示。
+fn eval_conditional(inner: &[Segment], vars: &[(&str, &str)]) -> String {
+    let refs = collect_var_refs(inner);
+    if refs.is_empty() {
+        return String::new();
+    }
+    let all_empty = refs.iter().all(|name| {
+        vars.iter()
+            .find(|(k, _)| k == name)
+            .is_none_or(|(_, v)| v.is_empty())
+    });
+    if all_empty {
+        String::new()
+    } else {
+        eval_segments(inner, vars)
+    }
+}
+
+/// Segment ツリーから `$varname` 参照を収集する。
+fn collect_var_refs(segs: &[Segment]) -> Vec<&str> {
+    let mut refs = Vec::new();
+    for seg in segs {
+        let text = match seg {
+            Segment::Text(t) => t.as_str(),
+            Segment::Styled { content, .. } => content.as_str(),
+            Segment::Conditional(inner) => {
+                refs.extend(collect_var_refs(inner));
+                continue;
+            }
+        };
+        extract_var_names(text, &mut refs);
+    }
+    refs
+}
+
+fn extract_var_names<'a>(s: &'a str, out: &mut Vec<&'a str>) {
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'$' {
+            let start = i + 1;
+            let end = bytes[start..]
+                .iter()
+                .position(|&b| !b.is_ascii_alphanumeric() && b != b'_')
+                .map_or(bytes.len(), |pos| start + pos);
+            if end > start {
+                out.push(&s[start..end]);
+            }
+            i = end;
+        } else {
+            i += 1;
+        }
+    }
+}
+
+/// `$varname` を vars で置換する。マップにない変数はリテラルのまま残す。
+fn substitute_vars(s: &str, vars: &[(&str, &str)]) -> String {
+    let bytes = s.as_bytes();
+    let mut result = String::with_capacity(s.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'$' {
+            let start = i + 1;
+            let end = bytes[start..]
+                .iter()
+                .position(|&b| !b.is_ascii_alphanumeric() && b != b'_')
+                .map_or(bytes.len(), |pos| start + pos);
+            if end > start {
+                let name = &s[start..end];
+                if let Some((_, val)) = vars.iter().find(|(k, _)| *k == name) {
+                    result.push_str(val);
+                } else {
+                    result.push('$');
+                    result.push_str(name);
+                }
+                i = end;
+            } else {
+                result.push('$');
+                i += 1;
+            }
+        } else {
+            result.push(bytes[i] as char);
+            i += 1;
+        }
+    }
+    result
 }
 
 #[cfg(test)]
@@ -290,6 +379,48 @@ mod tests {
             .replace("$symbol", &tok.symbol)
             .replace("$label", &tok.label);
         assert_eq!(render_token(&tok, None), expected);
+    }
+
+    // ── Conditional ブロックのテスト ──────────────────────────────────────
+
+    #[test]
+    fn render_token_conditional_shown_when_pr_id_nonempty() {
+        let tok = TokenConfig {
+            symbol: "✓".to_owned(),
+            label: "Ready for merge".to_owned(),
+            format: "$symbol $label( #$pr_id)".to_owned(),
+        };
+        assert_eq!(render_token(&tok, Some("200")), "✓ Ready for merge #200");
+    }
+
+    #[test]
+    fn render_token_conditional_hidden_when_pr_id_empty() {
+        let tok = TokenConfig {
+            symbol: "✓".to_owned(),
+            label: "Ready for merge".to_owned(),
+            format: "$symbol $label( #$pr_id)".to_owned(),
+        };
+        assert_eq!(render_token(&tok, Some("")), "✓ Ready for merge");
+    }
+
+    #[test]
+    fn render_token_conditional_hidden_when_pr_id_none() {
+        let tok = TokenConfig {
+            symbol: "✓".to_owned(),
+            label: "Ready for merge".to_owned(),
+            format: "$symbol $label( #$pr_id)".to_owned(),
+        };
+        assert_eq!(render_token(&tok, None), "✓ Ready for merge");
+    }
+
+    #[test]
+    fn render_token_conditional_no_vars_always_hidden() {
+        let tok = TokenConfig {
+            symbol: "✓".to_owned(),
+            label: "Ready".to_owned(),
+            format: "$symbol $label( static text)".to_owned(),
+        };
+        assert_eq!(render_token(&tok, Some("200")), "✓ Ready");
     }
 
     // ── $pr_id 置換のテスト ────────────────────────────────────────────────

--- a/src/contexts/evaluation/domain/format_parser.rs
+++ b/src/contexts/evaluation/domain/format_parser.rs
@@ -1,47 +1,85 @@
+enum Either<L, R> {
+    Left(L),
+    Right(R),
+}
+
 #[derive(Debug, PartialEq)]
 pub(crate) enum Segment {
     Text(String),
     Styled { content: String, style_str: String },
+    Conditional(Vec<Segment>),
 }
 
-/// `[text](style)` 構文を `Segment` 列に分解する。
+/// `[text](style)` および `(content)` 構文を `Segment` 列に分解する。
 ///
-/// `]` の直後が `(` でない場合は Styled として扱わず Text に含める（後方互換）。
-/// ASCII の `[` `]` `(` `)` はすべて 1 バイトなので `str::find` でバイト操作しても安全。
+/// - `[text](style)` → `Segment::Styled`
+/// - `(content)` → `Segment::Conditional`（内側を再帰パース）
+/// - `]` の直後が `(` でない場合は Styled として扱わず Text に含める（後方互換）。
+/// - ASCII の `[` `]` `(` `)` はすべて 1 バイトなので `str::find` でバイト操作しても安全。
 pub(crate) fn parse_segments(format: &str) -> Vec<Segment> {
     let mut segments = Vec::new();
     let mut remaining = format;
     let mut text_acc = String::new();
 
     while !remaining.is_empty() {
-        if let Some(open) = remaining.find('[') {
-            let after_open = &remaining[open + 1..];
+        let bracket_pos = remaining.find('[');
+        let paren_pos = remaining.find('(');
 
-            if let Some(close_bracket) = after_open.find(']') {
-                let after_bracket = &after_open[close_bracket + 1..];
+        // 先に現れるデリミタを判定する
+        let next = match (bracket_pos, paren_pos) {
+            (None, None) => None,
+            (Some(b), None) => Some(Either::Left(b)),
+            (None, Some(p)) => Some(Either::Right(p)),
+            (Some(b), Some(p)) => Some(if b <= p {
+                Either::Left(b)
+            } else {
+                Either::Right(p)
+            }),
+        };
 
-                if let Some(after_paren) = after_bracket.strip_prefix('(')
-                    && let Some(paren_close) = after_paren.find(')')
-                {
-                    text_acc.push_str(&remaining[..open]);
-                    if !text_acc.is_empty() {
-                        segments.push(Segment::Text(std::mem::take(&mut text_acc)));
+        match next {
+            // デリミタなし → 残りをすべて Text に
+            None => {
+                text_acc.push_str(remaining);
+                remaining = "";
+            }
+            // `[` が先 → `[text](style)` を試みる
+            Some(Either::Left(b)) => {
+                let after_open = &remaining[b + 1..];
+                if let Some(close_bracket) = after_open.find(']') {
+                    let after_bracket = &after_open[close_bracket + 1..];
+                    if let Some(after_paren) = after_bracket.strip_prefix('(')
+                        && let Some(paren_close) = after_paren.find(')')
+                    {
+                        text_acc.push_str(&remaining[..b]);
+                        flush_text_acc(&mut text_acc, &mut segments);
+                        segments.push(Segment::Styled {
+                            content: after_open[..close_bracket].to_owned(),
+                            style_str: after_paren[..paren_close].to_owned(),
+                        });
+                        remaining = &after_paren[paren_close + 1..];
+                        continue;
                     }
-                    segments.push(Segment::Styled {
-                        content: after_open[..close_bracket].to_owned(),
-                        style_str: after_paren[..paren_close].to_owned(),
-                    });
-                    remaining = &after_paren[paren_close + 1..];
+                }
+                // Styled 構文にならなかった — `[` を Text に蓄積
+                text_acc.push_str(&remaining[..=b]);
+                remaining = &remaining[b + 1..];
+            }
+            // `(` が先 → Conditional を試みる
+            Some(Either::Right(p)) => {
+                let after_paren = &remaining[p + 1..];
+                if let Some(close) = after_paren.find(')') {
+                    text_acc.push_str(&remaining[..p]);
+                    flush_text_acc(&mut text_acc, &mut segments);
+                    let inner = parse_segments(&after_paren[..close]);
+                    segments.push(Segment::Conditional(inner));
+                    remaining = &after_paren[close + 1..];
                     continue;
                 }
+                // `)` がない — `(` を Text に蓄積
+                text_acc.push_str(&remaining[..=p]);
+                remaining = &remaining[p + 1..];
             }
-
-            // `[` はスタイル構文の開始ではない — テキストとして蓄積
-            text_acc.push_str(&remaining[..=open]);
-            remaining = &remaining[open + 1..];
-        } else {
-            text_acc.push_str(remaining);
-            remaining = "";
         }
     }
 
@@ -50,6 +88,12 @@ pub(crate) fn parse_segments(format: &str) -> Vec<Segment> {
     }
 
     segments
+}
+
+fn flush_text_acc(text_acc: &mut String, segments: &mut Vec<Segment>) {
+    if !text_acc.is_empty() {
+        segments.push(Segment::Text(std::mem::take(text_acc)));
+    }
 }
 
 #[cfg(test)]
@@ -66,6 +110,46 @@ mod tests {
     #[case("", vec![])]
     fn plain_text_cases(#[case] input: &str, #[case] expected: Vec<Segment>) {
         assert_eq!(parse_segments(input), expected);
+    }
+
+    // ── Conditional セグメントのパース ──────────────────────────────────────
+
+    #[rstest]
+    #[case(
+        "( #$pr_id)",
+        vec![Segment::Conditional(vec![Segment::Text(" #$pr_id".to_owned())])]
+    )]
+    #[case(
+        "$symbol( #$pr_id)",
+        vec![
+            Segment::Text("$symbol".to_owned()),
+            Segment::Conditional(vec![Segment::Text(" #$pr_id".to_owned())]),
+        ]
+    )]
+    #[case(
+        "()",
+        vec![Segment::Conditional(vec![])]
+    )]
+    #[case(
+        "(no close",
+        vec![Segment::Text("(no close".to_owned())]
+    )]
+    fn conditional_segment_cases(#[case] input: &str, #[case] expected: Vec<Segment>) {
+        assert_eq!(parse_segments(input), expected);
+    }
+
+    #[test]
+    fn styled_then_conditional() {
+        assert_eq!(
+            parse_segments("[$s](red)( suffix)"),
+            vec![
+                Segment::Styled {
+                    content: "$s".to_owned(),
+                    style_str: "red".to_owned()
+                },
+                Segment::Conditional(vec![Segment::Text(" suffix".to_owned())]),
+            ]
+        );
     }
 
     // ── Styled セグメントのパース ────────────────────────────────────────────

--- a/src/contexts/evaluation/interface/prompt.rs
+++ b/src/contexts/evaluation/interface/prompt.rs
@@ -237,8 +237,8 @@ mod tests {
             }]))
         });
         assert_eq!(result.pr_outputs.len(), 1);
-        assert!(result.output.contains('#'));
-        assert!(!result.output.contains("200"));
+        assert!(!result.output.contains('#'));
+        assert_eq!(result.output, "✓ Ready for merge");
     }
 
     #[test]

--- a/tests/e2e/config/config.rs
+++ b/tests/e2e/config/config.rs
@@ -34,9 +34,9 @@ fn assert_prompt_with_config(env: &TestEnv, expected: &str) {
 
 /// #42 設定なし / #43 symbol / #44 label / #45 format / #46 全フィールド / #48 不正 TOML
 #[rstest]
-#[case::no_config(None, "✓ Ready for merge #")]
-#[case::custom_symbol(Some("[merge_ready]\nsymbol = \"★\""), "★ Ready for merge #")]
-#[case::custom_label(Some("[merge_ready]\nlabel = \"OK!\""), "✓ OK! #")]
+#[case::no_config(None, "✓ Ready for merge")]
+#[case::custom_symbol(Some("[merge_ready]\nsymbol = \"★\""), "★ Ready for merge")]
+#[case::custom_label(Some("[merge_ready]\nlabel = \"OK!\""), "✓ OK!")]
 #[case::custom_format(
     Some("[merge_ready]\nformat = \"[$symbol] $label\""),
     "[✓] Ready for merge"
@@ -45,7 +45,7 @@ fn assert_prompt_with_config(env: &TestEnv, expected: &str) {
     Some("[merge_ready]\nsymbol = \"✅\"\nlabel = \"lgtm\"\nformat = \"$label $symbol\""),
     "lgtm ✅"
 )]
-#[case::invalid_toml(Some("this is not valid toml ][[["), "✓ Ready for merge #")]
+#[case::invalid_toml(Some("this is not valid toml ][[["), "✓ Ready for merge")]
 fn test_config_prompt(#[case] config: Option<&str>, #[case] expected: &str) {
     let env = TestEnv::new(MERGE_READY_JSON, Some(CHECKS_PASS_JSON));
     if let Some(cfg) = config {
@@ -61,7 +61,7 @@ fn test_config_prompt(#[case] config: Option<&str>, #[case] expected: &str) {
 fn test_partial_config_other_tokens_use_defaults() {
     let env = TestEnv::new(CONFLICT_JSON, Some(CHECKS_PASS_JSON));
     env.write_config("[conflict]\nsymbol = \"✘\"");
-    assert_prompt_with_config(&env, "✘ Resolve conflict #");
+    assert_prompt_with_config(&env, "✘ Resolve conflict");
 }
 
 // ── #49–50: XDG_CONFIG_HOME ───────────────────────────────────────────────────
@@ -93,7 +93,7 @@ fn test_xdg_config_home_is_used() {
     env.apply_with_cache(&mut cmd);
     cmd.assert()
         .success()
-        .stdout("★ Ready for merge #")
+        .stdout("★ Ready for merge")
         .stderr("");
 }
 
@@ -125,7 +125,7 @@ fn test_xdg_config_home_takes_precedence_over_home() {
     env.apply_with_cache(&mut cmd);
     cmd.assert()
         .success()
-        .stdout("★ Ready for merge #")
+        .stdout("★ Ready for merge")
         .stderr("");
 }
 

--- a/tests/e2e/prompt/branch_sync.rs
+++ b/tests/e2e/prompt/branch_sync.rs
@@ -36,17 +36,13 @@ fn assert_prompt(env: &TestEnv, expected: &str) {
 /// #21 `Resolve conflict` + `Fix CI failure` → 両方をスペース区切りで出力
 /// #22 `Resolve conflict` + `Resolve review` → 両方をスペース区切りで出力
 #[rstest]
-#[case::conflict(CONFLICTING_DIRTY, PASS_JSON, "✗ Resolve conflict #")]
-#[case::conflict_wins_over_update_branch(CONFLICTING_BEHIND, PASS_JSON, "✗ Resolve conflict #")]
-#[case::conflict_and_ci_fail(
-    CONFLICTING_DIRTY,
-    FAIL_JSON,
-    "✗ Resolve conflict # ✗ Fix CI failure #"
-)]
+#[case::conflict(CONFLICTING_DIRTY, PASS_JSON, "✗ Resolve conflict")]
+#[case::conflict_wins_over_update_branch(CONFLICTING_BEHIND, PASS_JSON, "✗ Resolve conflict")]
+#[case::conflict_and_ci_fail(CONFLICTING_DIRTY, FAIL_JSON, "✗ Resolve conflict ✗ Fix CI failure")]
 #[case::conflict_and_review(
     CONFLICTING_DIRTY_CHANGES,
     PASS_JSON,
-    "✗ Resolve conflict # ⚠ Resolve review #"
+    "✗ Resolve conflict ⚠ Resolve review"
 )]
 fn test_conflict_prompt(#[case] pr_json: &str, #[case] checks_json: &str, #[case] expected: &str) {
     let env = TestEnv::new(pr_json, Some(checks_json));
@@ -59,7 +55,7 @@ fn test_conflict_prompt(#[case] pr_json: &str, #[case] checks_json: &str, #[case
 #[test]
 fn test_update_branch() {
     let env = TestEnv::with_behind_by(MERGEABLE_BLOCKED, Some(PASS_JSON), 1);
-    assert_prompt(&env, "✗ Update branch #");
+    assert_prompt(&env, "✗ Update branch");
 }
 
 // ── #19: sync-unknown ────────────────────────────────────────────────────────
@@ -68,5 +64,5 @@ fn test_update_branch() {
 #[test]
 fn test_compare_api_error() {
     let env = TestEnv::with_compare_error(MERGEABLE_BLOCKED, Some(PASS_JSON));
-    assert_prompt(&env, "? Check branch sync #");
+    assert_prompt(&env, "? Check branch sync");
 }

--- a/tests/e2e/prompt/ci_checks.rs
+++ b/tests/e2e/prompt/ci_checks.rs
@@ -37,14 +37,14 @@ fn assert_prompt(env: &TestEnv, expected: &str) {
 /// #26 `fail` + `action_required` 混在 → `✗ Fix CI failure`（`Run CI action` は抑制）
 /// #29 `Fix CI failure` + `Resolve review` → 両方をスペース区切りで出力
 #[rstest]
-#[case::ci_fail_failure(BLOCKED_NO_REVIEW, FAIL_JSON, "✗ Fix CI failure #")]
-#[case::ci_fail_cancelled(BLOCKED_NO_REVIEW, CANCEL_JSON, "✗ Fix CI failure #")]
-#[case::ci_action(BLOCKED_NO_REVIEW, ACTION_REQUIRED_JSON, "⚠ Run CI action #")]
-#[case::ci_fail_wins_over_ci_action(BLOCKED_NO_REVIEW, FAIL_AND_ACTION_JSON, "✗ Fix CI failure #")]
+#[case::ci_fail_failure(BLOCKED_NO_REVIEW, FAIL_JSON, "✗ Fix CI failure")]
+#[case::ci_fail_cancelled(BLOCKED_NO_REVIEW, CANCEL_JSON, "✗ Fix CI failure")]
+#[case::ci_action(BLOCKED_NO_REVIEW, ACTION_REQUIRED_JSON, "⚠ Run CI action")]
+#[case::ci_fail_wins_over_ci_action(BLOCKED_NO_REVIEW, FAIL_AND_ACTION_JSON, "✗ Fix CI failure")]
 #[case::ci_fail_and_review(
     BLOCKED_CHANGES_REQUESTED,
     FAIL_JSON,
-    "✗ Fix CI failure # ⚠ Resolve review #"
+    "✗ Fix CI failure ⚠ Resolve review"
 )]
 fn test_ci_check_prompt(#[case] pr_json: &str, #[case] checks_json: &str, #[case] expected: &str) {
     let env = TestEnv::new(pr_json, Some(checks_json));
@@ -56,8 +56,8 @@ fn test_ci_check_prompt(#[case] pr_json: &str, #[case] checks_json: &str, #[case
 /// #27 `no checks reported` + review なし → `✓ Ready for merge`
 /// #28 `no checks reported` + review あり → `⚠ Resolve review`
 #[rstest]
-#[case::merge_ready(APPROVED_CLEAN, "✓ Ready for merge #")]
-#[case::review(BLOCKED_CHANGES_REQUESTED, "⚠ Resolve review #")]
+#[case::merge_ready(APPROVED_CLEAN, "✓ Ready for merge")]
+#[case::review(BLOCKED_CHANGES_REQUESTED, "⚠ Resolve review")]
 fn test_no_ci_checks_prompt(#[case] pr_json: &str, #[case] expected: &str) {
     let env = TestEnv::with_no_ci_checks(pr_json);
     assert_prompt(&env, expected);

--- a/tests/e2e/prompt/merge_ready.rs
+++ b/tests/e2e/prompt/merge_ready.rs
@@ -33,7 +33,7 @@ fn test_merge_ready() {
         r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED"}"#,
         Some(r#"[{"bucket":"pass","state":"SUCCESS"}]"#),
     );
-    assert_prompt(&env, "✓ Ready for merge #");
+    assert_prompt(&env, "✓ Ready for merge");
 }
 
 // ── #16: 全ブロッカーが成立 ──────────────────────────────────────────────────
@@ -45,8 +45,5 @@ fn test_all_conditions_block_merge_ready() {
         r#"{"state":"OPEN","isDraft":false,"mergeable":"CONFLICTING","mergeStateStatus":"DIRTY","reviewDecision":"CHANGES_REQUESTED"}"#,
         Some(r#"[{"bucket":"fail","state":"FAILURE"}]"#),
     );
-    assert_prompt(
-        &env,
-        "✗ Resolve conflict # ✗ Fix CI failure # ⚠ Resolve review #",
-    );
+    assert_prompt(&env, "✗ Resolve conflict ✗ Fix CI failure ⚠ Resolve review");
 }

--- a/tests/e2e/prompt/pr_state.rs
+++ b/tests/e2e/prompt/pr_state.rs
@@ -67,7 +67,7 @@ fn test_no_pr() {
 #[test]
 fn test_draft_pr_shows_ready_for_review() {
     let env = TestEnv::new(DRAFT_PR, Some(r#"[]"#));
-    assert_prompt(&env, "✎ Ready for review #");
+    assert_prompt(&env, "✎ Ready for review");
 }
 
 // ── #32–33: CLOSED / MERGED ───────────────────────────────────────────────────
@@ -88,14 +88,14 @@ fn test_non_open_pr_shows_nothing(#[case] pr_json: &str) {
 #[test]
 fn test_merge_state_unknown_shows_wait_for_status() {
     let env = TestEnv::new(MERGE_STATE_UNKNOWN_PR, Some(r#"[]"#));
-    assert_prompt(&env, "⧖ Wait for status #");
+    assert_prompt(&env, "⧖ Wait for status");
 }
 
 /// #179: `mergeStateStatus == "UNKNOWN"` → `⧖ Wait for status`
 #[test]
 fn test_unknown_merge_state_status_shows_wait_for_status() {
     let env = TestEnv::new(UNKNOWN_STATUS_PR, Some(r#"[]"#));
-    assert_prompt(&env, "⧖ Wait for status #");
+    assert_prompt(&env, "⧖ Wait for status");
 }
 
 // ── #178: BLOCKED + 全シグナル None ──────────────────────────────────────────
@@ -105,5 +105,5 @@ fn test_unknown_merge_state_status_shows_wait_for_status() {
 #[test]
 fn test_blocked_unknown_shows_check_merge_blocker() {
     let env = TestEnv::new(BLOCKED_UNKNOWN_PR, Some(r#"[]"#));
-    assert_prompt(&env, "? Check merge blocker #");
+    assert_prompt(&env, "? Check merge blocker");
 }

--- a/tests/e2e/prompt/review.rs
+++ b/tests/e2e/prompt/review.rs
@@ -23,10 +23,7 @@ fn test_review_changes_requested() {
 
     let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
     env.apply_with_cache(&mut cmd);
-    cmd.assert()
-        .success()
-        .stdout("⚠ Resolve review #")
-        .stderr("");
+    cmd.assert().success().stdout("⚠ Resolve review").stderr("");
 }
 
 /// #31: `reviewDecision == REVIEW_REQUIRED` → `@ Assign reviewer`
@@ -43,6 +40,6 @@ fn test_review_required() {
     env.apply_with_cache(&mut cmd);
     cmd.assert()
         .success()
-        .stdout("@ Assign reviewer #")
+        .stdout("@ Assign reviewer")
         .stderr("");
 }

--- a/tests/e2e/prompt/style.rs
+++ b/tests/e2e/prompt/style.rs
@@ -42,6 +42,45 @@ fn plain_format_produces_no_ansi() {
         .stderr("");
 }
 
+/// `[text](style)` の content 内に conditional ブロックを置いた場合の検証。
+///
+/// `[$symbol $label( #$pr_id)](cyan)` — 単独 PR（`$pr_id` が空）のとき
+/// `( #$pr_id)` ブロックが非表示になり、全体に cyan スタイルが適用される。
+#[test]
+fn conditional_inside_styled_block_hidden_when_pr_id_empty() {
+    let env = TestEnv::new(MERGE_READY_JSON, Some(CHECKS_PASS_JSON));
+    env.write_config("[merge_ready]\nformat = \"[$symbol $label( #$pr_id)](cyan)\"");
+
+    let _daemon = DaemonHandle::start(&env);
+    DaemonHandle::wait_for_cache(&env, 5000);
+
+    let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
+    env.apply_with_cache(&mut cmd);
+    // ANSI コードが含まれる（cyan スタイル適用）
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("\x1b["))
+        .stderr("");
+
+    // `( #)` が出力に含まれないこと（Conditional が非表示）
+    let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
+    env.apply_with_cache(&mut cmd);
+    let output = cmd.output().unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("( #"),
+        "conditional block should be hidden, got: {stdout:?}"
+    );
+    assert!(
+        stdout.contains("✓ Ready for merge"),
+        "symbol and label should be present, got: {stdout:?}"
+    );
+    assert!(
+        !stdout.contains("( #)"),
+        "literal '( #)' must not appear, got: {stdout:?}"
+    );
+}
+
 /// スタイル適用後のテキストに色が漏れない（reset が挿入される）。
 /// `[$symbol](bold green) $label` の $label 部分はデフォルトカラーで出力される。
 #[test]

--- a/tests/e2e/prompt/style.rs
+++ b/tests/e2e/prompt/style.rs
@@ -38,7 +38,7 @@ fn plain_format_produces_no_ansi() {
     env.apply_with_cache(&mut cmd);
     cmd.assert()
         .success()
-        .stdout(predicate::str::diff("✓ Ready for merge #"))
+        .stdout(predicate::str::diff("✓ Ready for merge"))
         .stderr("");
 }
 

--- a/tests/e2e/scenarios/cache_hit.rs
+++ b/tests/e2e/scenarios/cache_hit.rs
@@ -36,5 +36,5 @@ fn test_daemon_fresh_returns_cached_output() {
     cmd.current_dir(env.repo_dir.path());
     cmd.assert()
         .success()
-        .stdout(predicate::str::diff("✓ Ready for merge #"));
+        .stdout(predicate::str::diff("✓ Ready for merge"));
 }

--- a/tests/e2e/scenarios/initial_load.rs
+++ b/tests/e2e/scenarios/initial_load.rs
@@ -32,7 +32,7 @@ fn test_initial_load_then_shows_result() {
     env.apply_with_cache(&mut cmd);
     cmd.assert()
         .success()
-        .stdout(predicate::str::diff("✓ Ready for merge #"));
+        .stdout(predicate::str::diff("✓ Ready for merge"));
 
     // 自動起動された daemon を後始末
     let bin = assert_cmd::cargo::cargo_bin(BIN);

--- a/tests/e2e/scenarios/multi_repo.rs
+++ b/tests/e2e/scenarios/multi_repo.rs
@@ -23,7 +23,7 @@ fn test_daemon_multi_repo_isolation() {
     let out_b = env.prompt_output(&env.repo_b);
 
     assert_eq!(
-        out_a, "✓ Ready for merge #",
+        out_a, "✓ Ready for merge",
         "repo_a should be ready for merge"
     );
     assert!(


### PR DESCRIPTION
## Summary

- `(...)` ブロック内の変数がすべて空の場合にブロック全体を非表示にする conditional format strings を実装（Starship 仕様準拠）
- `Segment::Conditional` バリアントを追加し、`parse_segments` で `(...)` を再帰パース
- 変数マップ方式（`Vec<(&str, &str)>`）に変更し、`eval_conditional` で空判定を実装
- `[text](style)` の content 内に `(...)` が含まれる場合も再帰評価に対応
- `DEFAULT_PR_FORMAT` を `"$symbol $label( #$pr_id)"` に更新し、単独 PR 時の末尾 `#` を解消
- #256 実装時に暫定修正した E2E テスト期待値を元の形式に復旧
- README に複数 PR 対応・Format Variables・Conditional Format Strings セクションを追記

Closes #260

## Commits

- `feat: #260 conditional format strings のサポート` — コアとなる `Segment::Conditional` の実装と E2E Red/Green
- `feat: #260 Styled ブロック内の Conditional を再帰評価` — `[$symbol $label( #$pr_id)](cyan)` などの入れ子構文に対応
- `docs: #256 #260 README に複数 PR 対応と conditional format strings を追記`

## Test plan

- [x] `cargo test --workspace` がすべて通ること（unit 162 件、E2E 94 件）
- [x] 単独 PR 時に `✓ Ready for merge` と表示される（末尾 `#` なし）
- [x] 複数 PR 時に `✓ Ready for merge #200 ✎ Ready for review #201` と PR 番号付きで表示される
- [x] `[$symbol $label( #$pr_id)](cyan)` 形式で Styled 内 Conditional が正しく動作する
- [x] `cargo clippy --workspace -- -D warnings` がパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)