### PR TITLE
refactor: separate scenario-specific e2e helpers from shared utilities

### DIFF
--- a/tests/e2e/daemon/lifecycle.rs
+++ b/tests/e2e/daemon/lifecycle.rs
@@ -5,7 +5,8 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
 
-use super::super::helpers::{DaemonHandle, FakeDaemonHandle, TestEnv};
+use super::super::helpers::{DaemonHandle, TestEnv};
+use super::lifecycle_fixtures::FakeDaemonHandle;
 
 const BIN: &str = "merge-ready";
 const PROMPT_BIN: &str = "merge-ready-prompt";

--- a/tests/e2e/daemon/lifecycle_fixtures.rs
+++ b/tests/e2e/daemon/lifecycle_fixtures.rs
@@ -1,0 +1,126 @@
+use std::fs;
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::UnixListener;
+use std::sync::mpsc;
+
+use super::super::helpers::{TestEnv, daemon_dir_name};
+
+/// version 不一致を再現するための簡易 fake daemon。
+///
+/// `Status` には指定 version を返し、`Query` の version 不一致時には新 daemon を spawn して終了する。
+pub struct FakeDaemonHandle {
+    join: Option<std::thread::JoinHandle<()>>,
+    stop_tx: Option<mpsc::Sender<()>>,
+}
+
+impl FakeDaemonHandle {
+    #[must_use]
+    pub fn start_versioned(env: &TestEnv, version: &str) -> Self {
+        let socket_path = env.home().join(daemon_dir_name()).join("daemon.sock");
+        if let Some(parent) = socket_path.parent() {
+            fs::create_dir_all(parent).expect("create fake daemon dir");
+        }
+        let _ = fs::remove_file(&socket_path);
+
+        let listener = UnixListener::bind(&socket_path).expect("bind fake daemon socket");
+        listener
+            .set_nonblocking(true)
+            .expect("set fake daemon nonblocking");
+        let version = version.to_owned();
+        let socket_path_for_thread = socket_path.clone();
+        let tmpdir = env.home().to_path_buf();
+        let path_env = env.path_env();
+        let (stop_tx, stop_rx) = mpsc::channel::<()>();
+        let join = std::thread::spawn(move || {
+            let mut remove_socket_on_exit = true;
+            loop {
+                if stop_rx.try_recv().is_ok() {
+                    break;
+                }
+                let mut stream = match listener.accept() {
+                    Ok((stream, _)) => stream,
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(std::time::Duration::from_millis(10));
+                        continue;
+                    }
+                    Err(_) => continue,
+                };
+                let _ = stream.set_read_timeout(Some(std::time::Duration::from_millis(500)));
+                let mut line = String::new();
+                {
+                    let mut reader = BufReader::new(&stream);
+                    if reader.read_line(&mut line).is_err() {
+                        continue;
+                    }
+                }
+                if line.contains("\"action\":\"status\"") {
+                    let _ = stream.write_all(
+                        format!(
+                            "{{\"tag\":\"status\",\"pid\":1,\"entries\":0,\"uptime_secs\":0,\"version\":\"{version}\"}}\n"
+                        )
+                        .as_bytes(),
+                    );
+                } else if line.contains("\"action\":\"stop\"") {
+                    let _ = stream.write_all(b"{\"tag\":\"ok\"}\n");
+                    break;
+                } else if line.contains("\"action\":\"query\"") {
+                    // Query に対して "? loading" を返す
+                    let _ = stream.write_all(b"{\"tag\":\"output\",\"output\":\"? loading\"}\n");
+                    drop(stream);
+
+                    // クライアントのバージョンが自身と異なる場合は自己再起動をシミュレート
+                    let client_version =
+                        extract_client_version_from_query(&line).unwrap_or_default();
+                    if client_version != version {
+                        // socket を解放して新 daemon が bind できるようにする
+                        let _ = fs::remove_file(&socket_path_for_thread);
+                        remove_socket_on_exit = false;
+
+                        // 新 daemon を起動（実際の daemon の自己再起動をシミュレート）
+                        let bin = assert_cmd::cargo::cargo_bin("merge-ready");
+                        let _ = std::process::Command::new(&bin)
+                            .args(["daemon", "start"])
+                            .env("TMPDIR", &tmpdir)
+                            .env("HOME", &tmpdir)
+                            .env("PATH", &path_env)
+                            .stdin(std::process::Stdio::null())
+                            .stdout(std::process::Stdio::null())
+                            .stderr(std::process::Stdio::null())
+                            .spawn();
+                        break;
+                    }
+                } else {
+                    let _ = stream.write_all(b"{\"tag\":\"output\",\"output\":\"? loading\"}\n");
+                }
+            }
+            if remove_socket_on_exit {
+                let _ = fs::remove_file(&socket_path_for_thread);
+            }
+        });
+
+        Self {
+            join: Some(join),
+            stop_tx: Some(stop_tx),
+        }
+    }
+}
+
+/// JSON 行から `client_version` フィールドを簡易抽出する。
+fn extract_client_version_from_query(line: &str) -> Option<String> {
+    let key = "\"client_version\":\"";
+    let pos = line.find(key)?;
+    let rest = &line[pos + key.len()..];
+    let end = rest.find('"')?;
+    Some(rest[..end].to_owned())
+}
+
+impl Drop for FakeDaemonHandle {
+    fn drop(&mut self) {
+        if let Some(stop_tx) = self.stop_tx.take() {
+            let _ = stop_tx.send(());
+        }
+        if let Some(join) = self.join.take() {
+            let _ = join.join();
+        }
+    }
+}

--- a/tests/e2e/daemon/mod.rs
+++ b/tests/e2e/daemon/mod.rs
@@ -1,2 +1,3 @@
 mod lifecycle;
+mod lifecycle_fixtures;
 mod watch;

--- a/tests/e2e/helpers/daemon_handle.rs
+++ b/tests/e2e/helpers/daemon_handle.rs
@@ -1,10 +1,7 @@
 //! daemon プロセスを管理するテストヘルパー。
 
 use std::fs;
-use std::io::{BufRead, BufReader, Write};
-use std::os::unix::net::UnixListener;
 use std::path::Path;
-use std::sync::mpsc;
 
 use super::{TestEnv, daemon_dir_name, run_prompt_with_timeout};
 
@@ -185,125 +182,5 @@ fn wait_until_socket_removed(tmpdir: &Path, max_ms: u64) -> bool {
             return false;
         }
         std::thread::sleep(std::time::Duration::from_millis(20));
