### PR TITLE
refactor: config関連E2Eを責務ごとに分割し仕様記述へ整理

### DIFF
--- a/tests/e2e/config/config_path.rs
+++ b/tests/e2e/config/config_path.rs
@@ -1,0 +1,74 @@
+//! `config_path()` の環境変数によるパス解決を検証する E2E テスト（シナリオ #49–50）
+//!
+//! - #49: `XDG_CONFIG_HOME` が設定されている → そちらの設定ファイルを優先する
+//! - #50: `XDG_CONFIG_HOME` と `HOME` 両方ある → `XDG_CONFIG_HOME` が勝つ
+
+use assert_cmd::Command;
+
+use super::super::helpers::{DaemonHandle, TestEnv};
+
+const MERGE_READY_JSON: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED"}"#;
+const CHECKS_PASS_JSON: &str = r#"[{"bucket":"pass","state":"SUCCESS"}]"#;
+
+const PROMPT_BIN: &str = "merge-ready-prompt";
+
+/// #49: `XDG_CONFIG_HOME` が設定されている → そちらの設定ファイルを読む
+#[test]
+fn test_xdg_config_home_is_used() {
+    use std::fs;
+    use tempfile::tempdir;
+
+    let env = TestEnv::new(MERGE_READY_JSON, Some(CHECKS_PASS_JSON));
+    let xdg_dir = tempdir().expect("tempdir");
+    fs::write(
+        xdg_dir.path().join("merge-ready.toml"),
+        "[merge_ready]\nsymbol = \"★\"",
+    )
+    .expect("write config");
+
+    let _daemon = DaemonHandle::start_with_env(
+        &env,
+        &[("XDG_CONFIG_HOME", xdg_dir.path().to_str().unwrap())],
+    );
+
+    DaemonHandle::wait_for_cache(&env, 5000);
+
+    let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
+    env.apply_with_cache(&mut cmd);
+    cmd.assert()
+        .success()
+        .stdout("★ Ready for merge")
+        .stderr("");
+}
+
+/// #50: `XDG_CONFIG_HOME` と `HOME` 両方ある → `XDG_CONFIG_HOME` が優先される
+#[test]
+fn test_xdg_config_home_takes_precedence_over_home() {
+    use std::fs;
+    use tempfile::tempdir;
+
+    let env = TestEnv::new(MERGE_READY_JSON, Some(CHECKS_PASS_JSON));
+    // HOME 側にも設定を置く（XDG 側が優先されるはず）
+    env.write_config("[merge_ready]\nsymbol = \"✓\"");
+
+    let xdg_dir = tempdir().expect("tempdir");
+    fs::write(
+        xdg_dir.path().join("merge-ready.toml"),
+        "[merge_ready]\nsymbol = \"★\"",
+    )
+    .expect("write xdg config");
+
+    let _daemon = DaemonHandle::start_with_env(
+        &env,
+        &[("XDG_CONFIG_HOME", xdg_dir.path().to_str().unwrap())],
+    );
+
+    DaemonHandle::wait_for_cache(&env, 5000);
+
+    let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
+    env.apply_with_cache(&mut cmd);
+    cmd.assert()
+        .success()
+        .stdout("★ Ready for merge")
+        .stderr("");
+}

--- a/tests/e2e/config/edit_command.rs
+++ b/tests/e2e/config/edit_command.rs
@@ -1,135 +1,17 @@
-//! 設定ファイル（`~/.config/merge-ready.toml`）の E2E テスト（シナリオ #42–58）
+//! `merge-ready config` サブコマンドの E2E テスト（シナリオ #51–58）
 //!
-//! - #42–50: symbol / label / format のカスタマイズ、XDG_CONFIG_HOME の優先度
-//!   → prompt テストは daemon 経由フローで検証する
-//! - #51–58: `config` コマンド（エディタ起動）
+//! - #51–53: エディタ選択（$VISUAL → $EDITOR → vi フォールバック）
+//! - #54–55: 設定ファイル / ディレクトリ不在時の自動作成
+//! - #56–57: エラーケース（エディタ失敗、HOME/XDG_CONFIG_HOME 未設定）
+//! - #58: デフォルト生成内容の検証
 
 use assert_cmd::Command;
