### PR TITLE
ci: block clippy allow attributes in Rust files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,14 @@ jobs:
       - name: Check no mod.rs files
         run: bash scripts/check-no-mod-rs.sh
 
+  no-clippy-allow:
+    name: no-clippy-allow
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Check no clippy allow attributes
+        run: bash scripts/check-no-clippy-allow.sh
+
   deny:
     name: deny
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,7 @@ mise run setup-hooks  # sets local git hooks (pre-commit: fmt, pre-push: clippy)
 This repository uses local Git hooks configured via `mise` task:
 
 - `pre-commit`: `cargo fmt --all -- --check`
+- `pre-commit`: `bash scripts/check-no-clippy-allow.sh` (forbid `#[allow(clippy::...)]` in Rust files)
 - `pre-push`: `cargo clippy --workspace --all-targets --all-features -- -D warnings`
 
 Re-run after cloning the repository:
@@ -52,6 +53,7 @@ cargo fmt --check --all              # formatting check
 cargo deny check                     # dependency audit
 bash scripts/check-layer-deps.sh     # DDD layer dependency rules
 bash scripts/check-no-mod-rs.sh      # forbid mod.rs (use Rust 2018+ style)
+bash scripts/check-no-clippy-allow.sh # forbid #[allow(clippy::...)] in Rust files
 bash scripts/check-pr-title.sh       # require Conventional Commit PR titles (set PR_TITLE)
 bash scripts/check-e2e.sh           # feat/fix PRs must include changes under tests/e2e/ (set PR_TITLE and BASE_REF)
 ```

--- a/scripts/check-no-clippy-allow.sh
+++ b/scripts/check-no-clippy-allow.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Forbid masking Clippy warnings via #[allow(clippy::...)] in Rust files.
+
+set -euo pipefail
+
+cd "${ROOT_DIR:-$(dirname "$0")/..}"
+
+hits="$(rg --line-number --glob '*.rs' '#\[allow\(clippy::[^)]*\)\]' . \
+  --glob '!target/**' \
+  --glob '!.git/**' || true)"
+
+if [ -n "$hits" ]; then
+  printf '%s\n' "$hits"
+  cat >&2 <<'MSG'
+
+ERROR: #[allow(clippy::...)] is forbidden in Rust files (*.rs).
+
+Fix guidance:
+  - Remove the allow attribute.
+  - Refactor code so Clippy warnings are resolved without suppression.
+
+MSG
+  exit 1
+fi
+
+echo "No #[allow(clippy::...)] in Rust files. OK"

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 git config --local hook.rust-fmt.event pre-commit
 git config --local hook.rust-fmt.command "sh -c 'cargo fmt --all -- --check'"
 
+git config --local hook.no-clippy-allow.event pre-commit
+git config --local hook.no-clippy-allow.command "bash scripts/check-no-clippy-allow.sh"
+
 git config --local hook.rust-clippy.event pre-push
 git config --local hook.rust-clippy.command "sh -c 'cargo clippy --workspace --all-targets --all-features -- -D warnings'"
 


### PR DESCRIPTION
## Summary
- add `scripts/check-no-clippy-allow.sh` to fail when `#[allow(clippy::...)]` appears in any Rust file
- wire the check into local pre-commit hooks via `mise run setup-hooks`
- add a dedicated CI job (`no-clippy-allow`) so the same policy is enforced in pull requests
- document the new policy and local check command in `CONTRIBUTING.md`

## Test plan
- [x] Run `bash scripts/check-no-clippy-allow.sh`
- [x] Run `mise run setup-hooks`
- [x] Confirm hook config includes `hook.no-clippy-allow.*`

Made with [Cursor](https://cursor.com)