### PR TITLE
watch のエントリ一覧に PR 番号を表示する

### DIFF
--- a/src/contexts/daemon/application/port.rs
+++ b/src/contexts/daemon/application/port.rs
@@ -2,6 +2,7 @@
 pub struct EntryView {
     pub cwd: String,
     pub branch: String,
+    pub pr_id: Option<u64>,
     pub output: String,
     pub cached_at_secs: u64,
 }

--- a/src/contexts/daemon/domain/cache.rs
+++ b/src/contexts/daemon/domain/cache.rs
@@ -119,8 +119,6 @@ impl CacheEntry {
         self.refresh_mode = refresh_mode;
     }
 
-    // #239（watch コマンド）実装時に呼び出し元が追加される。その時点でこのアノテーションを削除する。
-    #[allow(dead_code)]
     pub fn pr_outputs(&self) -> &[PrOutput] {
         &self.pr_outputs
     }
@@ -342,6 +340,56 @@ mod tests {
         let mut e = make_entry("out", RefreshMode::Warm);
         e.update(String::new(), vec![], RefreshMode::Terminal);
         assert_eq!(e.refresh_mode(), RefreshMode::Terminal);
+    }
+
+    #[test]
+    fn update_stores_pr_outputs() {
+        let mut e = CacheEntry::new(PathBuf::new(), String::new(), 5);
+        e.update(
+            "combined".to_owned(),
+            vec![
+                PrOutput {
+                    pr_id: 200,
+                    output: "✓ Ready for merge".to_owned(),
+                },
+                PrOutput {
+                    pr_id: 201,
+                    output: "✎ Ready for review".to_owned(),
+                },
+            ],
+            RefreshMode::Warm,
+        );
+
+        assert_eq!(e.pr_outputs().len(), 2);
+        assert_eq!(e.pr_outputs()[0].pr_id, 200);
+        assert_eq!(e.pr_outputs()[0].output, "✓ Ready for merge");
+        assert_eq!(e.pr_outputs()[1].pr_id, 201);
+        assert_eq!(e.pr_outputs()[1].output, "✎ Ready for review");
+    }
+
+    #[test]
+    fn update_replaces_pr_outputs() {
+        let mut e = CacheEntry::new(PathBuf::new(), String::new(), 5);
+        e.update(
+            "old".to_owned(),
+            vec![PrOutput {
+                pr_id: 200,
+                output: "old".to_owned(),
+            }],
+            RefreshMode::Warm,
+        );
+        e.update(
+            "new".to_owned(),
+            vec![PrOutput {
+                pr_id: 201,
+                output: "new".to_owned(),
+            }],
+            RefreshMode::Warm,
+        );
+
+        assert_eq!(e.pr_outputs().len(), 1);
+        assert_eq!(e.pr_outputs()[0].pr_id, 201);
+        assert_eq!(e.pr_outputs()[0].output, "new");
     }
 
     // ── CacheEntry::is_active ─────────────────────────────────────────────────

--- a/src/contexts/daemon/infrastructure/daemon_lifecycle.rs
+++ b/src/contexts/daemon/infrastructure/daemon_lifecycle.rs
@@ -63,6 +63,7 @@ impl WatchPort for DaemonLifecycle {
                 .map(|dto| EntryView {
                     cwd: dto.cwd,
                     branch: dto.branch,
+                    pr_id: dto.pr_id,
                     output: dto.output,
                     cached_at_secs: dto.cached_at_secs,
                 })

--- a/src/contexts/daemon/infrastructure/daemon_server.rs
+++ b/src/contexts/daemon/infrastructure/daemon_server.rs
@@ -370,21 +370,7 @@ fn process(request: &Request, state: &Arc<Mutex<DaemonState>>) -> ActionResult {
             }
         }
         Request::Entries => {
-            use std::time::UNIX_EPOCH;
-            let dtos: Vec<EntryDto> = s
-                .entries
-                .values()
-                .map(|entry| EntryDto {
-                    cwd: entry.cwd().to_string_lossy().into_owned(),
-                    branch: entry.branch().to_owned(),
-                    output: entry.output().to_owned(),
-                    cached_at_secs: entry
-                        .fetched_at_wall()
-                        .duration_since(UNIX_EPOCH)
-                        .unwrap_or_default()
-                        .as_secs(),
-                })
-                .collect();
+            let dtos: Vec<EntryDto> = s.entries.values().flat_map(entry_to_dtos).collect();
             ActionResult {
                 response: Response::Entries { entries: dtos },
                 refresh_repo_id: None,
@@ -394,6 +380,60 @@ fn process(request: &Request, state: &Arc<Mutex<DaemonState>>) -> ActionResult {
             }
         }
     }
