### PR TITLE
refactor: git.rs の Option<&Path> 引数を &Path に変更してデッドコードを除去

### DIFF
--- a/src/contexts/evaluation/infrastructure/gh.rs
+++ b/src/contexts/evaluation/infrastructure/gh.rs
@@ -22,21 +22,22 @@ use crate::contexts::evaluation::infrastructure::git::{current_branch, is_git_re
 // ── GhClient ────────────────────────────────────────────────────────────────
 
 pub struct GhClient<L> {
-    cwd: Option<std::path::PathBuf>,
+    cwd: std::path::PathBuf,
     logger: L,
 }
 
 impl<L: ErrorLogger + Sync> GhClient<L> {
     #[must_use]
     pub fn new_in(cwd: std::path::PathBuf, logger: L) -> Self {
-        Self {
-            cwd: Some(cwd),
-            logger,
-        }
+        Self { cwd, logger }
     }
 
     fn run_gh(&self, args: &[&str]) -> Result<Vec<u8>, GhError> {
-        run_gh(args, self.cwd.as_deref())
+        run_gh(args, Some(&self.cwd))
+    }
+
+    fn cwd(&self) -> &std::path::Path {
+        &self.cwd
     }
 
     fn log_and_convert(&self, e: GhError) -> RepositoryError {
@@ -75,7 +76,7 @@ impl<L: ErrorLogger + Sync> GhClient<L> {
     }
 
     fn is_default_branch(&self) -> bool {
-        let branch = current_branch(self.cwd.as_deref()).unwrap_or_default();
+        let branch = current_branch(self.cwd()).unwrap_or_default();
         if branch.is_empty() {
             return false;
         }
@@ -83,7 +84,7 @@ impl<L: ErrorLogger + Sync> GhClient<L> {
     }
 
     fn fetch_pr_list(&self) -> Result<Vec<GhPrListItem>, GhError> {
-        let branch = current_branch(self.cwd.as_deref()).unwrap_or_default();
+        let branch = current_branch(self.cwd()).unwrap_or_default();
         let bytes = self.run_gh(&[
             "pr",
             "list",
@@ -130,14 +131,14 @@ impl<L: ErrorLogger + Sync> GhClient<L> {
 
         // branch_sync と ci を並列取得
         let (branch_sync, ci_result) = std::thread::scope(|s| {
-            let cwd = self.cwd.as_deref();
+            let cwd = self.cwd();
             let base = pr_view.base_ref_name.as_str();
             let head = pr_view.head_ref_name.as_str();
             let mergeable = pr_view.mergeable.as_str();
             let pr_number = pr_view.number;
 
             let sync_handle = s.spawn(move || {
-                let behind_by = fetch_behind_by(base, head, cwd);
+                let behind_by = fetch_behind_by(base, head, Some(cwd));
                 translate_sync(mergeable, behind_by)
             });
             let ci_handle = s.spawn(move || self.fetch_ci_state_for(pr_number));
@@ -173,7 +174,7 @@ impl<L: ErrorLogger + Sync> GhClient<L> {
 
 impl<L: ErrorLogger + Sync> PromptRepository for GhClient<L> {
     fn fetch(&self) -> Result<Prompt, RepositoryError> {
-        if !is_git_repo(self.cwd.as_deref()) {
+        if !is_git_repo(self.cwd()) {
             return Ok(Prompt::NoRepository);
         }
 

--- a/src/contexts/evaluation/infrastructure/git.rs
+++ b/src/contexts/evaluation/infrastructure/git.rs
@@ -1,15 +1,8 @@
 use std::path::Path;
 use std::process::{Command, Stdio};
 
-pub fn is_git_repo(cwd: Option<&Path>) -> bool {
-    let base = match cwd {
-        Some(d) => d.to_path_buf(),
-        None => match std::env::current_dir() {
-            Ok(d) => d,
-            Err(_) => return false,
-        },
-    };
-    let mut current = base.as_path();
+pub fn is_git_repo(cwd: &Path) -> bool {
+    let mut current = cwd;
     loop {
         if current.join(".git").exists() {
             return true;
@@ -21,14 +14,14 @@ pub fn is_git_repo(cwd: Option<&Path>) -> bool {
     }
 }
 
-pub fn current_branch(cwd: Option<&Path>) -> Option<String> {
-    let mut cmd = Command::new("git");
-    cmd.args(["branch", "--show-current"]);
-    cmd.stdout(Stdio::piped()).stderr(Stdio::null());
-    if let Some(dir) = cwd {
-        cmd.current_dir(dir);
-    }
-    let out = cmd.output().ok()?;
+pub fn current_branch(cwd: &Path) -> Option<String> {
+    let out = Command::new("git")
+        .args(["branch", "--show-current"])
+        .current_dir(cwd)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
     if out.status.success() {
         Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
     } else {


### PR DESCRIPTION
## Summary

- `is_git_repo` / `current_branch` の引数を `Option<&Path>` → `&Path` に変更
- `GhClient.cwd` を `Option<PathBuf>` → `PathBuf` に変更し、`Option` ラッパーを排除
- 到達不可能だった `None` ブランチ（`std::env::current_dir()` フォールバック）を削除

Closes #293

## Test plan

- [x] `cargo build` 通過
- [x] `cargo clippy --workspace -- -D warnings` 通過
- [x] `cargo fmt --check --all` 通過
- [x] `cargo llvm-cov --test e2e` 120 tests passed（`git.rs` カバレッジ 73.1% → 81.0%）

🤖 Generated with [Claude Code](https://claude.com/claude-code)