-    }
-}
-
-/// version 不一致を再現するための簡易 fake daemon。
-///
-/// `Status` には指定 version を返し、`Query` の version 不一致時には新 daemon を spawn して終了する。
-pub struct FakeDaemonHandle {
-    join: Option<std::thread::JoinHandle<()>>,
-    stop_tx: Option<mpsc::Sender<()>>,
-}
-
-impl FakeDaemonHandle {
-    #[must_use]
-    pub fn start_versioned(env: &TestEnv, version: &str) -> Self {
-        let socket_path = env.home().join(daemon_dir_name()).join("daemon.sock");
-        if let Some(parent) = socket_path.parent() {
-            fs::create_dir_all(parent).expect("create fake daemon dir");
-        }
-        let _ = fs::remove_file(&socket_path);
-
-        let listener = UnixListener::bind(&socket_path).expect("bind fake daemon socket");
-        listener
-            .set_nonblocking(true)
-            .expect("set fake daemon nonblocking");
-        let version = version.to_owned();
-        let socket_path_for_thread = socket_path.clone();
-        let tmpdir = env.home().to_path_buf();
-        let path_env = env.path_env();
-        let (stop_tx, stop_rx) = mpsc::channel::<()>();
-        let join = std::thread::spawn(move || {
-            let mut remove_socket_on_exit = true;
-            loop {
-                if stop_rx.try_recv().is_ok() {
-                    break;
-                }
-                let mut stream = match listener.accept() {
-                    Ok((stream, _)) => stream,
-                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                        std::thread::sleep(std::time::Duration::from_millis(10));
-                        continue;
-                    }
-                    Err(_) => continue,
-                };
-                let _ = stream.set_read_timeout(Some(std::time::Duration::from_millis(500)));
-                let mut line = String::new();
-                {
-                    let mut reader = BufReader::new(&stream);
-                    if reader.read_line(&mut line).is_err() {
-                        continue;
-                    }
-                }
-                if line.contains("\"action\":\"status\"") {
-                    let _ = stream.write_all(
-                        format!(
-                            "{{\"tag\":\"status\",\"pid\":1,\"entries\":0,\"uptime_secs\":0,\"version\":\"{version}\"}}\n"
-                        )
-                        .as_bytes(),
-                    );
-                } else if line.contains("\"action\":\"stop\"") {
-                    let _ = stream.write_all(b"{\"tag\":\"ok\"}\n");
-                    break;
-                } else if line.contains("\"action\":\"query\"") {
-                    // Query に対して "? loading" を返す
-                    let _ = stream.write_all(b"{\"tag\":\"output\",\"output\":\"? loading\"}\n");
-                    drop(stream);
-
-                    // クライアントのバージョンが自身と異なる場合は自己再起動をシミュレート
-                    let client_version =
-                        extract_client_version_from_query(&line).unwrap_or_default();
-                    if client_version != version {
-                        // socket を解放して新 daemon が bind できるようにする
-                        let _ = fs::remove_file(&socket_path_for_thread);
-                        remove_socket_on_exit = false;
-
-                        // 新 daemon を起動（実際の daemon の自己再起動をシミュレート）
-                        let bin = assert_cmd::cargo::cargo_bin("merge-ready");
-                        let _ = std::process::Command::new(&bin)
-                            .args(["daemon", "start"])
-                            .env("TMPDIR", &tmpdir)
-                            .env("HOME", &tmpdir)
-                            .env("PATH", &path_env)
-                            .stdin(std::process::Stdio::null())
-                            .stdout(std::process::Stdio::null())
-                            .stderr(std::process::Stdio::null())
-                            .spawn();
-                        break;
-                    }
-                } else {
-                    let _ = stream.write_all(b"{\"tag\":\"output\",\"output\":\"? loading\"}\n");
-                }
-            }
-            if remove_socket_on_exit {
-                let _ = fs::remove_file(&socket_path_for_thread);
-            }
-        });
-
-        Self {
-            join: Some(join),
-            stop_tx: Some(stop_tx),
-        }
-    }
-}
-
-/// JSON 行から `client_version` フィールドを簡易抽出する。
-fn extract_client_version_from_query(line: &str) -> Option<String> {
-    let key = "\"client_version\":\"";
-    let pos = line.find(key)?;
-    let rest = &line[pos + key.len()..];
-    let end = rest.find('"')?;
-    Some(rest[..end].to_owned())
-}
-
-impl Drop for FakeDaemonHandle {
-    fn drop(&mut self) {
-        if let Some(stop_tx) = self.stop_tx.take() {
-            let _ = stop_tx.send(());
-        }
-        if let Some(join) = self.join.take() {
-            let _ = join.join();
-        }
     }
 }

--- a/tests/e2e/helpers/env.rs
+++ b/tests/e2e/helpers/env.rs
@@ -9,6 +9,33 @@ use tempfile::{TempDir, tempdir};
 
 use super::write_executable;
 