+}
+
+fn entry_to_dtos(entry: &CacheEntry) -> Vec<EntryDto> {
+    let cwd = entry.cwd().to_string_lossy().into_owned();
+    let branch = entry.branch().to_owned();
+    let cached_at_secs = cached_at_secs(entry);
+
+    if entry.pr_outputs().is_empty() {
+        return vec![entry_dto(
+            cwd,
+            branch,
+            None,
+            entry.output().to_owned(),
+            cached_at_secs,
+        )];
+    }
+
+    entry
+        .pr_outputs()
+        .iter()
+        .map(|pr_output| {
+            entry_dto(
+                cwd.clone(),
+                branch.clone(),
+                Some(pr_output.pr_id),
+                pr_output.output.clone(),
+                cached_at_secs,
+            )
+        })
+        .collect()
+}
+
+fn entry_dto(
+    cwd: String,
+    branch: String,
+    pr_id: Option<u64>,
+    output: String,
+    cached_at_secs: u64,
+) -> EntryDto {
+    EntryDto {
+        cwd,
+        branch,
+        pr_id,
+        output,
+        cached_at_secs,
+    }
+}
+
+fn cached_at_secs(entry: &CacheEntry) -> u64 {
+    entry
+        .fetched_at_wall()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
 }
 
 fn process_query(
@@ -758,6 +798,43 @@ mod tests {
     }
 
     #[test]
+    fn process_update_stores_pr_outputs() {
+        let repo_id = RepoId::new("repo");
+        let mut entries = HashMap::new();
+        entries.insert(
+            repo_id.clone(),
+            make_entry(
+                "✓ Ready for merge #200 ✎ Ready for review #201",
+                RefreshMode::Warm,
+            ),
+        );
+
+        process_update(
+            &repo_id,
+            "✓ Ready for merge #200 ✎ Ready for review #201",
+            RefreshMode::Warm,
+            &[
+                PrOutputDto {
+                    pr_id: 200,
+                    output: "✓ Ready for merge #200".to_owned(),
+                },
+                PrOutputDto {
+                    pr_id: 201,
+                    output: "✎ Ready for review #201".to_owned(),
+                },
+            ],
+            &mut entries,
+        );
+
+        let pr_outputs = entries[&repo_id].pr_outputs();
+        assert_eq!(pr_outputs.len(), 2);
+        assert_eq!(pr_outputs[0].pr_id, 200);
+        assert_eq!(pr_outputs[0].output, "✓ Ready for merge #200");
+        assert_eq!(pr_outputs[1].pr_id, 201);
+        assert_eq!(pr_outputs[1].output, "✎ Ready for review #201");
+    }
+
+    #[test]
     fn process_update_unknown_repo_id_is_ignored() {
         // ブランチ切替後に spawn_refresh が新 repo_id で Update してきた場合、
         // エントリを新規作成せず無視する（孤立エントリ防止）
@@ -788,6 +865,53 @@ mod tests {
             &mut entries,
         );
         assert_eq!(entries[&repo_id].refresh_mode(), RefreshMode::Warm);
+    }
+
+    // ── entry_to_dtos ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn entry_to_dtos_expands_pr_outputs() {
+        let mut entry = CacheEntry::new(PathBuf::from("/repo"), "feat/multi".to_owned(), 5);
+        entry.update(
+            "✓ Ready for merge #200 ✎ Ready for review #201".to_owned(),
+            vec![
+                PrOutput {
+                    pr_id: 200,
+                    output: "✓ Ready for merge #200".to_owned(),
+                },
+                PrOutput {
+                    pr_id: 201,
+                    output: "✎ Ready for review #201".to_owned(),
+                },
+            ],
+            RefreshMode::Warm,
+        );
+
+        let dtos = entry_to_dtos(&entry);
+
+        assert_eq!(dtos.len(), 2);
+        assert_eq!(dtos[0].cwd, "/repo");
+        assert_eq!(dtos[0].branch, "feat/multi");
+        assert_eq!(dtos[0].pr_id, Some(200));
+        assert_eq!(dtos[0].output, "✓ Ready for merge #200");
+        assert_eq!(dtos[1].cwd, "/repo");
+        assert_eq!(dtos[1].branch, "feat/multi");
+        assert_eq!(dtos[1].pr_id, Some(201));
+        assert_eq!(dtos[1].output, "✎ Ready for review #201");
+    }
+
+    #[test]
+    fn entry_to_dtos_keeps_aggregate_output_without_pr_outputs() {
+        let mut entry = CacheEntry::new(PathBuf::from("/repo"), "chore/no-pr".to_owned(), 5);
+        entry.update("+ Create PR".to_owned(), vec![], RefreshMode::Warm);
+
+        let dtos = entry_to_dtos(&entry);
+
+        assert_eq!(dtos.len(), 1);
+        assert_eq!(dtos[0].cwd, "/repo");
+        assert_eq!(dtos[0].branch, "chore/no-pr");
+        assert_eq!(dtos[0].pr_id, None);
+        assert_eq!(dtos[0].output, "+ Create PR");
     }
 
     // ── collect_background_refresh_targets ─────────────────────────────────────

