### PR TITLE
refactor: StyleSpec の bool フィールドを修飾子集合へ置き換える

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,6 +621,7 @@ name = "merge-ready"
 version = "0.7.2"
 dependencies = [
  "assert_cmd",
+ "bitflags",
  "clap",
  "clap_complete",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ serde_json = "1.0.149"
 simplelog = "0.12"
 toml = "1.1.2"
 crossterm = "0.29.0"
+bitflags = "2.11.1"
 
 [lib]
 name = "merge_ready"

--- a/src/contexts/evaluation/domain/style_spec.rs
+++ b/src/contexts/evaluation/domain/style_spec.rs
@@ -1,192 +1,98 @@
-use nu_ansi_term::{Color, Style};
+mod color;
+mod modifiers;
 
-#[derive(Debug, PartialEq)]
-pub(crate) enum NamedColor {
-    Black,
-    Red,
-    Green,
-    Yellow,
-    Blue,
-    Purple,
-    Cyan,
-    White,
-    BrightBlack,
-    BrightRed,
-    BrightGreen,
-    BrightYellow,
-    BrightBlue,
-    BrightPurple,
-    BrightCyan,
-    BrightWhite,
+use color::{ColorSpec, color_spec_to_nu, parse_color_value, parse_named_color};
+use modifiers::StyleModifiers;
+use nu_ansi_term::Style;
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum StyleSpec {
+    None,
+    Styled {
+        fg: Option<ColorSpec>,
+        bg: Option<ColorSpec>,
+        modifiers: StyleModifiers,
+    },
 }
 
-#[derive(Debug, PartialEq)]
-pub(crate) enum ColorSpec {
-    Named(NamedColor),
-    Ansi256(u8),
-    Rgb(u8, u8, u8),
-}
-
-#[derive(Debug, PartialEq, Default)]
-#[allow(clippy::struct_excessive_bools)]
-pub(crate) struct StyleSpec {
-    pub fg: Option<ColorSpec>,
-    pub bg: Option<ColorSpec>,
-    pub bold: bool,
-    pub italic: bool,
-    pub underline: bool,
-    pub dimmed: bool,
-    pub inverted: bool,
-    pub blink: bool,
-    pub hidden: bool,
-    pub strikethrough: bool,
-    pub none: bool,
+impl Default for StyleSpec {
+    fn default() -> Self {
+        Self::Styled {
+            fg: None,
+            bg: None,
+            modifiers: StyleModifiers::empty(),
+        }
+    }
 }
 
 impl StyleSpec {
     pub(crate) fn parse(s: &str) -> Self {
-        let mut spec = Self::default();
+        let mut fg = None;
+        let mut bg = None;
+        let mut modifiers = StyleModifiers::empty();
+
         for token in s.split_whitespace() {
             let lower = token.to_ascii_lowercase();
-            match lower.as_str() {
-                "bold" => spec.bold = true,
-                "italic" => spec.italic = true,
-                "underline" => spec.underline = true,
-                "dimmed" => spec.dimmed = true,
-                "inverted" => spec.inverted = true,
-                "blink" => spec.blink = true,
-                "hidden" => spec.hidden = true,
-                "strikethrough" => spec.strikethrough = true,
-                "none" => spec.none = true,
-                name if parse_named_color(name).is_some() => {
-                    spec.fg = Some(ColorSpec::Named(parse_named_color(name).unwrap()));
+
+            if lower == "none" {
+                return Self::None;
+            }
+            if let Some(modifier) = StyleModifiers::parse_token(&lower) {
+                modifiers.insert(modifier);
+                continue;
+            }
+            if let Some(color) = parse_named_color(&lower) {
+                fg = Some(ColorSpec::Named(color));
+                continue;
+            }
+            if let Some(value) = lower.strip_prefix("fg:") {
+                if let Some(color) = parse_color_value(value) {
+                    fg = Some(color);
                 }
-                s if s.starts_with("fg:") => {
-                    if let Some(color) = parse_color_value(&s["fg:".len()..]) {
-                        spec.fg = Some(color);
-                    }
-                }
-                s if s.starts_with("bg:") => {
-                    if let Some(color) = parse_color_value(&s["bg:".len()..]) {
-                        spec.bg = Some(color);
-                    }
-                }
-                _ => {}
+                continue;
+            }
+            if let Some(value) = lower.strip_prefix("bg:")
+                && let Some(color) = parse_color_value(value)
+            {
+                bg = Some(color);
             }
         }
-        spec
+
+        Self::Styled { fg, bg, modifiers }
     }
 
     pub(crate) fn to_ansi_style(&self) -> Style {
-        if self.none {
-            return Style::new();
+        match self {
+            Self::None => Style::new(),
+            Self::Styled { fg, bg, modifiers } => {
+                let mut style = Style::new();
+                if let Some(fg) = fg {
+                    style = style.fg(color_spec_to_nu(fg));
+                }
+                if let Some(bg) = bg {
+                    style = style.on(color_spec_to_nu(bg));
+                }
+                (*modifiers).apply_to(style)
+            }
         }
-        let mut style = Style::new();
-        if let Some(fg) = &self.fg {
-            style = style.fg(color_spec_to_nu(fg));
-        }
-        if let Some(bg) = &self.bg {
-            style = style.on(color_spec_to_nu(bg));
-        }
-        if self.bold {
-            style = style.bold();
-        }
-        if self.italic {
-            style = style.italic();
-        }
-        if self.underline {
-            style = style.underline();
-        }
-        if self.dimmed {
-            style = style.dimmed();
-        }
-        if self.inverted {
-            style = style.reverse();
-        }
-        if self.blink {
-            style = style.blink();
-        }
-        if self.hidden {
-            style = style.hidden();
-        }
-        if self.strikethrough {
-            style = style.strikethrough();
-        }
-        style
-    }
-}
-
-fn parse_named_color(s: &str) -> Option<NamedColor> {
-    match s {
-        "black" => Some(NamedColor::Black),
-        "red" => Some(NamedColor::Red),
-        "green" => Some(NamedColor::Green),
-        "yellow" => Some(NamedColor::Yellow),
-        "blue" => Some(NamedColor::Blue),
-        "purple" => Some(NamedColor::Purple),
-        "cyan" => Some(NamedColor::Cyan),
-        "white" => Some(NamedColor::White),
-        "bright-black" => Some(NamedColor::BrightBlack),
-        "bright-red" => Some(NamedColor::BrightRed),
-        "bright-green" => Some(NamedColor::BrightGreen),
-        "bright-yellow" => Some(NamedColor::BrightYellow),
-        "bright-blue" => Some(NamedColor::BrightBlue),
-        "bright-purple" => Some(NamedColor::BrightPurple),
-        "bright-cyan" => Some(NamedColor::BrightCyan),
-        "bright-white" => Some(NamedColor::BrightWhite),
-        _ => None,
-    }
-}
-
-fn parse_color_value(s: &str) -> Option<ColorSpec> {
-    if let Some(hex) = s.strip_prefix('#').filter(|h| h.len() == 6) {
-        let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
-        let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
-        let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
-        return Some(ColorSpec::Rgb(r, g, b));
-    }
-    if let Ok(n) = s.parse::<u8>() {
-        return Some(ColorSpec::Ansi256(n));
-    }
-    parse_named_color(s).map(ColorSpec::Named)
-}
-
-fn named_color_to_nu(c: &NamedColor) -> Color {
-    match c {
-        NamedColor::Black => Color::Black,
-        NamedColor::Red => Color::Red,
-        NamedColor::Green => Color::Green,
-        NamedColor::Yellow => Color::Yellow,
-        NamedColor::Blue => Color::Blue,
-        NamedColor::Purple => Color::Purple,
-        NamedColor::Cyan => Color::Cyan,
-        NamedColor::White => Color::White,
-        NamedColor::BrightBlack => Color::DarkGray,
-        NamedColor::BrightRed => Color::LightRed,
-        NamedColor::BrightGreen => Color::LightGreen,
-        NamedColor::BrightYellow => Color::LightYellow,
-        NamedColor::BrightBlue => Color::LightBlue,
-        NamedColor::BrightPurple => Color::LightPurple,
-        NamedColor::BrightCyan => Color::LightCyan,
-        NamedColor::BrightWhite => Color::LightGray,
-    }
-}
-
-fn color_spec_to_nu(spec: &ColorSpec) -> Color {
-    match spec {
-        ColorSpec::Named(n) => named_color_to_nu(n),
-        ColorSpec::Ansi256(n) => Color::Fixed(*n),
-        ColorSpec::Rgb(r, g, b) => Color::Rgb(*r, *g, *b),
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use color::{ColorSpec, NamedColor};
+    use modifiers::StyleModifiers;
+    use nu_ansi_term::Color;
     use rstest::rstest;
 
     use super::*;
 
-    // ── fg カラー解析 ────────────────────────────────────────────────────────
+    fn parse_styled(input: &str) -> (Option<ColorSpec>, Option<ColorSpec>, StyleModifiers) {
+        match StyleSpec::parse(input) {
+            StyleSpec::Styled { fg, bg, modifiers } => (fg, bg, modifiers),
+            StyleSpec::None => panic!("expected styled spec"),
+        }
+    }
 
     #[rstest]
     #[case("green", Some(ColorSpec::Named(NamedColor::Green)))]
@@ -196,61 +102,63 @@ mod tests {
     #[case("fg:196", Some(ColorSpec::Ansi256(196)))]
     #[case("fg:#ff8800", Some(ColorSpec::Rgb(0xff, 0x88, 0x00)))]
     fn fg_color_cases(#[case] input: &str, #[case] expected: Option<ColorSpec>) {
-        assert_eq!(StyleSpec::parse(input).fg, expected);
-    }
+        let (fg, _, _) = parse_styled(input);
 
-    // ── bg カラー解析 ────────────────────────────────────────────────────────
+        assert_eq!(fg, expected);
+    }
 
     #[rstest]
     #[case("bg:red", Some(ColorSpec::Named(NamedColor::Red)))]
     #[case("bg:208", Some(ColorSpec::Ansi256(208)))]
     #[case("bg:#001122", Some(ColorSpec::Rgb(0x00, 0x11, 0x22)))]
     fn bg_color_cases(#[case] input: &str, #[case] expected: Option<ColorSpec>) {
-        assert_eq!(StyleSpec::parse(input).bg, expected);
-    }
+        let (_, bg, _) = parse_styled(input);
 
-    // ── 不正・未知指定子が有効な色を上書きしない ─────────────────────────────
+        assert_eq!(bg, expected);
+    }
 
     #[rstest]
     #[case("bold xyzzy green", Some(ColorSpec::Named(NamedColor::Green)))]
     #[case("green fg:typo", Some(ColorSpec::Named(NamedColor::Green)))]
     fn invalid_token_does_not_clear_fg(#[case] input: &str, #[case] expected: Option<ColorSpec>) {
-        assert_eq!(StyleSpec::parse(input).fg, expected);
+        let (fg, _, _) = parse_styled(input);
+
+        assert_eq!(fg, expected);
     }
 
     #[rstest]
     #[case("bg:red bg:typo", Some(ColorSpec::Named(NamedColor::Red)))]
     fn invalid_token_does_not_clear_bg(#[case] input: &str, #[case] expected: Option<ColorSpec>) {
-        assert_eq!(StyleSpec::parse(input).bg, expected);
-    }
+        let (_, bg, _) = parse_styled(input);
 
-    // ── その他 ───────────────────────────────────────────────────────────────
+        assert_eq!(bg, expected);
+    }
 
     #[test]
     fn parse_bold_green() {
-        let s = StyleSpec::parse("bold green");
-        assert!(s.bold);
-        assert_eq!(s.fg, Some(ColorSpec::Named(NamedColor::Green)));
+        let (fg, _, modifiers) = parse_styled("bold green");
+
+        assert!(modifiers.contains(StyleModifiers::BOLD));
+        assert_eq!(fg, Some(ColorSpec::Named(NamedColor::Green)));
     }
 
     #[test]
     fn parse_none() {
-        let s = StyleSpec::parse("none");
-        assert!(s.none);
-        assert!(!s.bold);
-        assert!(s.fg.is_none());
+        assert_eq!(StyleSpec::parse("none"), StyleSpec::None);
     }
 
     #[test]
     fn parse_all_attributes() {
-        let s = StyleSpec::parse("italic underline dimmed inverted blink hidden strikethrough");
-        assert!(s.italic);
-        assert!(s.underline);
-        assert!(s.dimmed);
-        assert!(s.inverted);
-        assert!(s.blink);
-        assert!(s.hidden);
-        assert!(s.strikethrough);
+        let (_, _, modifiers) =
+            parse_styled("italic underline dimmed inverted blink hidden strikethrough");
+
+        assert!(modifiers.contains(StyleModifiers::ITALIC));
+        assert!(modifiers.contains(StyleModifiers::UNDERLINE));
+        assert!(modifiers.contains(StyleModifiers::DIMMED));
+        assert!(modifiers.contains(StyleModifiers::INVERTED));
+        assert!(modifiers.contains(StyleModifiers::BLINK));
+        assert!(modifiers.contains(StyleModifiers::HIDDEN));
+        assert!(modifiers.contains(StyleModifiers::STRIKETHROUGH));
     }
 
     #[test]
@@ -265,6 +173,14 @@ mod tests {
     fn to_ansi_style_none_returns_empty_style() {
         let s = StyleSpec::parse("none");
         let style = s.to_ansi_style();
+        assert_eq!(style, Style::new());
+    }
+
+    #[test]
+    fn to_ansi_style_none_with_other_tokens_returns_empty_style() {
+        let s = StyleSpec::parse("bold green none");
+        let style = s.to_ansi_style();
+
         assert_eq!(style, Style::new());
     }
 }

--- a/src/contexts/evaluation/domain/style_spec/color.rs
+++ b/src/contexts/evaluation/domain/style_spec/color.rs
@@ -1,0 +1,92 @@
+use nu_ansi_term::Color;
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum NamedColor {
+    Black,
+    Red,
+    Green,
+    Yellow,
+    Blue,
+    Purple,
+    Cyan,
+    White,
+    BrightBlack,
+    BrightRed,
+    BrightGreen,
+    BrightYellow,
+    BrightBlue,
+    BrightPurple,
+    BrightCyan,
+    BrightWhite,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ColorSpec {
+    Named(NamedColor),
+    Ansi256(u8),
+    Rgb(u8, u8, u8),
+}
+
+pub(super) fn parse_named_color(s: &str) -> Option<NamedColor> {
+    match s {
+        "black" => Some(NamedColor::Black),
+        "red" => Some(NamedColor::Red),
+        "green" => Some(NamedColor::Green),
+        "yellow" => Some(NamedColor::Yellow),
+        "blue" => Some(NamedColor::Blue),
+        "purple" => Some(NamedColor::Purple),
+        "cyan" => Some(NamedColor::Cyan),
+        "white" => Some(NamedColor::White),
+        "bright-black" => Some(NamedColor::BrightBlack),
+        "bright-red" => Some(NamedColor::BrightRed),
+        "bright-green" => Some(NamedColor::BrightGreen),
+        "bright-yellow" => Some(NamedColor::BrightYellow),
+        "bright-blue" => Some(NamedColor::BrightBlue),
+        "bright-purple" => Some(NamedColor::BrightPurple),
+        "bright-cyan" => Some(NamedColor::BrightCyan),
+        "bright-white" => Some(NamedColor::BrightWhite),
+        _ => None,
+    }
+}
+
+pub(super) fn parse_color_value(s: &str) -> Option<ColorSpec> {
+    if let Some(hex) = s.strip_prefix('#').filter(|h| h.len() == 6) {
+        let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
+        let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
+        let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
+        return Some(ColorSpec::Rgb(r, g, b));
+    }
+    if let Ok(n) = s.parse::<u8>() {
+        return Some(ColorSpec::Ansi256(n));
+    }
+    parse_named_color(s).map(ColorSpec::Named)
+}
+
+pub(super) fn color_spec_to_nu(spec: &ColorSpec) -> Color {
+    match spec {
+        ColorSpec::Named(n) => named_color_to_nu(n),
+        ColorSpec::Ansi256(n) => Color::Fixed(*n),
+        ColorSpec::Rgb(r, g, b) => Color::Rgb(*r, *g, *b),
+    }
+}
+
+fn named_color_to_nu(c: &NamedColor) -> Color {
+    match c {
+        NamedColor::Black => Color::Black,
+        NamedColor::Red => Color::Red,
+        NamedColor::Green => Color::Green,
+        NamedColor::Yellow => Color::Yellow,
+        NamedColor::Blue => Color::Blue,
+        NamedColor::Purple => Color::Purple,
+        NamedColor::Cyan => Color::Cyan,
+        NamedColor::White => Color::White,
+        NamedColor::BrightBlack => Color::DarkGray,
+        NamedColor::BrightRed => Color::LightRed,
+        NamedColor::BrightGreen => Color::LightGreen,
+        NamedColor::BrightYellow => Color::LightYellow,
+        NamedColor::BrightBlue => Color::LightBlue,
+        NamedColor::BrightPurple => Color::LightPurple,
+        NamedColor::BrightCyan => Color::LightCyan,
+        NamedColor::BrightWhite => Color::LightGray,
+    }
+}

--- a/src/contexts/evaluation/domain/style_spec/modifiers.rs
+++ b/src/contexts/evaluation/domain/style_spec/modifiers.rs
@@ -1,0 +1,60 @@
+use bitflags::bitflags;
+use nu_ansi_term::Style;
+
+bitflags! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+    pub(crate) struct StyleModifiers: u16 {
+        const BOLD = 1 << 0;
+        const ITALIC = 1 << 1;
+        const UNDERLINE = 1 << 2;
+        const DIMMED = 1 << 3;
+        const INVERTED = 1 << 4;
+        const BLINK = 1 << 5;
+        const HIDDEN = 1 << 6;
+        const STRIKETHROUGH = 1 << 7;
+    }
+}
+
+impl StyleModifiers {
+    pub(super) fn parse_token(token: &str) -> Option<Self> {
+        match token {
+            "bold" => Some(Self::BOLD),
+            "italic" => Some(Self::ITALIC),
+            "underline" => Some(Self::UNDERLINE),
+            "dimmed" => Some(Self::DIMMED),
+            "inverted" => Some(Self::INVERTED),
+            "blink" => Some(Self::BLINK),
+            "hidden" => Some(Self::HIDDEN),
+            "strikethrough" => Some(Self::STRIKETHROUGH),
+            _ => None,
+        }
+    }
+
+    pub(super) fn apply_to(self, mut style: Style) -> Style {
+        if self.contains(Self::BOLD) {
+            style = style.bold();
+        }
+        if self.contains(Self::ITALIC) {
+            style = style.italic();
+        }
+        if self.contains(Self::UNDERLINE) {
+            style = style.underline();
+        }
+        if self.contains(Self::DIMMED) {
+            style = style.dimmed();
+        }
+        if self.contains(Self::INVERTED) {
+            style = style.reverse();
+        }
+        if self.contains(Self::BLINK) {
+            style = style.blink();
+        }
+        if self.contains(Self::HIDDEN) {
+            style = style.hidden();
+        }
+        if self.contains(Self::STRIKETHROUGH) {
+            style = style.strikethrough();
+        }
+        style
+    }
+}


### PR DESCRIPTION
## 概要

- `StyleSpec` を `None` / `Styled` の enum に変更し、`none` をスタイル全体の無効化状態として型で表現しました。
- `bold` / `italic` などの個別 bool フィールドを削除し、`bitflags` ベースの `StyleModifiers` に置き換えました。
- `style_spec.rs` が肥大化しないよう、色処理と修飾子処理を `style_spec/color.rs` と `style_spec/modifiers.rs` に分割しました。

Closes #271

## テスト

- `cargo fmt --check --all`
- `cargo test --lib`
- `cargo test --test e2e`
- `cargo test --workspace`
- `cargo clippy --workspace -- -D warnings`


Made with [Cursor](https://cursor.com)