### PR TITLE
chore: add mise task for local rust hook setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,18 @@ Key principles:
 
 ```bash
 mise install   # installs Rust toolchain declared in mise.toml
+mise run setup-hooks  # sets local git hooks (pre-commit: fmt, pre-push: clippy)
+```
+
+This repository uses local Git hooks configured via `mise` task:
+
+- `pre-commit`: `cargo fmt --all -- --check`
+- `pre-push`: `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+
+Re-run after cloning the repository:
+
+```bash
+mise run setup-hooks
 ```
 
 ## Build & Test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ mise run setup-hooks  # sets local git hooks (pre-commit: fmt, pre-push: clippy)
 This repository uses local Git hooks configured via `mise` task:
 
 - `pre-commit`: `cargo fmt --all -- --check`
-- `pre-push`: `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `pre-push`: `cargo clippy --workspace -- -D warnings`
 
 Re-run after cloning the repository:
 

--- a/mise.toml
+++ b/mise.toml
@@ -18,3 +18,7 @@ gh workflow run release-prepare.yml --repo toshiki670/merge-ready
 echo "Workflow をトリガーしました。"
 echo "進捗: https://github.com/toshiki670/merge-ready/actions/workflows/release-prepare.yml"
 """
+
+[tasks.setup-hooks]
+description = "Set up local git hooks for rust fmt/clippy"
+run = "bash scripts/setup-hooks.sh"

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+git config --local hook.rust-fmt.event pre-commit
+git config --local hook.rust-fmt.command "cargo fmt --all -- --check"
+
+git config --local hook.rust-clippy.event pre-push
+git config --local hook.rust-clippy.command "cargo clippy --workspace --all-targets --all-features -- -D warnings"
+
+echo "Configured local hooks:"
+git config --local --get-regexp '^hook\.'

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -2,10 +2,10 @@
 set -euo pipefail
 
 git config --local hook.rust-fmt.event pre-commit
-git config --local hook.rust-fmt.command "cargo fmt --all -- --check"
+git config --local hook.rust-fmt.command "sh -c 'cargo fmt --all -- --check'"
 
 git config --local hook.rust-clippy.event pre-push
-git config --local hook.rust-clippy.command "cargo clippy --workspace --all-targets --all-features -- -D warnings"
+git config --local hook.rust-clippy.command "sh -c 'cargo clippy --workspace --all-targets --all-features -- -D warnings'"
 
 echo "Configured local hooks:"
 git config --local --get-regexp '^hook\.'

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -5,7 +5,7 @@ git config --local hook.rust-fmt.event pre-commit
 git config --local hook.rust-fmt.command "sh -c 'cargo fmt --all -- --check'"
 
 git config --local hook.rust-clippy.event pre-push
-git config --local hook.rust-clippy.command "sh -c 'cargo clippy --workspace --all-targets --all-features -- -D warnings'"
+git config --local hook.rust-clippy.command "sh -c 'cargo clippy --workspace -- -D warnings'"
 
 echo "Configured local hooks:"
 git config --local --get-regexp '^hook\.'


### PR DESCRIPTION
## Summary
- add `scripts/setup-hooks.sh` to configure local config-based hooks for Rust formatting and lint checks
- register `setup-hooks` task in `mise.toml` so hook setup is reproducible after cloning
- document the hook setup workflow in `CONTRIBUTING.md`
- wrap hook commands with `sh -c` and align pre-push clippy scope with current CI (`--workspace -- -D warnings`)

## Test plan
- [x] Run `mise run setup-hooks`
- [x] Confirm local hook config via `git config --local --get-regexp '^hook\.'`
- [x] Push branch and verify pre-push hook passes

Made with [Cursor](https://cursor.com)