### PR TITLE
ci: PR title の Conventional Commit 形式チェックを追加する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,23 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, edited, synchronize, reopened]
 
 permissions:
   contents: read
 
 jobs:
+  check-pr-title:
+    name: check-pr-title
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Check PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: bash scripts/check-pr-title.sh
+
   fmt:
     name: fmt
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,7 @@ cargo fmt --check --all              # formatting check
 cargo deny check                     # dependency audit
 bash scripts/check-layer-deps.sh     # DDD layer dependency rules
 bash scripts/check-no-mod-rs.sh      # forbid mod.rs (use Rust 2018+ style)
+bash scripts/check-pr-title.sh       # require Conventional Commit PR titles (set PR_TITLE)
 bash scripts/check-e2e.sh           # feat/fix PRs must include changes under tests/e2e/ (set PR_TITLE and BASE_REF)
 ```
 

--- a/scripts/check-pr-title.sh
+++ b/scripts/check-pr-title.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+title="${PR_TITLE:-}"
+
+if [ -z "$title" ]; then
+  printf 'ERROR: PR_TITLE is required.\n' >&2
+  exit 1
+fi
+
+conventional_title='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-zA-Z0-9._/-]+\))?(!)?: .+'
+
+if [[ "$title" =~ $conventional_title ]]; then
+  echo "PR title is Conventional Commit compatible. OK"
+  exit 0
+fi
+
+cat >&2 <<'MSG'
+ERROR: PR title must use Conventional Commit format.
+
+Accepted examples:
+  feat: add watch PR column
+  fix(daemon): avoid startup race
+  chore!: remove legacy config
+
+Allowed types:
+  build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test
+MSG
+printf '\nActual title:\n  %s\n' "$title" >&2
+exit 1


### PR DESCRIPTION
## 概要
- PR title が Conventional Commit 形式かを検査する `check-pr-title` job を CI に追加しました。
- PR title 編集時にも再検査されるよう、`pull_request` の `edited` イベントを対象に含めました。
- ローカルでも確認できるよう `scripts/check-pr-title.sh` を追加し、`CONTRIBUTING.md` に手順を追記しました。

## 動作確認
- `bash -n scripts/check-pr-title.sh`
- `PR_TITLE='ci: check PR title format' bash scripts/check-pr-title.sh`
- invalid title が reject されること
- `cargo fmt --check --all`

Made with [Cursor](https://cursor.com)