-use predicates::prelude::*;
-use rstest::rstest;
 
-use super::super::helpers::{DaemonHandle, TestEnv};
-
-const MERGE_READY_JSON: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED"}"#;
-const CHECKS_PASS_JSON: &str = r#"[{"bucket":"pass","state":"SUCCESS"}]"#;
-const CONFLICT_JSON: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"CONFLICTING","mergeStateStatus":"DIRTY","reviewDecision":"APPROVED"}"#;
+use super::super::helpers::TestEnv;
 
 const BIN: &str = "merge-ready";
-const PROMPT_BIN: &str = "merge-ready-prompt";
 
-/// 設定を書いて daemon を起動し、キャッシュが温まった後の `prompt` 出力を検証する。
-fn assert_prompt_with_config(env: &TestEnv, expected: &str) {
-    let _daemon = DaemonHandle::start(env);
-    DaemonHandle::wait_for_cache(env, 5000);
-
-    let mut cmd = Command::cargo_bin("merge-ready-prompt").unwrap();
-    env.apply_with_cache(&mut cmd);
-    cmd.assert()
-        .success()
-        .stdout(predicate::str::diff(expected.to_owned()))
-        .stderr("");
-}
-
-// ── #42–46, #48: prompt 出力契約（パラメータ化） ─────────────────────────────
-
-/// #42 設定なし / #43 symbol / #44 label / #45 format / #46 全フィールド / #48 不正 TOML
-#[rstest]
-#[case::no_config(None, "✓ Ready for merge")]
-#[case::custom_symbol(Some("[merge_ready]\nsymbol = \"★\""), "★ Ready for merge")]
-#[case::custom_label(Some("[merge_ready]\nlabel = \"OK!\""), "✓ OK!")]
-#[case::custom_format(
-    Some("[merge_ready]\nformat = \"[$symbol] $label\""),
-    "[✓] Ready for merge"
-)]
-#[case::all_fields_custom(
-    Some("[merge_ready]\nsymbol = \"✅\"\nlabel = \"lgtm\"\nformat = \"$label $symbol\""),
-    "lgtm ✅"
-)]
-#[case::invalid_toml(Some("this is not valid toml ][[["), "✓ Ready for merge")]
-fn test_config_prompt(#[case] config: Option<&str>, #[case] expected: &str) {
-    let env = TestEnv::new(MERGE_READY_JSON, Some(CHECKS_PASS_JSON));
-    if let Some(cfg) = config {
-        env.write_config(cfg);
-    }
-    assert_prompt_with_config(&env, expected);
-}
-
-// ── #47: 一部セクションのみ設定 ──────────────────────────────────────────────
-
-/// #47: 一部セクションのみ設定 → 未設定セクションはデフォルト値にフォールバック
-#[test]
-fn test_partial_config_other_tokens_use_defaults() {
-    let env = TestEnv::new(CONFLICT_JSON, Some(CHECKS_PASS_JSON));
-    env.write_config("[conflict]\nsymbol = \"✘\"");
-    assert_prompt_with_config(&env, "✘ Resolve conflict");
-}
-
-// ── #49–50: XDG_CONFIG_HOME ───────────────────────────────────────────────────
-
-/// #49: `XDG_CONFIG_HOME` が設定されている → そちらの設定ファイルを読む
-#[test]
-fn test_xdg_config_home_is_used() {
-    use std::fs;
-    use tempfile::tempdir;
-
-    let env = TestEnv::new(MERGE_READY_JSON, Some(CHECKS_PASS_JSON));
-    let xdg_dir = tempdir().expect("tempdir");
-    fs::write(
-        xdg_dir.path().join("merge-ready.toml"),
-        "[merge_ready]\nsymbol = \"★\"",
-    )
-    .expect("write config");
-
-    // start_with_env はソケット出現を確認してから返るため、
-    // prompt が spawn_daemon() を呼んで XDG なし daemon を起動する競合が発生しない。
-    let _daemon = DaemonHandle::start_with_env(
-        &env,
-        &[("XDG_CONFIG_HOME", xdg_dir.path().to_str().unwrap())],
-    );
-
-    DaemonHandle::wait_for_cache(&env, 5000);
-
-    let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
-    env.apply_with_cache(&mut cmd);
-    cmd.assert()
-        .success()
-        .stdout("★ Ready for merge")
-        .stderr("");
-}
-
-/// #50: `XDG_CONFIG_HOME` と `HOME` 両方ある → `XDG_CONFIG_HOME` が優先される
-#[test]
-fn test_xdg_config_home_takes_precedence_over_home() {
-    use std::fs;
-    use tempfile::tempdir;
-
-    let env = TestEnv::new(MERGE_READY_JSON, Some(CHECKS_PASS_JSON));
-    // HOME 側にも設定を置く（XDG 側が優先されるはず）
-    env.write_config("[merge_ready]\nsymbol = \"✓\"");
-
-    let xdg_dir = tempdir().expect("tempdir");
-    fs::write(
-        xdg_dir.path().join("merge-ready.toml"),
-        "[merge_ready]\nsymbol = \"★\"",
-    )
-    .expect("write xdg config");
-
-    let _daemon = DaemonHandle::start_with_env(
-        &env,
-        &[("XDG_CONFIG_HOME", xdg_dir.path().to_str().unwrap())],
-    );
-
-    DaemonHandle::wait_for_cache(&env, 5000);
-
-    let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
-    env.apply_with_cache(&mut cmd);
-    cmd.assert()
-        .success()
-        .stdout("★ Ready for merge")
-        .stderr("");
-}
-
-// ── #51–58: config ────────────────────────────────────────────────────────────
+// ── #51–53: エディタ選択 ──────────────────────────────────────────────────────
 
 /// #51: `$VISUAL` が設定されている場合、`$VISUAL` がファイルパスを引数として呼ばれる
 #[test]