+/// `.git` を持つ一時ディレクトリ群を生成する。fixture モジュールからの呼び出し用。
+pub(crate) fn setup_git_dirs(branch: &str) -> (TempDir, TempDir, TempDir) {
+    let bin = tempdir().expect("failed to create bin");
+    let home_tmp = tempdir().expect("failed to create home_tmp");
+    let repo = tempdir().expect("failed to create repo");
+
+    let git_dir = repo.path().join(".git");
+    fs::create_dir_all(git_dir.join("objects")).expect("create .git/objects");
+    fs::create_dir_all(git_dir.join("refs")).expect("create .git/refs");
+    fs::write(git_dir.join("HEAD"), format!("ref: refs/heads/{branch}\n")).expect("write HEAD");
+    fs::write(
+        git_dir.join("config"),
+        "[core]\n\trepositoryformatversion = 0\n\tfilemode = true\n\tbare = false\n",
+    )
+    .expect("write config");
+
+    (bin, home_tmp, repo)
+}
+
+/// `.git` のない空のディレクトリ群を生成する。fixture モジュールからの呼び出し用。
+pub(crate) fn setup_empty_dirs() -> (TempDir, TempDir, TempDir) {
+    let bin = tempdir().expect("failed to create bin");
+    let home_tmp = tempdir().expect("failed to create home_tmp");
+    let repo = tempdir().expect("failed to create repo");
+    (bin, home_tmp, repo)
+}
+
 /// テスト実行環境を完全に隔離するヘルパー。
 pub struct TestEnv {
     /// `fake gh` を配置する一時ディレクトリ
@@ -20,35 +47,9 @@ pub struct TestEnv {
 }
 
 impl TestEnv {
-    fn setup_with_git(branch: &str) -> (TempDir, TempDir, TempDir) {
-        let bin = tempdir().expect("failed to create bin");
-        let home_tmp = tempdir().expect("failed to create home_tmp");
-        let repo = tempdir().expect("failed to create repo");
-
-        let git_dir = repo.path().join(".git");
-        fs::create_dir_all(git_dir.join("objects")).expect("create .git/objects");
-        fs::create_dir_all(git_dir.join("refs")).expect("create .git/refs");
-        fs::write(git_dir.join("HEAD"), format!("ref: refs/heads/{branch}\n")).expect("write HEAD");
-        fs::write(
-            git_dir.join("config"),
-            "[core]\n\trepositoryformatversion = 0\n\tfilemode = true\n\tbare = false\n",
-        )
-        .expect("write config");
-
-        (bin, home_tmp, repo)
-    }
-
-    /// `.git` のない空のワーキングディレクトリを生成する（git リポジトリ外シナリオ用）。
-    fn setup_without_git() -> (TempDir, TempDir, TempDir) {
-        let bin = tempdir().expect("failed to create bin");
-        let home_tmp = tempdir().expect("failed to create home_tmp");
-        let repo = tempdir().expect("failed to create repo");
-        (bin, home_tmp, repo)
-    }
-
     /// 正常系: `pr list` / `pr checks` それぞれの JSON を返す `fake gh` を配置する。
     pub fn new(pr_view_json: &str, pr_checks_json: Option<&str>) -> Self {
-        let (bin, home_tmp, repo) = Self::setup_with_git("feat/my-feature");
+        let (bin, home_tmp, repo) = setup_git_dirs("feat/my-feature");
 
         let checks_block = match pr_checks_json {
             Some(j) => format!("printf '%s' '{j}'\n"),
@@ -83,221 +84,6 @@ impl TestEnv {
             home_tmp,
             repo,
         }
-    }
-
-    /// compare API が `behind_by` を返すシナリオ用の `fake gh` を配置する。
-    pub fn with_behind_by(
-        pr_view_json: &str,
-        pr_checks_json: Option<&str>,
-        behind_by: u64,
-    ) -> Self {
-        let (bin, home_tmp, repo) = Self::setup_with_git("feat/my-feature");
-
-        let checks_block = match pr_checks_json {
-            Some(j) => format!("printf '%s' '{j}'\n"),
-            None => "printf 'unexpected pr checks call' >&2\nexit 1\n".to_string(),
-        };
-
-        let inner = pr_view_json.strip_prefix('{').unwrap_or(pr_view_json);
-        let pr_list_json = format!(r#"[{{"number":1,{inner}]"#);
-
-        let script = format!(
-            "#!/bin/sh\n\
-             case \"$*\" in\n\
-               *'pr list'*)\n\
-                 printf '%s' '{pr_list_json}'\n\
-                 ;;\n\
-               *'pr checks'*)\n\
-                 {checks_block}\
-                 ;;\n\
-               *'repo view'*)\n\
-                 printf '{{\"nameWithOwner\":\"owner/repo\"}}'\n\
-                 ;;\n\
-               *'api'*'compare'*)\n\
-                 printf '{{\"behind_by\":{behind_by}}}'\n\
-                 ;;\n\
-               *)\n\
-                 printf 'unknown gh command: %s' \"$*\" >&2\n\
-                 exit 127\n\
-                 ;;\n\
-             esac\n"
-        );
-
-        write_executable(bin.path().join("gh"), &script);
-        Self {
-            bin,
-            home_tmp,
-            repo,
-        }
-    }
-
-    /// compare API がエラーを返すシナリオ用の `fake gh` を配置する。
-    pub fn with_compare_error(pr_view_json: &str, pr_checks_json: Option<&str>) -> Self {
-        let (bin, home_tmp, repo) = Self::setup_with_git("feat/my-feature");
-
-        let checks_block = match pr_checks_json {
-            Some(j) => format!("printf '%s' '{j}'\n"),
-            None => "printf 'unexpected pr checks call' >&2\nexit 1\n".to_string(),
-        };
-
-        let inner = pr_view_json.strip_prefix('{').unwrap_or(pr_view_json);
-        let pr_list_json = format!(r#"[{{"number":1,{inner}]"#);
-
-        let script = format!(
-            "#!/bin/sh\n\
-             case \"$*\" in\n\
-               *'pr list'*)\n\
-                 printf '%s' '{pr_list_json}'\n\
-                 ;;\n\
-               *'pr checks'*)\n\
-                 {checks_block}\
-                 ;;\n\
-               *'repo view'*)\n\
-                 printf '{{\"nameWithOwner\":\"owner/repo\"}}'\n\
-                 ;;\n\
-               *'api'*'compare'*)\n\
-                 printf 'API error' >&2\n\
-                 exit 1\n\
-                 ;;\n\
-               *)\n\
-                 printf 'unknown gh command: %s' \"$*\" >&2\n\
-                 exit 127\n\
-                 ;;\n\
-             esac\n"
-        );
-
-        write_executable(bin.path().join("gh"), &script);
-        Self {
-            bin,
-            home_tmp,
-            repo,
-        }
-    }
-
-    /// エラー系: 指定した `exit_code` と `stderr` メッセージを返す `fake gh` を配置する。
-    pub fn with_error(stderr_msg: &str, exit_code: u8) -> Self {
-        let (bin, home_tmp, repo) = Self::setup_with_git("feat/my-feature");
-        let script = format!("#!/bin/sh\nprintf '%s' '{stderr_msg}' >&2\nexit {exit_code}\n");
-        write_executable(bin.path().join("gh"), &script);
-        Self {
-            bin,
-            home_tmp,
-            repo,
-        }
-    }
-
-    /// CI 未設定シナリオ: `gh pr checks` が `"no checks reported"` で `exit 1` を返す。
-    pub fn with_no_ci_checks(pr_view_json: &str) -> Self {
-        let (bin, home_tmp, repo) = Self::setup_with_git("feat/my-feature");
-
-        let inner = pr_view_json.strip_prefix('{').unwrap_or(pr_view_json);
-        let pr_list_json = format!(r#"[{{"number":1,{inner}]"#);
-
-        let script = format!(
-            "#!/bin/sh\n\
-             case \"$*\" in\n\
-               *'pr list'*)\n\
-                 printf '%s' '{pr_list_json}'\n\
-                 ;;\n\
-               *'pr checks'*)\n\
-                 printf \"%s\" \"no checks reported on the 'test-branch' branch\" >&2\n\
-                 exit 1\n\
-                 ;;\n\
-               *)\n\
-                 printf 'unknown gh command: %s' \"$*\" >&2\n\
-                 exit 127\n\
-                 ;;\n\
-             esac\n"
-        );
-        write_executable(bin.path().join("gh"), &script);
-        Self {
-            bin,
-            home_tmp,
-            repo,
-        }
-    }
-
-    /// 複数 PR シナリオ: `pr_list_json` に複数エントリを含む JSON 配列を直接指定する。
-    ///
-    /// `pr_list_json` は `[{...}, {...}]` 形式の完全な JSON 配列。
-    /// `gh pr checks` はすべての PR 番号に対して同じ `pr_checks_json` を返す。
-    pub fn with_pr_list(pr_list_json: &str, pr_checks_json: Option<&str>) -> Self {
-        let (bin, home_tmp, repo) = Self::setup_with_git("feat/my-feature");
-
-        let checks_block = match pr_checks_json {
-            Some(j) => format!("printf '%s' '{j}'\n"),
-            None => "printf 'unexpected pr checks call' >&2\nexit 1\n".to_string(),
-        };
-
-        let script = format!(
-            "#!/bin/sh\n\
-             case \"$*\" in\n\
-               *'pr list'*)\n\
-                 printf '%s' '{pr_list_json}'\n\
-                 ;;\n\
-               *'pr checks'*)\n\
-                 {checks_block}\
-                 ;;\n\
-               *'api'*'compare'*)\n\
-                 printf '{{\"behind_by\":0}}'\n\
-                 ;;\n\
-               *)\n\
-                 printf 'unknown gh command: %s' \"$*\" >&2\n\
-                 exit 127\n\
-                 ;;\n\
-             esac\n"
-        );
-
-        write_executable(bin.path().join("gh"), &script);
-        Self {
-            bin,
-            home_tmp,
-            repo,
-        }
-    }
-
-    /// `gh` バイナリが `PATH` に存在しないシナリオ
-    pub fn without_gh() -> Self {
-        let (bin, home_tmp, repo) = Self::setup_with_git("feat/my-feature");
-        Self {
-            bin,
-            home_tmp,
-            repo,
-        }
-    }
-
-    /// terminal PR シナリオ（呼び出しカウンタ付き）
-    ///
-    /// `gh pr list` が closed / merged JSON を返す。カウンタログファイルのパスを返す。
-    pub fn with_terminal_pr_call_log(state: &str) -> (Self, std::path::PathBuf) {
-        let (bin, home_tmp, repo) = Self::setup_with_git("feat/my-feature");
-        let log_path = home_tmp.path().join("gh_calls.log");
-        let log = log_path.display().to_string();
-        let pr_list_json = format!(
-            r#"[{{"number":1,"state":"{state}","isDraft":false,"mergeable":"UNKNOWN","mergeStateStatus":"UNKNOWN","reviewDecision":null}}]"#
-        );
-        let script = format!(
-            "#!/bin/sh\n\
-             printf '1' >> \"{log}\"\n\
-             case \"$*\" in\n\
-               *'pr list'*)\n\
-                 printf '%s' '{pr_list_json}'\n\
-                 ;;\n\
-               *)\n\
-                 printf 'unexpected gh call: %s' \"$*\" >&2\n\
-                 exit 127\n\
-                 ;;\n\
-             esac\n"
-        );
-        write_executable(bin.path().join("gh"), &script);
-        (
-            Self {
-                bin,
-                home_tmp,
-                repo,
-            },
-            log_path,
-        )
     }
 
     /// PR なしシナリオ: フィーチャーブランチに PR が存在しない場合を模倣する。
@@ -306,7 +92,7 @@ impl TestEnv {
     /// `gh pr list` → 空配列 `[]` を返す
     /// `gh repo view --json defaultBranchRef` → main をデフォルトブランチとして返す
     pub fn with_no_pr() -> Self {
-        let (bin, home_tmp, repo) = Self::setup_with_git("feat/my-feature");
+        let (bin, home_tmp, repo) = setup_git_dirs("feat/my-feature");
         let script = "#!/bin/sh\n\
                       case \"$*\" in\n\
                         *'pr list'*)\n\
@@ -328,38 +114,10 @@ impl TestEnv {
         }
     }
 
-    /// PR なしシナリオ（遅延付き）: stale refresh 中の挙動を再現するため、初回呼び出しは即座に返し、
-    /// 2回目以降（stale refresh）のみ `delay_ms` 遅延させる。
-    ///
-    /// これにより `wait_for_cache` が初回リフレッシュ完了を確実に待てる一方で、
-    /// stale refresh 中の挙動（空出力を維持）を検証できる。
-    pub fn with_no_pr_stale_delay_ms(delay_ms: u64) -> Self {
-        let (bin, home_tmp, repo) = Self::setup_with_git("feat/my-feature");
-        let secs = delay_ms / 1000;
-        let millis = delay_ms % 1000;
-        let sleep_arg = format!("{secs}.{millis:03}");
-        let count_path = home_tmp.path().join(".gh_call_count").display().to_string();
-        let script = format!(
-            "#!/bin/sh\n\
-             case \"$*\" in\n\
-               *'pr list'*)\n\
-                 count=$(cat \"{count_path}\" 2>/dev/null || printf '0')\n\
-                 count=$((count + 1))\n\
-                 printf '%d' \"$count\" > \"{count_path}\"\n\
-                 if [ \"$count\" -gt 1 ]; then\n\
-                     sleep {sleep_arg}\n\
-                 fi\n\
-                 printf '[]'\n\
-                 ;;\n\
-               *'repo view'*'defaultBranchRef'*)\n\
-                 printf '{{\"defaultBranchRef\":{{\"name\":\"main\"}}}}'\n\
-                 ;;\n\
-               *)\n\
-                 printf 'unknown gh command: %s' \"$*\" >&2\n\
-                 exit 127\n\
-                 ;;\n\
-             esac\n"
-        );
+    /// エラー系: 指定した `exit_code` と `stderr` メッセージを返す `fake gh` を配置する。
+    pub fn with_error(stderr_msg: &str, exit_code: u8) -> Self {
+        let (bin, home_tmp, repo) = setup_git_dirs("feat/my-feature");
+        let script = format!("#!/bin/sh\nprintf '%s' '{stderr_msg}' >&2\nexit {exit_code}\n");
         write_executable(bin.path().join("gh"), &script);
         Self {
             bin,
@@ -368,85 +126,28 @@ impl TestEnv {
         }
     }
 
-    /// デフォルトブランチ上シナリオ: 現在ブランチ == デフォルトブランチ、PR なし。
+    /// `gh` バイナリが `PATH` に存在しないシナリオ
+    pub fn without_gh() -> Self {
+        let (bin, home_tmp, repo) = setup_git_dirs("feat/my-feature");
+        Self {
+            bin,
+            home_tmp,
+            repo,
+        }
+    }
+
+    /// 複数 PR シナリオ: `pr_list_json` に複数エントリを含む JSON 配列を直接指定する。
     ///
-    /// `branch` に "main" または "master" などを指定する。
-    /// `gh pr list` → 空配列 `[]` を返す
-    /// `gh repo view --json defaultBranchRef` → `branch` をデフォルトブランチとして返す
-    pub fn with_default_branch_no_pr(branch: &str) -> Self {
-        let (bin, home_tmp, repo) = Self::setup_with_git(branch);
-        let script = format!(
-            "#!/bin/sh\n\
-             case \"$*\" in\n\
-               *'pr list'*)\n\
-                 printf '[]'\n\
-                 ;;\n\
-               *'repo view'*'defaultBranchRef'*)\n\
-                 printf '{{\"defaultBranchRef\":{{\"name\":\"{branch}\"}}}}'\n\
-                 ;;\n\
-               *)\n\
-                 printf 'unknown gh command: %s' \"$*\" >&2\n\
-                 exit 127\n\
-                 ;;\n\
-             esac\n"
-        );
-        write_executable(bin.path().join("gh"), &script);
-        Self {
-            bin,
-            home_tmp,
-            repo,
-        }
-    }
+    /// `pr_list_json` は `[{...}, {...}]` 形式の完全な JSON 配列。
+    /// `gh pr checks` はすべての PR 番号に対して同じ `pr_checks_json` を返す。
+    pub fn with_pr_list(pr_list_json: &str, pr_checks_json: Option<&str>) -> Self {
+        let (bin, home_tmp, repo) = setup_git_dirs("feat/my-feature");
 
-    /// git リポジトリ外シナリオ（`.git` のない空ディレクトリで実行）
-    pub fn without_git_remote() -> Self {
-        let (bin, home_tmp, repo) = Self::setup_without_git();
-        let gh_script = "#!/bin/sh\necho 'gh should not be called' >&2\nexit 1\n";
-        write_executable(bin.path().join("gh"), gh_script);
-        Self {
-            bin,
-            home_tmp,
-            repo,
-        }
-    }
+        let checks_block = match pr_checks_json {
+            Some(j) => format!("printf '%s' '{j}'\n"),
+            None => "printf 'unexpected pr checks call' >&2\nexit 1\n".to_string(),
+        };
 
-    /// `gh` バイナリが無期限にハングするシナリオ（タイムアウト検証用）
-    pub fn with_hanging_gh() -> Self {
-        let (bin, home_tmp, repo) = Self::setup_with_git("feat/my-feature");
-        write_executable(bin.path().join("gh"), "#!/bin/sh\nsleep 9999\n");
-        Self {
-            bin,
-            home_tmp,
-            repo,
-        }
-    }
-
-    /// `gh pr list` が exit 0 で不正な JSON を返すシナリオ
-    pub fn with_invalid_pr_list_json() -> Self {
-        let (bin, home_tmp, repo) = Self::setup_with_git("feat/my-feature");
-        let script = "#!/bin/sh\n\
-                      case \"$*\" in\n\
-                        *'pr list'*)\n\
-                          printf 'not-valid-json'\n\
-                          ;;\n\
-                        *)\n\
-                          printf 'unknown gh command: %s' \"$*\" >&2\n\
-                          exit 127\n\
-                          ;;\n\
-                      esac\n";
-        write_executable(bin.path().join("gh"), script);
-        Self {
-            bin,
-            home_tmp,
-            repo,
-        }
-    }
-
-    /// `gh pr list` が成功するが `gh pr checks` が exit 0 で不正な JSON を返すシナリオ
-    pub fn with_invalid_pr_checks_json(pr_view_json: &str) -> Self {
-        let (bin, home_tmp, repo) = Self::setup_with_git("feat/my-feature");
-        let inner = pr_view_json.strip_prefix('{').unwrap_or(pr_view_json);
-        let pr_list_json = format!(r#"[{{"number":1,{inner}]"#);
         let script = format!(
             "#!/bin/sh\n\
              case \"$*\" in\n\
@@ -454,7 +155,7 @@ impl TestEnv {
                  printf '%s' '{pr_list_json}'\n\
                  ;;\n\
                *'pr checks'*)\n\
-                 printf 'not-valid-json'\n\
+                 {checks_block}\
                  ;;\n\
                *'api'*'compare'*)\n\
                  printf '{{\"behind_by\":0}}'\n\
@@ -465,39 +166,7 @@ impl TestEnv {
                  ;;\n\
              esac\n"
         );
-        write_executable(bin.path().join("gh"), &script);
-        Self {
-            bin,
-            home_tmp,
-            repo,
-        }
-    }
 
-    /// `gh pr list` / `gh pr checks` が成功するが `gh repo view --json nameWithOwner` が
-    /// exit 0 で不正な JSON を返すシナリオ（compare API への到達前に失敗）
-    pub fn with_invalid_repo_view_json(pr_view_json: &str, pr_checks_json: &str) -> Self {
-        let (bin, home_tmp, repo) = Self::setup_with_git("feat/my-feature");
-        let inner = pr_view_json.strip_prefix('{').unwrap_or(pr_view_json);
-        let pr_list_json = format!(r#"[{{"number":1,{inner}]"#);
-        let checks_json = pr_checks_json.to_owned();
-        let script = format!(
-            "#!/bin/sh\n\
-             case \"$*\" in\n\
-               *'pr list'*)\n\
-                 printf '%s' '{pr_list_json}'\n\
-                 ;;\n\
-               *'pr checks'*)\n\
-                 printf '%s' '{checks_json}'\n\
-                 ;;\n\
-               *'repo view'*'nameWithOwner'*)\n\
-                 printf 'not-valid-json'\n\
-                 ;;\n\
-               *)\n\
-                 printf 'unknown gh command: %s' \"$*\" >&2\n\
-                 exit 127\n\
-                 ;;\n\
-             esac\n"
-        );
         write_executable(bin.path().join("gh"), &script);
         Self {
             bin,

--- a/tests/e2e/helpers/mod.rs
+++ b/tests/e2e/helpers/mod.rs
@@ -2,8 +2,9 @@ mod daemon_handle;
 mod env;
 mod multi_repo;
 
-pub use daemon_handle::{DaemonHandle, FakeDaemonHandle};
+pub use daemon_handle::DaemonHandle;
 pub use env::TestEnv;
+pub(crate) use env::{setup_empty_dirs, setup_git_dirs};
 pub use multi_repo::MultiRepoEnv;
 
 use std::fs;

--- a/tests/e2e/prompt/branch_sync.rs
+++ b/tests/e2e/prompt/branch_sync.rs
@@ -8,6 +8,7 @@ use predicates::prelude::*;
 use rstest::rstest;
 
 use super::super::helpers::{DaemonHandle, TestEnv};
+use super::branch_sync_fixtures;
 
 const CONFLICTING_DIRTY: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"CONFLICTING","mergeStateStatus":"DIRTY","reviewDecision":null}"#;
 const CONFLICTING_BEHIND: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"CONFLICTING","mergeStateStatus":"BEHIND","reviewDecision":null}"#;
@@ -54,7 +55,7 @@ fn test_conflict_prompt(#[case] pr_json: &str, #[case] checks_json: &str, #[case
 /// #18: compare API の `behind_by > 0` → `✗ Update branch`
 #[test]
 fn test_update_branch() {
-    let env = TestEnv::with_behind_by(MERGEABLE_BLOCKED, Some(PASS_JSON), 1);
+    let env = branch_sync_fixtures::with_behind_by(MERGEABLE_BLOCKED, Some(PASS_JSON), 1);
     assert_prompt(&env, "✗ Update branch");
 }
 
@@ -63,13 +64,13 @@ fn test_update_branch() {
 /// #19: compare API がエラーを返す → `? Check branch sync`
 #[test]
 fn test_compare_api_error() {
-    let env = TestEnv::with_compare_error(MERGEABLE_BLOCKED, Some(PASS_JSON));
+    let env = branch_sync_fixtures::with_compare_error(MERGEABLE_BLOCKED, Some(PASS_JSON));
     assert_prompt(&env, "? Check branch sync");
 }
 
 /// `gh repo view --json nameWithOwner` が exit 0 で不正な JSON を返す → `? Check branch sync`
 #[test]
 fn test_repo_view_invalid_json_shows_check_branch_sync() {
-    let env = TestEnv::with_invalid_repo_view_json(MERGEABLE_BLOCKED, PASS_JSON);
+    let env = branch_sync_fixtures::with_invalid_repo_view_json(MERGEABLE_BLOCKED, PASS_JSON);
     assert_prompt(&env, "? Check branch sync");
 }

--- a/tests/e2e/prompt/branch_sync_fixtures.rs
+++ b/tests/e2e/prompt/branch_sync_fixtures.rs
@@ -1,0 +1,119 @@
+use super::super::helpers::{TestEnv, setup_git_dirs, write_executable};
+
+/// compare API が `behind_by` を返すシナリオ用の `fake gh` を配置する。
+pub fn with_behind_by(pr_view_json: &str, pr_checks_json: Option<&str>, behind_by: u64) -> TestEnv {
+    let (bin, home_tmp, repo) = setup_git_dirs("feat/my-feature");
+
+    let checks_block = match pr_checks_json {
+        Some(j) => format!("printf '%s' '{j}'\n"),
+        None => "printf 'unexpected pr checks call' >&2\nexit 1\n".to_string(),
+    };
+
+    let inner = pr_view_json.strip_prefix('{').unwrap_or(pr_view_json);
+    let pr_list_json = format!(r#"[{{"number":1,{inner}]"#);
+
+    let script = format!(
+        "#!/bin/sh\n\
+         case \"$*\" in\n\
+           *'pr list'*)\n\
+             printf '%s' '{pr_list_json}'\n\
+             ;;\n\
+           *'pr checks'*)\n\
+             {checks_block}\
+             ;;\n\
+           *'repo view'*)\n\
+             printf '{{\"nameWithOwner\":\"owner/repo\"}}'\n\
+             ;;\n\
+           *'api'*'compare'*)\n\
+             printf '{{\"behind_by\":{behind_by}}}'\n\
+             ;;\n\
+           *)\n\
+             printf 'unknown gh command: %s' \"$*\" >&2\n\
+             exit 127\n\
+             ;;\n\
+         esac\n"
+    );
+
+    write_executable(bin.path().join("gh"), &script);
+    TestEnv {
+        bin,
+        home_tmp,
+        repo,
+    }
+}
+
+/// compare API がエラーを返すシナリオ用の `fake gh` を配置する。
+pub fn with_compare_error(pr_view_json: &str, pr_checks_json: Option<&str>) -> TestEnv {
+    let (bin, home_tmp, repo) = setup_git_dirs("feat/my-feature");
+
+    let checks_block = match pr_checks_json {
+        Some(j) => format!("printf '%s' '{j}'\n"),
+        None => "printf 'unexpected pr checks call' >&2\nexit 1\n".to_string(),
+    };
+
+    let inner = pr_view_json.strip_prefix('{').unwrap_or(pr_view_json);
+    let pr_list_json = format!(r#"[{{"number":1,{inner}]"#);
+
+    let script = format!(
+        "#!/bin/sh\n\
+         case \"$*\" in\n\
+           *'pr list'*)\n\
+             printf '%s' '{pr_list_json}'\n\
+             ;;\n\
+           *'pr checks'*)\n\
+             {checks_block}\
+             ;;\n\
+           *'repo view'*)\n\
+             printf '{{\"nameWithOwner\":\"owner/repo\"}}'\n\
+             ;;\n\
+           *'api'*'compare'*)\n\
+             printf 'API error' >&2\n\
+             exit 1\n\
+             ;;\n\
+           *)\n\
+             printf 'unknown gh command: %s' \"$*\" >&2\n\
+             exit 127\n\
+             ;;\n\
+         esac\n"
+    );
+
+    write_executable(bin.path().join("gh"), &script);
+    TestEnv {
+        bin,
+        home_tmp,
+        repo,
+    }
+}
+
+/// `gh pr list` / `gh pr checks` が成功するが `gh repo view --json nameWithOwner` が
+/// exit 0 で不正な JSON を返すシナリオ（compare API への到達前に失敗）
+pub fn with_invalid_repo_view_json(pr_view_json: &str, pr_checks_json: &str) -> TestEnv {
+    let (bin, home_tmp, repo) = setup_git_dirs("feat/my-feature");
+    let inner = pr_view_json.strip_prefix('{').unwrap_or(pr_view_json);
+    let pr_list_json = format!(r#"[{{"number":1,{inner}]"#);
+    let checks_json = pr_checks_json.to_owned();
+    let script = format!(
+        "#!/bin/sh\n\
+         case \"$*\" in\n\
+           *'pr list'*)\n\
+             printf '%s' '{pr_list_json}'\n\
+             ;;\n\
+           *'pr checks'*)\n\
+             printf '%s' '{checks_json}'\n\
+             ;;\n\
+           *'repo view'*'nameWithOwner'*)\n\
+             printf 'not-valid-json'\n\
+             ;;\n\
+           *)\n\
+             printf 'unknown gh command: %s' \"$*\" >&2\n\
+             exit 127\n\
+             ;;\n\
+         esac\n"
+    );
+    write_executable(bin.path().join("gh"), &script);
+    TestEnv {
+        bin,
+        home_tmp,
+        repo,
+    }
+}

--- a/tests/e2e/prompt/ci_checks.rs
+++ b/tests/e2e/prompt/ci_checks.rs
@@ -8,6 +8,7 @@ use predicates::prelude::*;
 use rstest::rstest;
 
 use super::super::helpers::{DaemonHandle, TestEnv};
+use super::ci_checks_fixtures;
 
 const BLOCKED_NO_REVIEW: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"BLOCKED","reviewDecision":null}"#;
 const BLOCKED_CHANGES_REQUESTED: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"BLOCKED","reviewDecision":"CHANGES_REQUESTED"}"#;
@@ -59,6 +60,6 @@ fn test_ci_check_prompt(#[case] pr_json: &str, #[case] checks_json: &str, #[case
 #[case::merge_ready(APPROVED_CLEAN, "✓ Ready for merge")]
 #[case::review(BLOCKED_CHANGES_REQUESTED, "⚠ Resolve review")]
 fn test_no_ci_checks_prompt(#[case] pr_json: &str, #[case] expected: &str) {
-    let env = TestEnv::with_no_ci_checks(pr_json);
+    let env = ci_checks_fixtures::with_no_ci_checks(pr_json);
     assert_prompt(&env, expected);
 }

--- a/tests/e2e/prompt/ci_checks_fixtures.rs
+++ b/tests/e2e/prompt/ci_checks_fixtures.rs
@@ -1,0 +1,32 @@
+use super::super::helpers::{TestEnv, setup_git_dirs, write_executable};
+
+/// CI 未設定シナリオ: `gh pr checks` が `"no checks reported"` で `exit 1` を返す。
+pub fn with_no_ci_checks(pr_view_json: &str) -> TestEnv {
+    let (bin, home_tmp, repo) = setup_git_dirs("feat/my-feature");
+
+    let inner = pr_view_json.strip_prefix('{').unwrap_or(pr_view_json);
+    let pr_list_json = format!(r#"[{{"number":1,{inner}]"#);
+
+    let script = format!(
+        "#!/bin/sh\n\
+         case \"$*\" in\n\
+           *'pr list'*)\n\
+             printf '%s' '{pr_list_json}'\n\
+             ;;\n\
+           *'pr checks'*)\n\
+             printf \"%s\" \"no checks reported on the 'test-branch' branch\" >&2\n\
+             exit 1\n\
+             ;;\n\
+           *)\n\
+             printf 'unknown gh command: %s' \"$*\" >&2\n\
+             exit 127\n\
+             ;;\n\
+         esac\n"
+    );
+    write_executable(bin.path().join("gh"), &script);
+    TestEnv {
+        bin,
+        home_tmp,
+        repo,
+    }
+}

--- a/tests/e2e/prompt/errors.rs
+++ b/tests/e2e/prompt/errors.rs
@@ -11,6 +11,7 @@ use assert_cmd::Command;
 use rstest::rstest;
 
 use super::super::helpers::{DaemonHandle, TestEnv};
+use super::errors_fixtures;
 
 fn cmd(env: &TestEnv) -> Command {
     let mut c = Command::cargo_bin(PROMPT_BIN).unwrap();
@@ -78,7 +79,7 @@ fn test_error_output(#[case] msg: &str, #[case] code: u8, #[case] expected: &str
 /// #40: `gh` がハングした場合、タイムアウト後に `✗ unexpected error` を返すこと（詳細はログ）。
 #[test]
 fn test_gh_timeout() {
-    let env = TestEnv::with_hanging_gh();
+    let env = errors_fixtures::with_hanging_gh();
     let _daemon = DaemonHandle::start_with_env(&env, &[("MERGE_READY_GH_TIMEOUT_SECS", "2")]);
     DaemonHandle::wait_for_cache(&env, 10000);
 
@@ -107,7 +108,7 @@ fn test_error_log_written() {
 /// `gh pr list` が exit 0 で不正な JSON を返した場合 → `✗ unexpected error`
 #[test]
 fn test_pr_list_invalid_json_shows_unexpected_error() {
-    let env = TestEnv::with_invalid_pr_list_json();
+    let env = errors_fixtures::with_invalid_pr_list_json();
     let _daemon = DaemonHandle::start(&env);
     DaemonHandle::wait_for_cache(&env, 5000);
 
@@ -122,7 +123,7 @@ fn test_pr_list_invalid_json_shows_unexpected_error() {
 #[test]
 fn test_pr_checks_invalid_json_shows_unexpected_error() {
     const OPEN_PR: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"BLOCKED","reviewDecision":null,"baseRefName":"","headRefName":""}"#;
-    let env = TestEnv::with_invalid_pr_checks_json(OPEN_PR);
+    let env = errors_fixtures::with_invalid_pr_checks_json(OPEN_PR);
     let _daemon = DaemonHandle::start(&env);
     DaemonHandle::wait_for_cache(&env, 5000);
 

--- a/tests/e2e/prompt/errors_fixtures.rs
+++ b/tests/e2e/prompt/errors_fixtures.rs
@@ -1,0 +1,64 @@
+use super::super::helpers::{TestEnv, setup_git_dirs, write_executable};
+
+/// `gh` バイナリが無期限にハングするシナリオ（タイムアウト検証用）
+pub fn with_hanging_gh() -> TestEnv {
+    let (bin, home_tmp, repo) = setup_git_dirs("feat/my-feature");
+    write_executable(bin.path().join("gh"), "#!/bin/sh\nsleep 9999\n");
+    TestEnv {
+        bin,
+        home_tmp,
+        repo,
+    }
+}
+
+/// `gh pr list` が exit 0 で不正な JSON を返すシナリオ
+pub fn with_invalid_pr_list_json() -> TestEnv {
+    let (bin, home_tmp, repo) = setup_git_dirs("feat/my-feature");
+    let script = "#!/bin/sh\n\
+                  case \"$*\" in\n\
+                    *'pr list'*)\n\
+                      printf 'not-valid-json'\n\
+                      ;;\n\
+                    *)\n\
+                      printf 'unknown gh command: %s' \"$*\" >&2\n\
+                      exit 127\n\
+                      ;;\n\
+                  esac\n";
+    write_executable(bin.path().join("gh"), script);
+    TestEnv {
+        bin,
+        home_tmp,
+        repo,
+    }
+}
+
+/// `gh pr list` が成功するが `gh pr checks` が exit 0 で不正な JSON を返すシナリオ
+pub fn with_invalid_pr_checks_json(pr_view_json: &str) -> TestEnv {
+    let (bin, home_tmp, repo) = setup_git_dirs("feat/my-feature");
+    let inner = pr_view_json.strip_prefix('{').unwrap_or(pr_view_json);
+    let pr_list_json = format!(r#"[{{"number":1,{inner}]"#);
+    let script = format!(
+        "#!/bin/sh\n\
+         case \"$*\" in\n\
+           *'pr list'*)\n\
+             printf '%s' '{pr_list_json}'\n\
+             ;;\n\
+           *'pr checks'*)\n\
+             printf 'not-valid-json'\n\
+             ;;\n\
+           *'api'*'compare'*)\n\
+             printf '{{\"behind_by\":0}}'\n\
+             ;;\n\
+           *)\n\
+             printf 'unknown gh command: %s' \"$*\" >&2\n\
+             exit 127\n\
+             ;;\n\
+         esac\n"
+    );
+    write_executable(bin.path().join("gh"), &script);
+    TestEnv {
+        bin,
+        home_tmp,
+        repo,
+    }
+}

--- a/tests/e2e/prompt/mod.rs
+++ b/tests/e2e/prompt/mod.rs
@@ -1,6 +1,9 @@
 mod branch_sync;
+mod branch_sync_fixtures;
 mod ci_checks;
+mod ci_checks_fixtures;
 mod errors;
+mod errors_fixtures;
 mod merge_ready;
 mod pr_state;
 mod review;

--- a/tests/e2e/scenarios/default_branch.rs
+++ b/tests/e2e/scenarios/default_branch.rs
@@ -8,12 +8,13 @@ const PROMPT_BIN: &str = "merge-ready-prompt";
 use assert_cmd::Command;
 use predicates::prelude::*;
 
-use super::super::helpers::{DaemonHandle, TestEnv};
+use super::super::helpers::DaemonHandle;
+use super::default_branch_fixtures;
 
 /// main ブランチ（デフォルトブランチ）上: daemon キャッシュ確定後に空出力
 #[test]
 fn test_daemon_on_main_default_branch_outputs_empty() {
-    let env = TestEnv::with_default_branch_no_pr("main");
+    let env = default_branch_fixtures::with_default_branch_no_pr("main");
     let _daemon = DaemonHandle::start(&env);
 
     DaemonHandle::wait_for_cache(&env, 5000);
@@ -29,7 +30,7 @@ fn test_daemon_on_main_default_branch_outputs_empty() {
 /// master ブランチ（デフォルトブランチ）上: daemon キャッシュ確定後に空出力
 #[test]
 fn test_daemon_on_master_default_branch_outputs_empty() {
-    let env = TestEnv::with_default_branch_no_pr("master");
+    let env = default_branch_fixtures::with_default_branch_no_pr("master");
     let _daemon = DaemonHandle::start(&env);
 
     DaemonHandle::wait_for_cache(&env, 5000);

--- a/tests/e2e/scenarios/default_branch_fixtures.rs
+++ b/tests/e2e/scenarios/default_branch_fixtures.rs
@@ -1,0 +1,31 @@
+use super::super::helpers::{TestEnv, setup_git_dirs, write_executable};
+
+/// デフォルトブランチ上シナリオ: 現在ブランチ == デフォルトブランチ、PR なし。
+///
+/// `branch` に "main" または "master" などを指定する。
+/// `gh pr list` → 空配列 `[]` を返す
+/// `gh repo view --json defaultBranchRef` → `branch` をデフォルトブランチとして返す
+pub fn with_default_branch_no_pr(branch: &str) -> TestEnv {
+    let (bin, home_tmp, repo) = setup_git_dirs(branch);
+    let script = format!(
+        "#!/bin/sh\n\
+         case \"$*\" in\n\
+           *'pr list'*)\n\
+             printf '[]'\n\
+             ;;\n\
+           *'repo view'*'defaultBranchRef'*)\n\
+             printf '{{\"defaultBranchRef\":{{\"name\":\"{branch}\"}}}}'\n\
+             ;;\n\
+           *)\n\
+             printf 'unknown gh command: %s' \"$*\" >&2\n\
+             exit 127\n\
+             ;;\n\
+         esac\n"
+    );
+    write_executable(bin.path().join("gh"), &script);
+    TestEnv {
+        bin,
+        home_tmp,
+        repo,
+    }
+}

--- a/tests/e2e/scenarios/mod.rs
+++ b/tests/e2e/scenarios/mod.rs
@@ -1,10 +1,14 @@
 mod cache_hit;
 mod default_branch;
+mod default_branch_fixtures;
 mod initial_load;
 mod multi_repo;
 mod multiple_prs;
 mod no_github_remote;
 mod no_pr;
+mod no_pr_fixtures;
 mod no_repo;
+mod no_repo_fixtures;
 mod stale;
 mod terminal_pr;
+mod terminal_pr_fixtures;

--- a/tests/e2e/scenarios/no_pr.rs
+++ b/tests/e2e/scenarios/no_pr.rs
@@ -9,6 +9,7 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 
 use super::super::helpers::{DaemonHandle, TestEnv};
+use super::no_pr_fixtures;
 
 /// #4: PR なしブランチで daemon 経由: リフレッシュ完了後に `+ Create PR` が表示される
 #[test]
@@ -37,7 +38,7 @@ fn test_daemon_no_pr_shows_nothing_after_refresh() {
 /// #5: no-PR の stale リフレッシュ中でも `? loading` に戻らず空出力を維持する
 #[test]
 fn test_daemon_no_pr_stale_while_refreshing_keeps_empty_output() {
-    let env = TestEnv::with_no_pr_stale_delay_ms(1000);
+    let env = no_pr_fixtures::with_no_pr_stale_delay_ms(1000);
     let _daemon = DaemonHandle::start_with_env(&env, &[("MERGE_READY_STALE_TTL", "0")]);
 
     // 初回クエリ: キャッシュミス → loading

--- a/tests/e2e/scenarios/no_pr_fixtures.rs
+++ b/tests/e2e/scenarios/no_pr_fixtures.rs
@@ -1,0 +1,38 @@
+use super::super::helpers::{TestEnv, setup_git_dirs, write_executable};
+
+/// PR なしシナリオ（遅延付き）: stale refresh 中の挙動を再現するため、初回呼び出しは即座に返し、
+/// 2回目以降（stale refresh）のみ `delay_ms` 遅延させる。
+pub fn with_no_pr_stale_delay_ms(delay_ms: u64) -> TestEnv {
+    let (bin, home_tmp, repo) = setup_git_dirs("feat/my-feature");
+    let secs = delay_ms / 1000;
+    let millis = delay_ms % 1000;
+    let sleep_arg = format!("{secs}.{millis:03}");
+    let count_path = home_tmp.path().join(".gh_call_count").display().to_string();
+    let script = format!(
+        "#!/bin/sh\n\
+         case \"$*\" in\n\
+           *'pr list'*)\n\
+             count=$(cat \"{count_path}\" 2>/dev/null || printf '0')\n\
+             count=$((count + 1))\n\
+             printf '%d' \"$count\" > \"{count_path}\"\n\
+             if [ \"$count\" -gt 1 ]; then\n\
+                 sleep {sleep_arg}\n\
+             fi\n\
+             printf '[]'\n\
+             ;;\n\
+           *'repo view'*'defaultBranchRef'*)\n\
+             printf '{{\"defaultBranchRef\":{{\"name\":\"main\"}}}}'\n\
+             ;;\n\
+           *)\n\
+             printf 'unknown gh command: %s' \"$*\" >&2\n\
+             exit 127\n\
+             ;;\n\
+         esac\n"
+    );
+    write_executable(bin.path().join("gh"), &script);
+    TestEnv {
+        bin,
+        home_tmp,
+        repo,
+    }
+}

--- a/tests/e2e/scenarios/no_repo.rs
+++ b/tests/e2e/scenarios/no_repo.rs
@@ -5,14 +5,15 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
 
-use super::super::helpers::{DaemonHandle, TestEnv};
+use super::super::helpers::DaemonHandle;
+use super::no_repo_fixtures;
 
 const PROMPT_BIN: &str = "merge-ready-prompt";
 
 /// git リポジトリでない場合、何も出力しない
 #[test]
 fn test_no_git_remote_shows_nothing() {
-    let env = TestEnv::without_git_remote();
+    let env = no_repo_fixtures::without_git_remote();
     // daemon を起動して git リポジトリ外クエリを処理させる
     let _daemon = DaemonHandle::start(&env);
 

--- a/tests/e2e/scenarios/no_repo_fixtures.rs
+++ b/tests/e2e/scenarios/no_repo_fixtures.rs
@@ -1,0 +1,13 @@
+use super::super::helpers::{TestEnv, setup_empty_dirs, write_executable};
+
+/// git リポジトリ外シナリオ（`.git` のない空ディレクトリで実行）
+pub fn without_git_remote() -> TestEnv {
+    let (bin, home_tmp, repo) = setup_empty_dirs();
+    let gh_script = "#!/bin/sh\necho 'gh should not be called' >&2\nexit 1\n";
+    write_executable(bin.path().join("gh"), gh_script);
+    TestEnv {
+        bin,
+        home_tmp,
+        repo,
+    }
+}

--- a/tests/e2e/scenarios/terminal_pr.rs
+++ b/tests/e2e/scenarios/terminal_pr.rs
@@ -8,12 +8,13 @@ const PROMPT_BIN: &str = "merge-ready-prompt";
 use assert_cmd::Command;
 use predicates::prelude::*;
 
-use super::super::helpers::{DaemonHandle, TestEnv};
+use super::super::helpers::DaemonHandle;
+use super::terminal_pr_fixtures;
 
 /// #50: closed PR はキャッシュ確定後に再フェッチされない
 #[test]
 fn test_closed_pr_stops_refreshing_after_terminal_state() {
-    let (env, log_path) = TestEnv::with_terminal_pr_call_log("CLOSED");
+    let (env, log_path) = terminal_pr_fixtures::with_terminal_pr_call_log("CLOSED");
     let _daemon = DaemonHandle::start_with_env(&env, &[("MERGE_READY_STALE_TTL", "0")]);
 
     // 初回クエリ: キャッシュミス → ? loading
@@ -47,7 +48,7 @@ fn test_closed_pr_stops_refreshing_after_terminal_state() {
 /// #51: merged PR はキャッシュ確定後に再フェッチされない
 #[test]
 fn test_merged_pr_stops_refreshing_after_terminal_state() {
-    let (env, log_path) = TestEnv::with_terminal_pr_call_log("MERGED");
+    let (env, log_path) = terminal_pr_fixtures::with_terminal_pr_call_log("MERGED");
     let _daemon = DaemonHandle::start_with_env(&env, &[("MERGE_READY_STALE_TTL", "0")]);
 
     // 初回クエリ: ? loading

--- a/tests/e2e/scenarios/terminal_pr_fixtures.rs
+++ b/tests/e2e/scenarios/terminal_pr_fixtures.rs
@@ -1,0 +1,35 @@
+use super::super::helpers::{TestEnv, setup_git_dirs, write_executable};
+
+/// terminal PR シナリオ（呼び出しカウンタ付き）
+///
+/// `gh pr list` が closed / merged JSON を返す。カウンタログファイルのパスを返す。
+pub fn with_terminal_pr_call_log(state: &str) -> (TestEnv, std::path::PathBuf) {
+    let (bin, home_tmp, repo) = setup_git_dirs("feat/my-feature");
+    let log_path = home_tmp.path().join("gh_calls.log");
+    let log = log_path.display().to_string();
+    let pr_list_json = format!(
+        r#"[{{"number":1,"state":"{state}","isDraft":false,"mergeable":"UNKNOWN","mergeStateStatus":"UNKNOWN","reviewDecision":null}}]"#
+    );
+    let script = format!(
+        "#!/bin/sh\n\
+         printf '1' >> \"{log}\"\n\
+         case \"$*\" in\n\
+           *'pr list'*)\n\
+             printf '%s' '{pr_list_json}'\n\
+             ;;\n\
+           *)\n\
+             printf 'unexpected gh call: %s' \"$*\" >&2\n\
+             exit 127\n\
+             ;;\n\
+         esac\n"
+    );
+    write_executable(bin.path().join("gh"), &script);
+    (
+        TestEnv {
+            bin,
+            home_tmp,
+            repo,
+        },
+        log_path,
+    )
+}


### PR DESCRIPTION
## Summary

- `tests/e2e/helpers/env.rs` のシナリオ固有ファクトリメソッド13個を、それぞれ利用するテストファイルの近くに `xxx_fixtures.rs` として分離
- `FakeDaemonHandle` を `helpers/daemon_handle.rs` から `daemon/lifecycle_fixtures.rs` に移動
- `helpers/env.rs` を 577行 → 245行に削減
- `setup_git_dirs` / `setup_empty_dirs` を `pub(crate)` 自由関数として公開し、fixture モジュールが `TestEnv` を重複なく構築できるようにした

## 移動一覧

| 新規ファイル | 移動したもの |
|---|---|
| `prompt/errors_fixtures.rs` | `with_hanging_gh`, `with_invalid_pr_list_json`, `with_invalid_pr_checks_json` |
| `prompt/branch_sync_fixtures.rs` | `with_behind_by`, `with_compare_error`, `with_invalid_repo_view_json` |
| `prompt/ci_checks_fixtures.rs` | `with_no_ci_checks` |
| `scenarios/terminal_pr_fixtures.rs` | `with_terminal_pr_call_log` |
| `scenarios/no_pr_fixtures.rs` | `with_no_pr_stale_delay_ms` |
| `scenarios/default_branch_fixtures.rs` | `with_default_branch_no_pr` |
| `scenarios/no_repo_fixtures.rs` | `without_git_remote` |
| `daemon/lifecycle_fixtures.rs` | `FakeDaemonHandle` |

## helpers/ に残したもの（クロスカテゴリ）

- `TestEnv::new()`, `with_no_pr()`, `with_pr_list()`, `with_error()`, `without_gh()`
- `DaemonHandle`, `MultiRepoEnv`

> `with_error()` と `without_gh()` は `config/` カテゴリ（`edit_command.rs`, `token_customization.rs`）でも使用されているためクロスカテゴリとして残す

## Test plan

- [x] `cargo test --workspace` 311 passed
- [x] `cargo clippy -- -D warnings` no issues
- [x] `cargo fmt --check` OK
- [x] `scripts/check-layer-deps.sh` OK
- [x] `scripts/check-no-mod-rs.sh` OK
- [x] `scripts/check-no-clippy-allow.sh` OK

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)