--- a/src/contexts/daemon/infrastructure/protocol.rs
+++ b/src/contexts/daemon/infrastructure/protocol.rs
@@ -22,6 +22,8 @@ pub struct PrOutputDto {
 pub struct EntryDto {
     pub cwd: String,
     pub branch: String,
+    #[serde(default)]
+    pub pr_id: Option<u64>,
     pub output: String,
     pub cached_at_secs: u64,
 }
@@ -77,11 +79,13 @@ mod tests {
         let dto = EntryDto {
             cwd: "/tmp".into(),
             branch: "main".into(),
+            pr_id: Some(123),
             output: "✓ Ready".into(),
             cached_at_secs: 1_000,
         };
         let json = serde_json::to_string(&dto).unwrap();
         assert!(json.contains("cached_at_secs"));
+        assert!(json.contains("pr_id"));
         assert!(json.contains("/tmp"));
     }
 }

--- a/src/contexts/daemon/interface/cli/watch.rs
+++ b/src/contexts/daemon/interface/cli/watch.rs
@@ -49,53 +49,95 @@ fn format_table(entries: &[EntryView]) -> String {
         return "no entries cached\n".to_owned();
     }
 
-    let header = ("CWD", "BRANCH", "STATUS", "CACHED AT");
-    let rows: Vec<(String, String, String, String)> = entries
-        .iter()
-        .map(|e| {
-            (
-                e.cwd.clone(),
-                e.branch.clone(),
-                e.output.clone(),
-                format_cached_at(e.cached_at_secs),
-            )
-        })
-        .collect();
-
-    let w0 = rows
-        .iter()
-        .map(|r| r.0.len())
-        .max()
-        .unwrap_or(0)
-        .max(header.0.len());
-    let w1 = rows
-        .iter()
-        .map(|r| r.1.len())
-        .max()
-        .unwrap_or(0)
-        .max(header.1.len());
-    let w2 = rows
-        .iter()
-        .map(|r| visible_len(&r.2))
-        .max()
-        .unwrap_or(0)
-        .max(header.2.len());
+    let header = TableRow {
+        cwd: "CWD".to_owned(),
+        branch: "BRANCH".to_owned(),
+        pr: "PR".to_owned(),
+        status: "STATUS".to_owned(),
+        cached_at: "CACHED AT".to_owned(),
+    };
+    let rows: Vec<TableRow> = entries.iter().map(TableRow::from_entry).collect();
+    let widths = TableWidths::from_rows(&header, &rows);
 
     let mut out = String::new();
     let _ = writeln!(
         out,
-        "{:<w0$}  {:<w1$}  {:<w2$}  {}",
-        header.0, header.1, header.2, header.3,
+        "{:<cwd_width$}  {:<branch_width$}  {:<pr_width$}  {:<status_width$}  {}",
+        header.cwd,
+        header.branch,
+        header.pr,
+        header.status,
+        header.cached_at,
+        cwd_width = widths.cwd,
+        branch_width = widths.branch,
+        pr_width = widths.pr,
+        status_width = widths.status,
     );
     for row in &rows {
-        let pad = w2 - visible_len(&row.2) + row.2.len();
+        let status_pad = widths.status - visible_len(&row.status) + row.status.len();
         let _ = writeln!(
             out,
-            "{:<w0$}  {:<w1$}  {:<pad$}  {}",
-            row.0, row.1, row.2, row.3
+            "{:<cwd_width$}  {:<branch_width$}  {:<pr_width$}  {:<status_pad$}  {}",
+            row.cwd,
+            row.branch,
+            row.pr,
+            row.status,
+            row.cached_at,
+            cwd_width = widths.cwd,
+            branch_width = widths.branch,
+            pr_width = widths.pr,
         );
     }
     out