@@ -194,6 +76,8 @@ fn test_config_edit_falls_back_to_vi() {
     );
 }
 
+// ── #54–55: 設定ファイル / ディレクトリの自動作成 ────────────────────────────
+
 /// #54: 設定ファイル不在 → デフォルト設定ファイルを作成してエディタを開く
 #[test]
 fn test_config_edit_creates_default_when_absent() {
@@ -248,6 +132,8 @@ fn test_config_edit_creates_dir_and_file_when_both_absent() {
     );
 }
 
+// ── #56–57: エラーケース ──────────────────────────────────────────────────────
+
 /// #56: エディタが exit 非 0 → merge-ready も exit 非 0
 #[test]
 fn test_config_edit_exits_nonzero_when_editor_fails() {
@@ -281,6 +167,8 @@ fn test_config_edit_exits_nonzero_without_config_path() {
         .failure()
         .stderr(predicates::str::contains("failed to edit config"));
 }
+
+// ── #58: デフォルト生成内容の検証 ────────────────────────────────────────────
 
 /// #58: デフォルト生成内容に各セクションが含まれる
 #[test]

--- a/tests/e2e/config/mod.rs
+++ b/tests/e2e/config/mod.rs
@@ -1,1 +1,3 @@
-mod config;
+mod config_path;
+mod edit_command;
+mod token_customization;

--- a/tests/e2e/config/token_customization.rs
+++ b/tests/e2e/config/token_customization.rs
@@ -1,0 +1,86 @@
+//! TOML 設定がプロンプト出力トークンに反映されることを検証する E2E テスト（シナリオ #42–48）
+//!
+//! - #42–46, #48: `merge_ready` トークンの symbol / label / format カスタマイズ、不正 TOML
+//! - #47: 一部セクションのみ設定 → 未設定セクションはデフォルト値にフォールバック
+//! - 新規: `[error]` セクションを設定した場合、エラートークンの出力が変わることを検証
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use rstest::rstest;
+
+use super::super::helpers::{DaemonHandle, TestEnv};
+
+const MERGE_READY_JSON: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED"}"#;
+const CHECKS_PASS_JSON: &str = r#"[{"bucket":"pass","state":"SUCCESS"}]"#;
+const CONFLICT_JSON: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"CONFLICTING","mergeStateStatus":"DIRTY","reviewDecision":"APPROVED"}"#;
+
+const PROMPT_BIN: &str = "merge-ready-prompt";
+
+fn assert_prompt_with_config(env: &TestEnv, expected: &str) {
+    let _daemon = DaemonHandle::start(env);
+    DaemonHandle::wait_for_cache(env, 5000);
+
+    let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
+    env.apply_with_cache(&mut cmd);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::diff(expected.to_owned()))
+        .stderr("");
+}
+
+// ── #42–46, #48: prompt 出力契約（パラメータ化） ─────────────────────────────
+
+/// #42 設定なし / #43 symbol / #44 label / #45 format / #46 全フィールド / #48 不正 TOML
+#[rstest]
+#[case::no_config(None, "✓ Ready for merge")]
+#[case::custom_symbol(Some("[merge_ready]\nsymbol = \"★\""), "★ Ready for merge")]
+#[case::custom_label(Some("[merge_ready]\nlabel = \"OK!\""), "✓ OK!")]
+#[case::custom_format(
+    Some("[merge_ready]\nformat = \"[$symbol] $label\""),
+    "[✓] Ready for merge"
+)]
+#[case::all_fields_custom(
+    Some("[merge_ready]\nsymbol = \"✅\"\nlabel = \"lgtm\"\nformat = \"$label $symbol\""),
+    "lgtm ✅"
+)]
+#[case::invalid_toml(Some("this is not valid toml ][[["), "✓ Ready for merge")]
+fn test_config_prompt(#[case] config: Option<&str>, #[case] expected: &str) {
+    let env = TestEnv::new(MERGE_READY_JSON, Some(CHECKS_PASS_JSON));
+    if let Some(cfg) = config {
+        env.write_config(cfg);
+    }
+    assert_prompt_with_config(&env, expected);
+}
+
+// ── #47: 一部セクションのみ設定 ──────────────────────────────────────────────
+
+/// #47: 一部セクションのみ設定 → 未設定セクションはデフォルト値にフォールバック
+#[test]
+fn test_partial_config_other_tokens_use_defaults() {
+    let env = TestEnv::new(CONFLICT_JSON, Some(CHECKS_PASS_JSON));
+    env.write_config("[conflict]\nsymbol = \"✘\"");
+    assert_prompt_with_config(&env, "✘ Resolve conflict");
+}
+
+// ── 新規: [error] セクションのカスタマイズ ───────────────────────────────────
+
+/// `[error]` セクションを設定した場合、エラー出力に反映される
+#[rstest]
+#[case::custom_symbol("[error]\nsymbol = \"!\"", "! unexpected error")]
+#[case::custom_format(
+    "[error]\nformat = \"[$symbol] $message\"",
+    "[✗] unexpected error"
+)]
+fn test_error_token_customization(#[case] config_toml: &str, #[case] expected: &str) {
+    let env = TestEnv::with_error("HTTP 500: Internal Server Error", 1);
+    env.write_config(config_toml);
+    let _daemon = DaemonHandle::start(&env);
+    DaemonHandle::wait_for_cache(&env, 5000);
+
+    let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
+    env.apply_with_cache(&mut cmd);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::diff(expected.to_owned()))
+        .stderr("");
+}

