### PR TITLE
fix: daemon 起動レースを防ぐ

### DIFF
--- a/src/contexts/daemon/infrastructure/daemon_lifecycle.rs
+++ b/src/contexts/daemon/infrastructure/daemon_lifecycle.rs
@@ -22,14 +22,6 @@ impl DaemonLifecycle {
 
 impl DaemonLifecyclePort for DaemonLifecycle {
     fn start(&self) -> Result<(), DaemonError> {
-        if let Some(p) = pid::read() {
-            if pid::is_alive(p) {
-                log::error!("daemon is already running (pid {p})");
-                eprintln!("merge-ready daemon is already running (pid {p})");
-                return Err(DaemonError::AlreadyRunning);
-            }
-            pid::remove();
-        }
         daemon_server::run(&self.on_refresh)
     }
 

--- a/src/contexts/daemon/infrastructure/daemon_server.rs
+++ b/src/contexts/daemon/infrastructure/daemon_server.rs
@@ -110,8 +110,6 @@ pub fn run(on_refresh: &RefreshFn) -> Result<(), DaemonError> {
 
     let listener = bind_socket(&socket_path)?;
 
-    pid::write(std::process::id());
-
     // 外側プロセスへ起動完了を通知する（stdout pipe 経由）
     {
         use std::io::Write;
@@ -172,13 +170,34 @@ pub fn run(on_refresh: &RefreshFn) -> Result<(), DaemonError> {
 }
 
 fn bind_socket(socket_path: &std::path::Path) -> Result<UnixListener, DaemonError> {
+    let startup_lock = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(paths::lock_path())
+        .map_err(|e| {
+            log::error!("failed to open daemon lock file: {e}");
+            eprintln!("merge-ready daemon: failed to open lock file: {e}");
+            DaemonError::Failure
+        })?;
+    startup_lock.lock().map_err(|e| {
+        log::error!("failed to lock daemon startup: {e}");
+        eprintln!("merge-ready daemon: failed to acquire startup lock: {e}");
+        DaemonError::Failure
+    })?;
+
     match pid::read() {
         Some(p) if pid::is_alive(p) => {
             log::error!("daemon is already running (pid {p})");
             eprintln!("merge-ready daemon is already running (pid {p})");
             return Err(DaemonError::AlreadyRunning);
         }
-        _ => {
+        Some(_) => {
+            pid::remove();
+            let _ = std::fs::remove_file(socket_path);
+        }
+        None => {
             let _ = std::fs::remove_file(socket_path);
         }
     }
@@ -186,7 +205,10 @@ fn bind_socket(socket_path: &std::path::Path) -> Result<UnixListener, DaemonErro
     let mut retries = 0;
     loop {
         match UnixListener::bind(socket_path) {
-            Ok(l) => return Ok(l),
+            Ok(l) => {
+                pid::write(std::process::id());
+                return Ok(l);
+            }
             Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
                 if retries >= BIND_RETRY_MAX {
                     log::error!("socket already in use after retries, giving up");

--- a/src/contexts/daemon/infrastructure/paths.rs
+++ b/src/contexts/daemon/infrastructure/paths.rs
@@ -13,6 +13,10 @@ pub fn pid_path() -> PathBuf {
     base_dir().join("daemon.pid")
 }
 
+pub fn lock_path() -> PathBuf {
+    base_dir().join("daemon.lock")
+}
+
 pub fn base_dir() -> PathBuf {
     std::env::temp_dir().join(dir_name())
 }

--- a/tests/e2e/daemon/lifecycle.rs
+++ b/tests/e2e/daemon/lifecycle.rs
@@ -13,6 +13,25 @@ const PROMPT_BIN: &str = "merge-ready-prompt";
 const OPEN_PR_VIEW_JSON: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}"#;
 const CI_PASS_JSON: &str = r#"[{"bucket":"pass","state":"SUCCESS","name":"ci","link":""}]"#;
 
+fn assert_prompt_succeeded(output: &std::process::Output) {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "prompt failed: status={:?}, stdout={stdout:?}, stderr={stderr:?}",
+        output.status.code(),
+    );
+    assert!(
+        stderr.is_empty(),
+        "prompt stderr should be empty: {stderr:?}"
+    );
+    assert!(
+        stdout == "? loading" || stdout == "✓ Ready for merge",
+        "unexpected prompt stdout: {stdout:?}",
+    );
+}
+
 // ── #7: daemon start ─────────────────────────────────────────────────────────
 
 /// #7: `daemon start` → "daemon started" を出力して exit 0
@@ -242,9 +261,13 @@ fn test_concurrent_prompt_starts_only_one_daemon() {
         })
         .collect();
 
-    // 全スレッド完了を待つ
+    // 全スレッド完了を待ち、各 prompt が競合中も正常終了することを確認
     for h in handles {
-        let _ = h.join();
+        let output = h
+            .join()
+            .expect("prompt thread panicked")
+            .expect("run prompt");
+        assert_prompt_succeeded(&output);
     }
 
     // daemon が正確に 1 プロセス起動していることを確認
@@ -304,7 +327,11 @@ fn test_concurrent_version_mismatch_starts_only_one_daemon() {
         .collect();
 
     for h in handles {
-        let _ = h.join();
+        let output = h
+            .join()
+            .expect("prompt thread panicked")
+            .expect("run prompt");
+        assert_prompt_succeeded(&output);
     }
 
     // 新 daemon が起動するまでポーリング（最大 5 秒）


### PR DESCRIPTION
## 概要
- daemon 起動時の状態更新を lock file で直列化し、複数の prompt 実行が同時に socket bind へ進むレースを防ぎます。
- PID 書き込みをロック済みの bind 処理内へ移し、critical section 外の起動前 PID cleanup を削除します。
- 並列 prompt 起動の E2E テストを強化し、全 invocation が stderr なしで成功することを検証します。

Fixes #259

## テスト計画
- [x] cargo test --test e2e daemon::lifecycle::test_concurrent_prompt_starts_only_one_daemon
- [x] cargo test --test e2e daemon::lifecycle
- [x] cargo test --workspace
- [x] cargo clippy --workspace -- -D warnings
- [x] cargo fmt --check --all