### PR TITLE
feat: watch のエントリ一覧を CWD → BRANCH → PR 昇順でソートする

### DIFF
--- a/src/contexts/daemon/interface/cli/watch.rs
+++ b/src/contexts/daemon/interface/cli/watch.rs
@@ -264,7 +264,10 @@ mod tests {
         ];
         let table = format_table(&rows);
         let lines: Vec<&str> = table.lines().skip(1).collect();
-        assert!(lines[0].contains("/a/repo") && lines[0].contains("feat/1"), "1行目: /a/repo feat/1");
+        assert!(
+            lines[0].contains("/a/repo") && lines[0].contains("feat/1"),
+            "1行目: /a/repo feat/1"
+        );
         assert!(
             lines[1].contains("/a/repo") && lines[1].contains("feat/2") && lines[1].contains("#1"),
             "2行目: /a/repo feat/2 #1"

--- a/src/contexts/daemon/interface/cli/watch.rs
+++ b/src/contexts/daemon/interface/cli/watch.rs
@@ -49,6 +49,14 @@ fn format_table(entries: &[EntryView]) -> String {
         return "no entries cached\n".to_owned();
     }
 
+    let mut sorted: Vec<&EntryView> = entries.iter().collect();
+    sorted.sort_by(|a, b| {
+        a.cwd
+            .cmp(&b.cwd)
+            .then_with(|| a.branch.cmp(&b.branch))
+            .then_with(|| a.pr_id.cmp(&b.pr_id))
+    });
+
     let header = TableRow {
         cwd: "CWD".to_owned(),
         branch: "BRANCH".to_owned(),
@@ -56,7 +64,7 @@ fn format_table(entries: &[EntryView]) -> String {
         status: "STATUS".to_owned(),
         cached_at: "CACHED AT".to_owned(),
     };
-    let rows: Vec<TableRow> = entries.iter().map(TableRow::from_entry).collect();
+    let rows: Vec<TableRow> = sorted.iter().map(|e| TableRow::from_entry(e)).collect();
     let widths = TableWidths::from_rows(&header, &rows);
 
     let mut out = String::new();
@@ -239,6 +247,28 @@ mod tests {
         assert!(table.contains("PR"));
         assert!(!table.contains('#'));
         assert!(table.contains("+ Create PR"));
+    }
+
+    #[test]
+    fn format_table_entries_sorted_by_cwd_then_branch_then_pr() {
+        let rows = vec![
+            make_view("/z/repo", "main", None, "✓ Ready", 5),
+            make_view("/a/repo", "feat/2", Some(2), "✓ Ready", 5),
+            make_view("/a/repo", "feat/1", Some(1), "✓ Ready", 5),
+            make_view("/a/repo", "feat/2", Some(1), "✓ Ready", 5),
+        ];
+        let table = format_table(&rows);
+        let lines: Vec<&str> = table.lines().skip(1).collect();
+        assert!(lines[0].contains("/a/repo") && lines[0].contains("feat/1"), "1行目: /a/repo feat/1");
+        assert!(
+            lines[1].contains("/a/repo") && lines[1].contains("feat/2") && lines[1].contains("#1"),
+            "2行目: /a/repo feat/2 #1"
+        );
+        assert!(
+            lines[2].contains("/a/repo") && lines[2].contains("feat/2") && lines[2].contains("#2"),
+            "3行目: /a/repo feat/2 #2"
+        );
+        assert!(lines[3].contains("/z/repo"), "4行目: /z/repo");
     }
 
     #[test]

--- a/src/contexts/daemon/interface/cli/watch.rs
+++ b/src/contexts/daemon/interface/cli/watch.rs
@@ -171,18 +171,23 @@ fn format_cached_at(cached_at_secs: u64) -> String {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs();
-    let elapsed = now.saturating_sub(cached_at_secs);
-    if elapsed < 60 {
-        format!("{elapsed}s ago")
-    } else if elapsed < 3600 {
-        format!("{}m ago", elapsed / 60)
+    format_elapsed(now.saturating_sub(cached_at_secs))
+}
+
+fn format_elapsed(elapsed_secs: u64) -> String {
+    if elapsed_secs < 60 {
+        format!("{elapsed_secs}s ago")
+    } else if elapsed_secs < 3600 {
+        format!("{}m ago", elapsed_secs / 60)
     } else {
-        format!("{}h ago", elapsed / 3600)
+        format!("{}h ago", elapsed_secs / 3600)
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use super::*;
 
     fn make_view(
@@ -298,33 +303,14 @@ mod tests {
         assert!(table.contains("✎ Ready for review #201"));
     }
 
-    #[test]
-    fn format_cached_at_seconds() {
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
-        let s = format_cached_at(now.saturating_sub(5));
-        assert!(s.ends_with("s ago"));
-    }
-
-    #[test]
-    fn format_cached_at_minutes() {
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
-        let s = format_cached_at(now.saturating_sub(90));
-        assert!(s.ends_with("m ago"));
-    }
-
-    #[test]
-    fn format_cached_at_hours() {
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
-        let s = format_cached_at(now.saturating_sub(7200));
-        assert!(s.ends_with("h ago"));
+    #[rstest]
+    #[case(5, "5s ago")]
+    #[case(59, "59s ago")]
+    #[case(60, "1m ago")]
+    #[case(90, "1m ago")]
+    #[case(3600, "1h ago")]
+    #[case(7200, "2h ago")]
+    fn format_elapsed_various_durations(#[case] elapsed_secs: u64, #[case] expected: &str) {
+        assert_eq!(format_elapsed(elapsed_secs), expected);
     }
 }

--- a/tests/e2e/daemon/watch.rs
+++ b/tests/e2e/daemon/watch.rs
@@ -1,4 +1,4 @@
-//! `merge-ready watch` コマンドの E2E テスト（シナリオ #W1–#W3）
+//! `merge-ready watch` コマンドの E2E テスト（シナリオ #W1–#W7）
 
 use std::io::{BufRead, BufReader};
 use std::process::Stdio;
@@ -8,7 +8,7 @@ use std::time::Duration;
 use assert_cmd::Command;
 use predicates::prelude::*;
 
-use super::super::helpers::{DaemonHandle, TestEnv};
+use super::super::helpers::{DaemonHandle, MultiRepoEnv, TestEnv};
 
 const BIN: &str = "merge-ready";
 const OPEN_PR_VIEW_JSON: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}"#;
@@ -138,6 +138,82 @@ fn test_watch_leaves_pr_column_empty_without_pr() {
         "unexpected output: {output:?}"
     );
     assert!(!output.contains('#'), "unexpected output: {output:?}");
+}
+
+// ── #W7: 複数リポジトリのソート順 ────────────────────────────────────────────
+
+fn spawn_watch_and_read_multi(env: &MultiRepoEnv, n: usize, timeout: Duration) -> String {
+    let bin = assert_cmd::cargo::cargo_bin(BIN);
+    let mut child = std::process::Command::new(bin)
+        .args(["watch"])
+        .env("PATH", env.path_env())
+        .env("HOME", env.home())
+        .env("TMPDIR", env.home())
+        .env("XDG_CONFIG_HOME", env.home().join(".config"))
+        .current_dir(env.repo_a.path())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn merge-ready watch");
+
+    let stdout = child.stdout.take().expect("stdout not captured");
+    let (tx, rx) = mpsc::channel::<String>();
+    std::thread::spawn(move || {
+        let reader = BufReader::new(stdout);
+        let mut out = String::new();
+        for line in reader.lines().take(n) {
+            match line {
+                Ok(l) => {
+                    out.push_str(&l);
+                    out.push('\n');
+                }
+                Err(_) => break,
+            }
+        }
+        let _ = tx.send(out);
+    });
+
+    let output = rx.recv_timeout(timeout).unwrap_or_default();
+
+    let _ = std::process::Command::new("kill")
+        .args(["-INT", &child.id().to_string()])
+        .status();
+    let _ = child.wait();
+
+    output
+}
+
+/// #W7: 複数リポジトリがある場合、watch は CWD 昇順でソートして表示する
+#[test]
+fn test_watch_entries_sorted_by_cwd() {
+    let env = MultiRepoEnv::new(OPEN_PR_VIEW_JSON, OPEN_PR_VIEW_JSON);
+    let _daemon = env.start_daemon();
+    env.wait_for_cache_in(&env.repo_a, 5000);
+    env.wait_for_cache_in(&env.repo_b, 5000);
+
+    let output = spawn_watch_and_read_multi(&env, 3, Duration::from_secs(5));
+
+    let cwd_a = env.repo_a.path().to_string_lossy().into_owned();
+    let cwd_b = env.repo_b.path().to_string_lossy().into_owned();
+
+    let data_lines: Vec<&str> = output.lines().skip(1).collect();
+    let pos_a = data_lines.iter().position(|l| l.contains(&cwd_a));
+    let pos_b = data_lines.iter().position(|l| l.contains(&cwd_b));
+
+    assert!(pos_a.is_some(), "repo_a が出力に含まれない: {output:?}");
+    assert!(pos_b.is_some(), "repo_b が出力に含まれない: {output:?}");
+
+    if cwd_a < cwd_b {
+        assert!(
+            pos_a.unwrap() < pos_b.unwrap(),
+            "repo_a が repo_b より前に表示されるべき: {output:?}"
+        );
+    } else {
+        assert!(
+            pos_b.unwrap() < pos_a.unwrap(),
+            "repo_b が repo_a より前に表示されるべき: {output:?}"
+        );
+    }
 }
 
 /// #W6: 複数 PR がある場合、watch は 1 PR 1 行に展開して表示する


### PR DESCRIPTION
## Summary

- `watch` コマンドのエントリ一覧を CWD → BRANCH → PR番号の昇順でソートして表示する（従来は `HashMap` 由来の非決定的な順序）
- `format_elapsed` を `format_cached_at` から切り出して純粋関数化し、`SystemTime` 依存をテストから除去
- 経過時間テストを rstest `#[case]` でパターン化し、境界値（59秒/60秒/3600秒）を直接検証できるようにする
- ソート順を検証する e2e テスト #W7 を追加（`MultiRepoEnv` で2リポジトリの CWD 昇順表示を確認）

## Test plan

- [ ] `cargo test --workspace` が全通過することを確認
- [ ] `cargo clippy --workspace -- -D warnings` がクリーンであることを確認
- [ ] `cargo fmt --check --all` がクリーンであることを確認
- [ ] `watch` コマンドを実際に起動してエントリが CWD → BRANCH → PR 順で表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)