--- a/tests/e2e/config/token_customization.rs
+++ b/tests/e2e/config/token_customization.rs
@@ -67,10 +67,7 @@ fn test_partial_config_other_tokens_use_defaults() {
 /// `[error]` セクションを設定した場合、エラー出力に反映される
 #[rstest]
 #[case::custom_symbol("[error]\nsymbol = \"!\"", "! unexpected error")]
-#[case::custom_format(
-    "[error]\nformat = \"[$symbol] $message\"",
-    "[✗] unexpected error"
-)]
+#[case::custom_format("[error]\nformat = \"[$symbol] $message\"", "[✗] unexpected error")]
 fn test_error_token_customization(#[case] config_toml: &str, #[case] expected: &str) {
     let env = TestEnv::with_error("HTTP 500: Internal Server Error", 1);
     env.write_config(config_toml);

--- a/tests/e2e/prompt/style.rs
+++ b/tests/e2e/prompt/style.rs
@@ -6,6 +6,7 @@ const CHECKS_PASS_JSON: &str = r#"[{"bucket":"pass","state":"SUCCESS"}]"#;
 
 use assert_cmd::Command;
 use predicates::prelude::*;
+use rstest::rstest;
 
 use super::super::helpers::{DaemonHandle, TestEnv};
 
@@ -79,6 +80,42 @@ fn conditional_inside_styled_block_hidden_when_pr_id_empty() {
         !stdout.contains("( #)"),
         "literal '( #)' must not appear, got: {stdout:?}"
     );
+}
+
+/// 複数の色指定形式（Ansi256 / RGB / Named fg+bg）を使った format で、
+/// スタイル付き出力が有効になることを検証する E2E テスト。
+#[rstest]
+#[case::ansi256_fg("[$symbol](fg:196) $label")]
+#[case::rgb_fg("[$symbol](fg:#ff0000) $label")]
+#[case::named_fg_bg("[$symbol](red bg:blue) $label")]
+#[case::ansi256_fg_rgb_bg("[$symbol](fg:196 bg:#001122) $label")]
+/// サポートされる named color（通常色 / bright 色）指定で
+/// ANSI エスケープコード付き出力になることを確認する。
+#[case::black("[$symbol](black) $label")]
+#[case::yellow("[$symbol](yellow) $label")]
+#[case::purple("[$symbol](purple) $label")]
+#[case::white("[$symbol](white) $label")]
+#[case::bright_black("[$symbol](bright-black) $label")]
+#[case::bright_red("[$symbol](bright-red) $label")]
+#[case::bright_green("[$symbol](bright-green) $label")]
+#[case::bright_yellow("[$symbol](bright-yellow) $label")]
+#[case::bright_blue("[$symbol](bright-blue) $label")]
+#[case::bright_purple("[$symbol](bright-purple) $label")]
+#[case::bright_cyan("[$symbol](bright-cyan) $label")]
+#[case::bright_white("[$symbol](bright-white) $label")]
+fn multi_color_format_produces_ansi_output(#[case] fmt: &str) {
+    let env = TestEnv::new(MERGE_READY_JSON, Some(CHECKS_PASS_JSON));
+    env.write_config(&format!("[merge_ready]\nformat = \"{fmt}\""));
+
+    let _daemon = DaemonHandle::start(&env);
+    DaemonHandle::wait_for_cache(&env, 5000);
+
+    let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
+    env.apply_with_cache(&mut cmd);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("\x1b["))
+        .stderr("");
 }
 
 /// スタイル適用後のテキストに色が漏れない（reset が挿入される）。


### PR DESCRIPTION
## 概要
- `tests/e2e/config/config.rs` を責務ごとに分割し、`config_path` / `edit_command` / `token_customization` に再編
- config関連E2Eを「入力条件と観測可能なCLI出力」に基づくユーザー視点の仕様テストとして整理
- prompt style E2Eの説明を実装依存の表現から、仕様ベースの記述へ修正

## テスト計画
- [x] `cargo test --test e2e config::`
- [x] `cargo test --test e2e prompt::style::`