+}
+
+struct TableRow {
+    cwd: String,
+    branch: String,
+    pr: String,
+    status: String,
+    cached_at: String,
+}
+
+impl TableRow {
+    fn from_entry(entry: &EntryView) -> Self {
+        Self {
+            cwd: entry.cwd.clone(),
+            branch: entry.branch.clone(),
+            pr: format_pr_id(entry.pr_id),
+            status: entry.output.clone(),
+            cached_at: format_cached_at(entry.cached_at_secs),
+        }
+    }
+}
+
+struct TableWidths {
+    cwd: usize,
+    branch: usize,
+    pr: usize,
+    status: usize,
+}
+
+impl TableWidths {
+    fn from_rows(header: &TableRow, rows: &[TableRow]) -> Self {
+        Self {
+            cwd: max_width(rows.iter().map(|row| row.cwd.len()), header.cwd.len()),
+            branch: max_width(rows.iter().map(|row| row.branch.len()), header.branch.len()),
+            pr: max_width(rows.iter().map(|row| row.pr.len()), header.pr.len()),
+            status: max_width(
+                rows.iter().map(|row| visible_len(&row.status)),
+                header.status.len(),
+            ),
+        }
+    }
+}
+
+fn max_width(widths: impl Iterator<Item = usize>, header_width: usize) -> usize {
+    widths.max().unwrap_or(0).max(header_width)
+}
+
+fn format_pr_id(pr_id: Option<u64>) -> String {
+    pr_id.map_or_else(String::new, |id| format!("#{id}"))
 }
 
 fn visible_len(s: &str) -> usize {
@@ -135,7 +177,13 @@ fn format_cached_at(cached_at_secs: u64) -> String {
 mod tests {
     use super::*;
 
-    fn make_view(cwd: &str, branch: &str, output: &str, age_secs: u64) -> EntryView {
+    fn make_view(
+        cwd: &str,
+        branch: &str,
+        pr_id: Option<u64>,
+        output: &str,
+        age_secs: u64,
+    ) -> EntryView {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
@@ -143,6 +191,7 @@ mod tests {
         EntryView {
             cwd: cwd.to_owned(),
             branch: branch.to_owned(),
+            pr_id,
             output: output.to_owned(),
             cached_at_secs: now.saturating_sub(age_secs),
         }
@@ -156,22 +205,67 @@ mod tests {
 
     #[test]
     fn format_table_shows_header() {
-        let view = make_view("/repo", "main", "✓ Ready", 5);
+        let view = make_view("/repo", "main", Some(123), "✓ Ready", 5);
         let table = format_table(&[view]);
         assert!(table.contains("CWD"));
         assert!(table.contains("BRANCH"));
+        assert!(table.contains("PR"));
         assert!(table.contains("STATUS"));
         assert!(table.contains("CACHED AT"));
     }
 
     #[test]
     fn format_table_shows_all_columns() {
-        let view = make_view("/repo/myapp", "feat/123", "✓ Ready for merge", 10);
+        let view = make_view(
+            "/repo/myapp",
+            "feat/123",
+            Some(123),
+            "✓ Ready for merge",
+            10,
+        );
         let table = format_table(&[view]);
         assert!(table.contains("/repo/myapp"));
         assert!(table.contains("feat/123"));
+        assert!(table.contains("#123"));
         assert!(table.contains("✓ Ready for merge"));
         assert!(table.contains("ago"));
+    }
+
+    #[test]
+    fn format_table_leaves_pr_column_empty_without_pr_id() {
+        let view = make_view("/repo/myapp", "chore/deps", None, "+ Create PR", 10);
+        let table = format_table(&[view]);
+
+        assert!(table.contains("PR"));
+        assert!(!table.contains('#'));
+        assert!(table.contains("+ Create PR"));
+    }
+
+    #[test]
+    fn format_table_shows_multiple_pr_rows() {
+        let rows = vec![
+            make_view(
+                "/repo/myapp",
+                "feat/multi",
+                Some(200),
+                "✓ Ready for merge #200",
+                10,
+            ),
+            make_view(
+                "/repo/myapp",
+                "feat/multi",
+                Some(201),
+                "✎ Ready for review #201",
+                10,
+            ),
+        ];
+
+        let table = format_table(&rows);
+
+        assert!(table.contains("#200"));
+        assert!(table.contains("#201"));
+        assert!(table.contains("✓ Ready for merge #200"));
+        assert!(table.contains("✎ Ready for review #201"));
     }
 
     #[test]

--- a/src/contexts/evaluation/interface/prompt.rs
+++ b/src/contexts/evaluation/interface/prompt.rs
@@ -65,13 +65,10 @@ where
                 } else {
                     String::new()
                 };
-                let pr_out = display_items
-                    .iter()
-                    .map(|item| render_token(item_to_token(item, &config), Some(&id_str)))
-                    .collect::<Vec<_>>()
-                    .join(" ");
-                pr_outputs.push((*pr_id, pr_out.clone()));
-                all_outputs.push(pr_out);
+                let prompt_out = render_display_items(display_items, &config, &id_str);
+                let watch_out = render_display_items(display_items, &config, "");
+                pr_outputs.push((*pr_id, watch_out));
+                all_outputs.push(prompt_out);
             }
 
             let cache_hint = if items.iter().any(|(_, dis)| {
@@ -95,6 +92,18 @@ where
             pr_outputs: vec![],
         },
     }
+}
+
+fn render_display_items(
+    display_items: &[DisplayItem],
+    config: &DisplayConfig,
+    pr_id: &str,
+) -> String {
+    display_items
+        .iter()
+        .map(|item| render_token(item_to_token(item, config), Some(pr_id)))
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 fn item_to_token<'a>(item: &DisplayItem, config: &'a DisplayConfig) -> &'a TokenConfig {
@@ -258,6 +267,25 @@ mod tests {
         assert_eq!(result.pr_outputs.len(), 2);
         assert!(result.output.contains("200"));
         assert!(result.output.contains("201"));
+    }
+
+    #[test]
+    fn multiple_prs_pr_outputs_omit_pr_id_numbers_for_watch() {
+        let result = do_render(|| {
+            Ok(Prompt::PullRequests(vec![
+                PullRequest {
+                    id: PrId::new(200),
+                    state: State::Unblocked(UnblockedState::MergeReady),
+                },
+                PullRequest {
+                    id: PrId::new(201),
+                    state: State::Unblocked(UnblockedState::Draft),
+                },
+            ]))
+        });
+
+        assert_eq!(result.pr_outputs[0].1, "✓ Ready for merge");
+        assert_eq!(result.pr_outputs[1].1, "✎ Ready for review");
     }
 
     #[test]

--- a/tests/e2e/daemon/watch.rs
+++ b/tests/e2e/daemon/watch.rs
@@ -103,3 +103,65 @@ fn test_watch_shows_no_entries_when_empty() {
         "unexpected output: {output:?}"
     );
 }
+
+// ── #W4: PR 番号カラム ────────────────────────────────────────────────────────
+
+/// #W4: cache に PR が存在する場合、watch は PR 番号カラムを表示する
+#[test]
+fn test_watch_shows_pr_column_for_cached_pr() {
+    let env = TestEnv::new(OPEN_PR_VIEW_JSON, Some(CI_PASS_JSON));
+    let _daemon = DaemonHandle::start(&env);
+    DaemonHandle::wait_for_cache(&env, 5000);
+
+    let output = spawn_watch_and_read(&env, 2, Duration::from_secs(5));
+
+    assert!(output.contains("PR"), "unexpected output: {output:?}");
+    assert!(output.contains("#1"), "unexpected output: {output:?}");
+    assert!(
+        output.contains("✓ Ready for merge"),
+        "unexpected output: {output:?}"
+    );
+}
+
+/// #W5: PR が存在しない場合、watch は PR 番号カラムを空欄にする
+#[test]
+fn test_watch_leaves_pr_column_empty_without_pr() {
+    let env = TestEnv::with_no_pr();
+    let _daemon = DaemonHandle::start(&env);
+    DaemonHandle::wait_for_cache(&env, 5000);
+
+    let output = spawn_watch_and_read(&env, 2, Duration::from_secs(5));
+
+    assert!(output.contains("PR"), "unexpected output: {output:?}");
+    assert!(
+        output.contains("+ Create PR"),
+        "unexpected output: {output:?}"
+    );
+    assert!(!output.contains('#'), "unexpected output: {output:?}");
+}
+
+/// #W6: 複数 PR がある場合、watch は 1 PR 1 行に展開して表示する
+#[test]
+fn test_watch_expands_multiple_prs_to_rows() {
+    let pr_list_json = r#"[
+        {"number":200,"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null,"baseRefName":"","headRefName":""},
+        {"number":201,"state":"OPEN","isDraft":true,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null,"baseRefName":"","headRefName":""}
+    ]"#;
+    let env = TestEnv::with_pr_list(pr_list_json, Some(r#"[]"#));
+    let _daemon = DaemonHandle::start(&env);
+    DaemonHandle::wait_for_cache(&env, 5000);
+
+    let output = spawn_watch_and_read(&env, 3, Duration::from_secs(5));
+
+    assert!(output.contains("PR"), "unexpected output: {output:?}");
+    assert!(output.contains("#200"), "unexpected output: {output:?}");
+    assert!(output.contains("#201"), "unexpected output: {output:?}");
+    assert!(
+        output.contains("✓ Ready for merge"),
+        "unexpected output: {output:?}"
+    );
+    assert!(
+        output.contains("✎ Ready for review"),
+        "unexpected output: {output:?}"
+    );
+}


### PR DESCRIPTION
## 概要
- `merge-ready watch` の一覧に `PR` カラムを追加しました。
- daemon の cache entries 応答で `pr_outputs` を 1 PR 1 行に展開し、複数 PR のブランチを複数行で表示できるようにしました。
- PR なしのエントリでは `PR` カラムを空欄にし、watch 表示と E2E テストを追加しました。

## 動作確認
- `cargo test --workspace`
- `cargo fmt --check --all`
- `cargo clippy --workspace -- -D warnings`

Closes #239

Made with [Cursor](https://cursor.com)