### PR TITLE
test: カバレッジ未到達パスをE2E・ユニットテストで補完

### DIFF
--- a/src/contexts/daemon/domain/refresh_policy.rs
+++ b/src/contexts/daemon/domain/refresh_policy.rs
@@ -62,3 +62,118 @@ impl RefreshPolicy {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use crate::contexts::daemon::domain::cache::{CacheEntry, RefreshMode};
+
+    use super::RefreshPolicy;
+
+    fn policy() -> RefreshPolicy {
+        RefreshPolicy {
+            hot_recent_query_secs: 60,
+            hot_with_query_secs: 10,
+            hot_without_query_secs: 30,
+            warm_refresh_secs: 120,
+            warm_to_cold_secs: 300,
+            cold_early_secs: 600,
+            cold_late_secs: 3600,
+            cold_early_limit: 5,
+        }
+    }
+
+    fn entry_with_mode(mode: RefreshMode) -> CacheEntry {
+        let mut e = CacheEntry::new(PathBuf::from("/tmp/test"), "branch".into(), 0);
+        e.update("output".into(), vec![], mode);
+        e
+    }
+
+    #[test]
+    fn terminal_returns_u64_max() {
+        let p = policy();
+        let e = entry_with_mode(RefreshMode::Terminal);
+        assert_eq!(p.effective_refresh_interval_secs(&e), u64::MAX);
+    }
+
+    #[test]
+    fn hot_with_recent_query_returns_hot_with_query_secs() {
+        let mut p = policy();
+        p.hot_recent_query_secs = u64::MAX;
+        let e = entry_with_mode(RefreshMode::Hot);
+        assert_eq!(p.effective_refresh_interval_secs(&e), p.hot_with_query_secs);
+    }
+
+    #[test]
+    fn warm_with_recent_query_returns_hot_with_query_secs() {
+        let mut p = policy();
+        p.hot_recent_query_secs = u64::MAX;
+        let e = entry_with_mode(RefreshMode::Warm);
+        assert_eq!(p.effective_refresh_interval_secs(&e), p.hot_with_query_secs);
+    }
+
+    #[test]
+    fn effective_ttl_terminal_returns_warm_refresh_secs() {
+        let p = policy();
+        let e = entry_with_mode(RefreshMode::Terminal);
+        assert_eq!(p.effective_ttl(&e, 999), p.warm_refresh_secs);
+    }
+
+    #[test]
+    fn effective_ttl_non_terminal_returns_base_ttl() {
+        let p = policy();
+        let e = entry_with_mode(RefreshMode::Warm);
+        assert_eq!(p.effective_ttl(&e, 999), 999);
+    }
+
+    // These tests need last_queried_at to be > 0 seconds old.
+    // CacheEntry::new sets last_queried_at = Some(Instant::now()), so we sleep 1 second.
+    // nextest runs tests in parallel processes, so all 1-second tests complete in ~1s total.
+
+    #[test]
+    fn hot_without_recent_query_returns_hot_without_query_secs() {
+        let mut p = policy();
+        p.hot_recent_query_secs = 0;
+        let e = entry_with_mode(RefreshMode::Hot);
+        std::thread::sleep(std::time::Duration::from_secs(1));
+        assert_eq!(
+            p.effective_refresh_interval_secs(&e),
+            p.hot_without_query_secs
+        );
+    }
+
+    #[test]
+    fn warm_not_cold_returns_warm_refresh_secs() {
+        let mut p = policy();
+        p.hot_recent_query_secs = 0;
+        p.warm_to_cold_secs = u64::MAX;
+        let e = entry_with_mode(RefreshMode::Warm);
+        std::thread::sleep(std::time::Duration::from_secs(1));
+        assert_eq!(p.effective_refresh_interval_secs(&e), p.warm_refresh_secs);
+    }
+
+    #[test]
+    fn warm_cold_early_returns_cold_early_secs() {
+        let mut p = policy();
+        p.hot_recent_query_secs = 0;
+        p.warm_to_cold_secs = 0;
+        p.cold_early_limit = 5;
+        // cold_refresh_count starts at 0 < 5 → early branch
+        let e = entry_with_mode(RefreshMode::Warm);
+        std::thread::sleep(std::time::Duration::from_secs(1));
+        assert_eq!(p.effective_refresh_interval_secs(&e), p.cold_early_secs);
+    }
+
+    #[test]
+    fn warm_cold_late_returns_cold_late_secs() {
+        let mut p = policy();
+        p.hot_recent_query_secs = 0;
+        p.warm_to_cold_secs = 0;
+        p.cold_early_limit = 0;
+        // cold_refresh_count starts at 0 >= 0 → late branch
+        let e = entry_with_mode(RefreshMode::Warm);
+        std::thread::sleep(std::time::Duration::from_secs(1));
+        assert_eq!(p.effective_refresh_interval_secs(&e), p.cold_late_secs);
+    }
+}

--- a/src/contexts/daemon/infrastructure/daemon_lifecycle.rs
+++ b/src/contexts/daemon/infrastructure/daemon_lifecycle.rs
@@ -92,35 +92,11 @@ impl WatchPort for DaemonLifecycle {
 
 #[cfg(test)]
 mod tests {
-    use super::{terminate_and_wait, wait_or_terminate};
+    use super::terminate_and_wait;
 
     #[test]
     fn terminate_and_wait_nonexistent_pid_returns_false() {
         // kill -TERM u32::MAX → fails (no such process) → signalled=false → false immediately
         assert!(!terminate_and_wait(u32::MAX));
-    }
-
-    #[test]
-    fn wait_or_terminate_falls_back_to_sigterm_when_not_responding() {
-        // Spawn a process that ignores SIGTERM.
-        // wait_or_terminate → wait_until_gone times out (STOP_TIMEOUT=50ms in tests)
-        // → terminate_and_wait sends SIGTERM (ignored) → wait_until_gone times out again → false.
-        let mut child = std::process::Command::new("sh")
-            .args(["-c", "trap '' TERM; sleep 100"])
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .spawn()
-            .expect("spawn sh");
-        let pid = child.id();
-
-        let result = wait_or_terminate(pid);
-        assert!(
-            !result,
-            "SIGTERM-ignoring process should cause false return"
-        );
-
-        child.kill().ok();
-        child.wait().ok();
     }
 }

--- a/src/contexts/daemon/infrastructure/daemon_lifecycle.rs
+++ b/src/contexts/daemon/infrastructure/daemon_lifecycle.rs
@@ -8,7 +8,10 @@ use crate::contexts::daemon::domain::daemon::{DaemonError, DaemonLifecyclePort, 
 use super::{daemon_client::DaemonClient, daemon_server, pid};
 
 type RefreshCallback = dyn Fn(&RepoId, &std::path::Path) + Send + Sync + 'static;
+#[cfg(not(test))]
 const STOP_TIMEOUT: Duration = Duration::from_secs(2);
+#[cfg(test)]
+const STOP_TIMEOUT: Duration = Duration::from_millis(50);
 
 pub struct DaemonLifecycle {
     on_refresh: Arc<RefreshCallback>,
@@ -84,5 +87,40 @@ impl WatchPort for DaemonLifecycle {
                 })
                 .collect()
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{terminate_and_wait, wait_or_terminate};
+
+    #[test]
+    fn terminate_and_wait_nonexistent_pid_returns_false() {
+        // kill -TERM u32::MAX → fails (no such process) → signalled=false → false immediately
+        assert!(!terminate_and_wait(u32::MAX));
+    }
+
+    #[test]
+    fn wait_or_terminate_falls_back_to_sigterm_when_not_responding() {
+        // Spawn a process that ignores SIGTERM.
+        // wait_or_terminate → wait_until_gone times out (STOP_TIMEOUT=50ms in tests)
+        // → terminate_and_wait sends SIGTERM (ignored) → wait_until_gone times out again → false.
+        let mut child = std::process::Command::new("sh")
+            .args(["-c", "trap '' TERM; sleep 100"])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn sh");
+        let pid = child.id();
+
+        let result = wait_or_terminate(pid);
+        assert!(
+            !result,
+            "SIGTERM-ignoring process should cause false return"
+        );
+
+        child.kill().ok();
+        child.wait().ok();
     }
 }

--- a/src/contexts/daemon/infrastructure/socket_listener.rs
+++ b/src/contexts/daemon/infrastructure/socket_listener.rs
@@ -63,3 +63,35 @@ pub(super) fn bind(socket_path: &std::path::Path) -> Result<UnixListener, Daemon
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use crate::contexts::daemon::domain::daemon::DaemonError;
+
+    use super::{bind, paths, pid};
+
+    #[test]
+    fn bind_returns_failure_when_socket_path_exceeds_os_limit() {
+        // Skip when a real daemon is already running: bind() reads the global PID file
+        // and returns AlreadyRunning before reaching the socket-bind step (Issue #299).
+        if pid::read().is_some_and(pid::is_alive) {
+            return;
+        }
+
+        // Ensure the lock file's parent directory exists; bind() opens
+        // paths::lock_path() (TMPDIR/merge-ready/daemon.lock) before binding the socket.
+        let _ = std::fs::create_dir_all(paths::base_dir());
+
+        // Unix socket paths are limited to ~104 bytes (macOS) / ~108 bytes (Linux).
+        // A 205-char path exceeds both limits, causing UnixListener::bind to fail
+        // with ENAMETOOLONG — not AddrInUse — which exercises lines 58–61.
+        let socket_path = format!("/tmp/{}", "a".repeat(200));
+        let result = bind(Path::new(&socket_path));
+        assert!(
+            matches!(result, Err(DaemonError::Failure)),
+            "expected Failure for oversized path, got: {result:?}"
+        );
+    }
+}

--- a/src/contexts/daemon/interface/cli/watch.rs
+++ b/src/contexts/daemon/interface/cli/watch.rs
@@ -316,4 +316,71 @@ mod tests {
     fn format_elapsed_various_durations(#[case] elapsed_secs: u64, #[case] expected: &str) {
         assert_eq!(format_elapsed(elapsed_secs), expected);
     }
+
+    // ── draw() and run() with mock WatchPort ─────────────────────────────────
+
+    struct EntryPort;
+    impl WatchPort for EntryPort {
+        fn entries(&self) -> Option<Vec<EntryView>> {
+            Some(vec![EntryView {
+                cwd: "/repo".to_owned(),
+                branch: "main".to_owned(),
+                pr_id: Some(1),
+                output: "ok".to_owned(),
+                cached_at_secs: 0,
+            }])
+        }
+    }
+
+    #[test]
+    fn draw_returns_true_when_entries_present() {
+        assert!(draw(&EntryPort));
+    }
+
+    struct TwoShotPort {
+        count: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    }
+    impl WatchPort for TwoShotPort {
+        fn entries(&self) -> Option<Vec<EntryView>> {
+            let n = self
+                .count
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            if n == 0 {
+                // First call: return entries → draw returns true → loop continues (lines 20–21)
+                Some(vec![EntryView {
+                    cwd: "/r".to_owned(),
+                    branch: "b".to_owned(),
+                    pr_id: None,
+                    output: "ok".to_owned(),
+                    cached_at_secs: 0,
+                }])
+            } else {
+                // Second call: no entries → draw returns false → run() exits
+                None
+            }
+        }
+    }
+
+    #[test]
+    fn run_loops_and_exits_when_entries_become_unavailable() {
+        // Takes ~1 second due to POLL_INTERVAL between iterations.
+        let call_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let port = TwoShotPort {
+            count: std::sync::Arc::clone(&call_count),
+        };
+        run(&port);
+        assert_eq!(
+            call_count.load(std::sync::atomic::Ordering::Relaxed),
+            2,
+            "run() should call entries() twice: once returning Some, once None"
+        );
+    }
+
+    // ── visible_len: ANSI escape sequence stripping ───────────────────────────
+
+    #[test]
+    fn visible_len_excludes_ansi_escape_sequences() {
+        // "\x1b[32m" starts a green color sequence terminated by "m"; only "hello" is visible
+        assert_eq!(visible_len("\x1b[32mhello\x1b[m"), 5);
+    }
 }

--- a/src/contexts/evaluation/interface/cli/config/edit.rs
+++ b/src/contexts/evaluation/interface/cli/config/edit.rs
@@ -34,3 +34,26 @@ fn ensure_config_file(path: &Path) -> Result<(), std::io::Error> {
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
     std::fs::write(path, content.as_bytes())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ensure_config_file;
+
+    #[test]
+    fn ensure_config_file_creates_parent_directory_when_missing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let config_path = tmp.path().join("subdir").join("merge-ready.toml");
+        assert!(
+            !config_path.parent().unwrap().exists(),
+            "precondition: parent dir must not exist yet"
+        );
+
+        ensure_config_file(&config_path).expect("ensure_config_file");
+
+        assert!(
+            config_path.parent().unwrap().exists(),
+            "parent directory should be created by create_dir_all"
+        );
+        assert!(config_path.exists(), "config file should be created");
+    }
+}

--- a/tests/e2e/scenarios/cold_mode.rs
+++ b/tests/e2e/scenarios/cold_mode.rs
@@ -8,7 +8,7 @@
 //! - `CacheEntry::increment_cold_count`
 //! - `CacheEntry::is_cold`
 //! - `CacheEntry::cold_refresh_count` (read in `cold_interval_secs`)
-//! - `RefreshPolicy::effective_refresh_interval_secs` の Warm + is_cold 分岐
+//! - `RefreshPolicy::effective_refresh_interval_secs` の Warm + `is_cold` 分岐
 //! - `RefreshPolicy::cold_interval_secs` の Cold late 分岐
 
 const PROMPT_BIN: &str = "merge-ready-prompt";
@@ -49,7 +49,7 @@ fn test_cold_mode_continues_refreshing_without_queries() {
     DaemonHandle::wait_for_cache(&env, 5000);
 
     // Query を送らずに 3 秒待機（warm_to_cold_secs=0 で即 Cold → cold_early/late_secs=0 で毎 tick）
-    std::thread::sleep(std::time::Duration::from_millis(3000));
+    std::thread::sleep(std::time::Duration::from_secs(3));
 
     // gh が 2 回以上呼ばれていること（Cold モードでも自動リフレッシュが継続）
     let call_log = std::fs::read_to_string(&log_path).unwrap_or_default();

--- a/tests/e2e/scenarios/cold_mode.rs
+++ b/tests/e2e/scenarios/cold_mode.rs
@@ -1,0 +1,61 @@
+//! Warm → Cold モード遷移シナリオ
+//!
+//! `MERGE_READY_WARM_TO_COLD_SECS=0` で Query がなくなると即 Cold に移行する。
+//! Cold モードでも `COLD_EARLY_SECS=0` / `COLD_LATE_SECS=0` によりスケジューラ tick ごとに
+//! リフレッシュが発生することを gh 呼び出し回数で検証する。
+//!
+//! カバー:
+//! - `CacheEntry::increment_cold_count`
+//! - `CacheEntry::is_cold`
+//! - `CacheEntry::cold_refresh_count` (read in `cold_interval_secs`)
+//! - `RefreshPolicy::effective_refresh_interval_secs` の Warm + is_cold 分岐
+//! - `RefreshPolicy::cold_interval_secs` の Cold late 分岐
+
+const PROMPT_BIN: &str = "merge-ready-prompt";
+
+use assert_cmd::cargo::cargo_bin;
+
+use super::super::helpers::{DaemonHandle, run_prompt_with_timeout};
+use super::cold_mode_fixtures;
+
+/// Query がなくても Cold モードでリフレッシュが継続する
+#[test]
+fn test_cold_mode_continues_refreshing_without_queries() {
+    let (env, log_path) = cold_mode_fixtures::with_open_pr_call_log();
+    let _daemon = DaemonHandle::start_with_env(
+        &env,
+        &[
+            ("MERGE_READY_WARM_TO_COLD_SECS", "0"),
+            ("MERGE_READY_COLD_EARLY_SECS", "0"),
+            ("MERGE_READY_COLD_EARLY_LIMIT", "1"),
+            ("MERGE_READY_COLD_LATE_SECS", "0"),
+            ("MERGE_READY_STALE_TTL", "0"),
+            ("MERGE_READY_SCHEDULER_TICK_SECS", "1"),
+        ],
+    );
+
+    let bin = cargo_bin(PROMPT_BIN);
+
+    // 初回クエリ
+    run_prompt_with_timeout(
+        std::process::Command::new(&bin)
+            .env("PATH", env.path_env())
+            .env("HOME", env.home())
+            .env("TMPDIR", env.home())
+            .current_dir(env.repo.path()),
+    );
+
+    // キャッシュ温まるまで待つ
+    DaemonHandle::wait_for_cache(&env, 5000);
+
+    // Query を送らずに 3 秒待機（warm_to_cold_secs=0 で即 Cold → cold_early/late_secs=0 で毎 tick）
+    std::thread::sleep(std::time::Duration::from_millis(3000));
+
+    // gh が 2 回以上呼ばれていること（Cold モードでも自動リフレッシュが継続）
+    let call_log = std::fs::read_to_string(&log_path).unwrap_or_default();
+    assert!(
+        call_log.len() > 1,
+        "Cold モードで gh が 2 回以上呼ばれるはず（実際: {} 回）",
+        call_log.len()
+    );
+}

--- a/tests/e2e/scenarios/cold_mode_fixtures.rs
+++ b/tests/e2e/scenarios/cold_mode_fixtures.rs
@@ -1,0 +1,43 @@
+use super::super::helpers::{TestEnv, setup_git_dirs, write_executable};
+
+/// Cold モード遷移シナリオ用 fixture。
+///
+/// 通常の OPEN PR を返す。`gh` 呼び出しのたびにログファイルに `1` を追記する。
+pub fn with_open_pr_call_log() -> (TestEnv, std::path::PathBuf) {
+    let (bin, home_tmp, repo) = setup_git_dirs("feat/my-feature");
+    let log_path = home_tmp.path().join("gh_calls.log");
+    let log = log_path.display().to_string();
+
+    let pr_list_json = r#"[{"number":1,"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}]"#;
+    let ci_pass_json = r#"[{"bucket":"pass","state":"SUCCESS","name":"ci","link":""}]"#;
+
+    let script = format!(
+        "#!/bin/sh\n\
+         printf '1' >> \"{log}\"\n\
+         case \"$*\" in\n\
+           *'pr list'*)\n\
+             printf '%s' '{pr_list_json}'\n\
+             ;;\n\
+           *'pr checks'*)\n\
+             printf '%s' '{ci_pass_json}'\n\
+             ;;\n\
+           *'api'*'compare'*)\n\
+             printf '{{\"behind_by\":0}}'\n\
+             ;;\n\
+           *)\n\
+             printf 'unknown gh command: %s' \"$*\" >&2\n\
+             exit 127\n\
+             ;;\n\
+         esac\n"
+    );
+
+    write_executable(bin.path().join("gh"), &script);
+    (
+        TestEnv {
+            bin,
+            home_tmp,
+            repo,
+        },
+        log_path,
+    )
+}

--- a/tests/e2e/scenarios/entry_eviction.rs
+++ b/tests/e2e/scenarios/entry_eviction.rs
@@ -1,0 +1,51 @@
+//! キャッシュエントリ自動削除シナリオ
+//!
+//! `MERGE_READY_ENTRY_MAX_AGE_SECS=0` により最終 Query からすぐにエントリが期限切れとなる。
+//! スケジューラ tick で `retain` が動き、次のクエリでエントリが存在しないため
+//! `? loading` に戻ることを確認する。
+//!
+//! カバー: `CacheEntry::is_expired`, `background_refresh::collect_targets` の eviction ループ
+
+const PROMPT_BIN: &str = "merge-ready-prompt";
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+use super::super::helpers::{DaemonHandle, TestEnv};
+
+const OPEN_PR_VIEW_JSON: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}"#;
+const CI_PASS_JSON: &str = r#"[{"bucket":"pass","state":"SUCCESS","name":"ci","link":""}]"#;
+
+/// エントリ期限切れ → 次クエリで再び `? loading` が返される
+#[test]
+fn test_entry_expires_and_shows_loading_again() {
+    let env = TestEnv::new(OPEN_PR_VIEW_JSON, Some(CI_PASS_JSON));
+    let _daemon = DaemonHandle::start_with_env(
+        &env,
+        &[
+            ("MERGE_READY_ENTRY_MAX_AGE_SECS", "0"),
+            ("MERGE_READY_SCHEDULER_TICK_SECS", "1"),
+            ("MERGE_READY_STALE_TTL", "0"),
+        ],
+    );
+
+    // 初回クエリ: ミス → ? loading
+    let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
+    env.apply_with_cache(&mut cmd);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::diff("? loading"));
+
+    // キャッシュ温まるまで待つ
+    DaemonHandle::wait_for_cache(&env, 5000);
+
+    // スケジューラが entry_max_age_secs=0 で evict するまで待機（1.5 tick 分）
+    std::thread::sleep(std::time::Duration::from_millis(1500));
+
+    // エントリが削除されているので再び ? loading が返る
+    let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
+    env.apply_with_cache(&mut cmd);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::diff("? loading"));
+}

--- a/tests/e2e/scenarios/git_subdir.rs
+++ b/tests/e2e/scenarios/git_subdir.rs
@@ -1,0 +1,59 @@
+//! Git サブディレクトリ探索シナリオ
+//!
+//! `.git` の直親でなく、その内部サブディレクトリから実行した場合でも
+//! `is_git_repo` が親ディレクトリを遡って `.git` を検出することを確認する。
+//!
+//! カバー:
+//! - `evaluation::infrastructure::git::is_git_repo` の `Some(p) => current = p` 分岐
+
+const PROMPT_BIN: &str = "merge-ready-prompt";
+
+use assert_cmd::cargo::cargo_bin;
+
+use super::super::helpers::{DaemonHandle, TestEnv, run_prompt_with_timeout};
+
+const OPEN_PR_VIEW_JSON: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}"#;
+const CI_PASS_JSON: &str = r#"[{"bucket":"pass","state":"SUCCESS","name":"ci","link":""}]"#;
+
+/// リポジトリのサブディレクトリから実行しても PR 出力が得られる
+#[test]
+fn test_prompt_from_git_subdirectory() {
+    let env = TestEnv::new(OPEN_PR_VIEW_JSON, Some(CI_PASS_JSON));
+
+    // repo 内にサブディレクトリを作成
+    let subdir = env.repo.path().join("src").join("nested");
+    std::fs::create_dir_all(&subdir).expect("create subdir");
+
+    let _daemon = DaemonHandle::start(&env);
+
+    let bin = cargo_bin(PROMPT_BIN);
+
+    // サブディレクトリから merge-ready-prompt を実行
+    // is_git_repo が .git を祖先ディレクトリで検出するパスを通る
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(5000);
+    loop {
+        let out = run_prompt_with_timeout(
+            std::process::Command::new(&bin)
+                .env("PATH", env.path_env())
+                .env("HOME", env.home())
+                .env("TMPDIR", env.home())
+                .current_dir(&subdir),
+        );
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let s = stdout.trim();
+        if s != "? loading" {
+            assert!(
+                out.status.success(),
+                "merge-ready-prompt should succeed from subdir"
+            );
+            // サブディレクトリでも PR 出力が得られること
+            assert!(!s.is_empty(), "subdir から実行しても PR 出力が得られるはず");
+            return;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "subdir からの PR 出力が 5000ms 以内に得られなかった"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+}

--- a/tests/e2e/scenarios/git_subdir.rs
+++ b/tests/e2e/scenarios/git_subdir.rs
@@ -30,7 +30,7 @@ fn test_prompt_from_git_subdirectory() {
 
     // サブディレクトリから merge-ready-prompt を実行
     // is_git_repo が .git を祖先ディレクトリで検出するパスを通る
-    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(5000);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
     loop {
         let out = run_prompt_with_timeout(
             std::process::Command::new(&bin)

--- a/tests/e2e/scenarios/hot_mode.rs
+++ b/tests/e2e/scenarios/hot_mode.rs
@@ -55,7 +55,7 @@ fn test_hot_mode_refreshes_multiple_times() {
     }
 
     // スケジューラ 2 tick 分（2 秒）待機
-    std::thread::sleep(std::time::Duration::from_millis(2000));
+    std::thread::sleep(std::time::Duration::from_secs(2));
 
     // gh が 2 回以上呼ばれていること（Hot モードで再フェッチが発生）
     let call_log = std::fs::read_to_string(&log_path).unwrap_or_default();

--- a/tests/e2e/scenarios/hot_mode.rs
+++ b/tests/e2e/scenarios/hot_mode.rs
@@ -1,0 +1,67 @@
+//! Hot モード高速リフレッシュシナリオ
+//!
+//! CI 実行中（pending）の PR → `RefreshMode::Hot` → スケジューラ tick ごとに再フェッチ。
+//! `HOT_WITH_QUERY_SECS=0` により直近 Query あり Hot エントリは毎 tick リフレッシュされる。
+//!
+//! カバー:
+//! - `RefreshPolicy::effective_refresh_interval_secs` の Hot 分岐
+//! - `CacheEntry::has_recent_query` (true パス)
+//! - `background_refresh::collect_targets` の interval チェック到達
+
+const PROMPT_BIN: &str = "merge-ready-prompt";
+
+use assert_cmd::cargo::cargo_bin;
+
+use super::super::helpers::{DaemonHandle, run_prompt_with_timeout};
+use super::hot_mode_fixtures;
+
+/// CI pending の Hot モードエントリがスケジューラ tick で複数回リフレッシュされる
+#[test]
+fn test_hot_mode_refreshes_multiple_times() {
+    let (env, log_path) = hot_mode_fixtures::with_ci_pending_call_log();
+    let _daemon = DaemonHandle::start_with_env(
+        &env,
+        &[
+            ("MERGE_READY_HOT_WITH_QUERY_SECS", "0"),
+            ("MERGE_READY_HOT_WITHOUT_QUERY_SECS", "0"),
+            ("MERGE_READY_STALE_TTL", "0"),
+            ("MERGE_READY_SCHEDULER_TICK_SECS", "1"),
+        ],
+    );
+
+    let bin = cargo_bin(PROMPT_BIN);
+
+    // 初回クエリ
+    run_prompt_with_timeout(
+        std::process::Command::new(&bin)
+            .env("PATH", env.path_env())
+            .env("HOME", env.home())
+            .env("TMPDIR", env.home())
+            .current_dir(env.repo.path()),
+    );
+
+    // キャッシュ温まるまで待つ（CI pending 出力）
+    DaemonHandle::wait_for_cache(&env, 5000);
+
+    // has_recent_query を true に保つためクエリを繰り返す
+    for _ in 0..3 {
+        run_prompt_with_timeout(
+            std::process::Command::new(&bin)
+                .env("PATH", env.path_env())
+                .env("HOME", env.home())
+                .env("TMPDIR", env.home())
+                .current_dir(env.repo.path()),
+        );
+    }
+
+    // スケジューラ 2 tick 分（2 秒）待機
+    std::thread::sleep(std::time::Duration::from_millis(2000));
+
+    // gh が 2 回以上呼ばれていること（Hot モードで再フェッチが発生）
+    let call_log = std::fs::read_to_string(&log_path).unwrap_or_default();
+    assert!(
+        call_log.len() > 1,
+        "Hot モードで gh が 2 回以上呼ばれるはず（実際: {} 回）",
+        call_log.len()
+    );
+}

--- a/tests/e2e/scenarios/hot_mode_fixtures.rs
+++ b/tests/e2e/scenarios/hot_mode_fixtures.rs
@@ -1,0 +1,44 @@
+use super::super::helpers::{TestEnv, setup_git_dirs, write_executable};
+
+/// Hot モード（CI 実行中）シナリオ用 fixture。
+///
+/// `gh pr list` は CI pending 状態の OPEN PR を返す。
+/// `gh` 呼び出しのたびにログファイルに `1` を追記してカウントを記録する。
+pub fn with_ci_pending_call_log() -> (TestEnv, std::path::PathBuf) {
+    let (bin, home_tmp, repo) = setup_git_dirs("feat/my-feature");
+    let log_path = home_tmp.path().join("gh_calls.log");
+    let log = log_path.display().to_string();
+
+    let pr_list_json = r#"[{"number":1,"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}]"#;
+    let ci_pending_json = r#"[{"bucket":"pending","state":"IN_PROGRESS","name":"ci","link":""}]"#;
+
+    let script = format!(
+        "#!/bin/sh\n\
+         printf '1' >> \"{log}\"\n\
+         case \"$*\" in\n\
+           *'pr list'*)\n\
+             printf '%s' '{pr_list_json}'\n\
+             ;;\n\
+           *'pr checks'*)\n\
+             printf '%s' '{ci_pending_json}'\n\
+             ;;\n\
+           *'api'*'compare'*)\n\
+             printf '{{\"behind_by\":0}}'\n\
+             ;;\n\
+           *)\n\
+             printf 'unknown gh command: %s' \"$*\" >&2\n\
+             exit 127\n\
+             ;;\n\
+         esac\n"
+    );
+
+    write_executable(bin.path().join("gh"), &script);
+    (
+        TestEnv {
+            bin,
+            home_tmp,
+            repo,
+        },
+        log_path,
+    )
+}

--- a/tests/e2e/scenarios/mod.rs
+++ b/tests/e2e/scenarios/mod.rs
@@ -1,6 +1,12 @@
 mod cache_hit;
+mod cold_mode;
+mod cold_mode_fixtures;
 mod default_branch;
 mod default_branch_fixtures;
+mod entry_eviction;
+mod git_subdir;
+mod hot_mode;
+mod hot_mode_fixtures;
 mod initial_load;
 mod multi_repo;
 mod multiple_prs;
@@ -12,3 +18,5 @@ mod no_repo_fixtures;
 mod stale;
 mod terminal_pr;
 mod terminal_pr_fixtures;
+mod terminal_pr_reset;
+mod terminal_pr_reset_fixtures;

--- a/tests/e2e/scenarios/terminal_pr_reset.rs
+++ b/tests/e2e/scenarios/terminal_pr_reset.rs
@@ -1,0 +1,79 @@
+//! Terminal PR 再オープンシナリオ
+//!
+//! MERGED → Terminal キャッシュ → stale → `reset_to_warm()` → 再フェッチ → OPEN PR 表示。
+//!
+//! カバー:
+//! - `CacheEntry::reset_to_warm`
+//! - `request_handler` の Terminal stale パス
+//! - `RefreshPolicy::effective_ttl` の Terminal 分岐
+
+const PROMPT_BIN: &str = "merge-ready-prompt";
+
+use assert_cmd::cargo::cargo_bin;
+
+use super::super::helpers::{DaemonHandle, run_prompt_with_timeout};
+use super::terminal_pr_reset_fixtures;
+
+/// MERGED PR がキャッシュされた後に re-open されると出力が再表示される
+#[test]
+fn test_terminal_pr_reset_to_warm_after_reopen() {
+    let env = terminal_pr_reset_fixtures::with_merged_then_open_pr();
+    let _daemon = DaemonHandle::start_with_env(
+        &env,
+        &[
+            ("MERGE_READY_STALE_TTL", "0"),
+            ("MERGE_READY_WARM_REFRESH_SECS", "0"),
+            ("MERGE_READY_SCHEDULER_TICK_SECS", "1"),
+        ],
+    );
+
+    // 初回クエリ: ミス → ? loading
+    let bin = cargo_bin(PROMPT_BIN);
+    let out = run_prompt_with_timeout(
+        std::process::Command::new(&bin)
+            .env("PATH", env.path_env())
+            .env("HOME", env.home())
+            .env("TMPDIR", env.home())
+            .current_dir(env.repo.path()),
+    );
+    assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), "? loading");
+
+    // キャッシュ確定（MERGED → Terminal → 空出力）を待つ
+    DaemonHandle::wait_for_cache(&env, 5000);
+
+    // stale Terminal エントリへのクエリ → reset_to_warm() 発火 → 再フェッチ予約
+    run_prompt_with_timeout(
+        std::process::Command::new(&bin)
+            .env("PATH", env.path_env())
+            .env("HOME", env.home())
+            .env("TMPDIR", env.home())
+            .current_dir(env.repo.path()),
+    );
+
+    // 再フェッチ完了（OPEN PR）で出力が非空になるまでポーリング
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(5000);
+    loop {
+        let out = run_prompt_with_timeout(
+            std::process::Command::new(&bin)
+                .env("PATH", env.path_env())
+                .env("HOME", env.home())
+                .env("TMPDIR", env.home())
+                .current_dir(env.repo.path()),
+        );
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let s = stdout.trim();
+        if !s.is_empty() && s != "? loading" {
+            // OPEN PR → 何らかの PR 出力が表示されるはず
+            assert!(
+                out.status.success(),
+                "merge-ready-prompt should succeed after re-open"
+            );
+            return;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "re-opened PR output did not appear within 5000ms"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+}

--- a/tests/e2e/scenarios/terminal_pr_reset.rs
+++ b/tests/e2e/scenarios/terminal_pr_reset.rs
@@ -51,7 +51,7 @@ fn test_terminal_pr_reset_to_warm_after_reopen() {
     );
 
     // 再フェッチ完了（OPEN PR）で出力が非空になるまでポーリング
-    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(5000);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
     loop {
         let out = run_prompt_with_timeout(
             std::process::Command::new(&bin)

--- a/tests/e2e/scenarios/terminal_pr_reset_fixtures.rs
+++ b/tests/e2e/scenarios/terminal_pr_reset_fixtures.rs
@@ -1,0 +1,45 @@
+use super::super::helpers::{TestEnv, setup_git_dirs, write_executable};
+
+/// Terminal PR 再オープンシナリオ用 fixture。
+///
+/// 1 回目の `gh pr list` 呼び出しでは MERGED PR を返し、
+/// 2 回目以降は OPEN + CLEAN + CI pass の PR を返す。
+/// カウンタはホームディレクトリ内のファイルで管理する。
+pub fn with_merged_then_open_pr() -> TestEnv {
+    let (bin, home_tmp, repo) = setup_git_dirs("feat/my-feature");
+    let home = home_tmp.path().display().to_string();
+
+    let script = format!(
+        "#!/bin/sh\n\
+         COUNT_FILE=\"{home}/gh_call_count\"\n\
+         count=$(cat \"$COUNT_FILE\" 2>/dev/null || printf '0')\n\
+         count=$((count + 1))\n\
+         printf '%s' \"$count\" > \"$COUNT_FILE\"\n\
+         case \"$*\" in\n\
+           *'pr list'*)\n\
+             if [ \"$count\" -le 1 ]; then\n\
+               printf '[{{\"number\":1,\"state\":\"MERGED\",\"isDraft\":false,\"mergeable\":\"UNKNOWN\",\"mergeStateStatus\":\"UNKNOWN\",\"reviewDecision\":null}}]'\n\
+             else\n\
+               printf '[{{\"number\":1,\"state\":\"OPEN\",\"isDraft\":false,\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"reviewDecision\":null}}]'\n\
+             fi\n\
+             ;;\n\
+           *'pr checks'*)\n\
+             printf '[{{\"bucket\":\"pass\",\"state\":\"SUCCESS\",\"name\":\"ci\",\"link\":\"\"}}]'\n\
+             ;;\n\
+           *'api'*'compare'*)\n\
+             printf '{{\"behind_by\":0}}'\n\
+             ;;\n\
+           *)\n\
+             printf 'unknown gh command: %s' \"$*\" >&2\n\
+             exit 127\n\
+             ;;\n\
+         esac\n"
+    );
+
+    write_executable(bin.path().join("gh"), &script);
+    TestEnv {
+        bin,
+        home_tmp,
+        repo,
+    }
+}


### PR DESCRIPTION
## Summary

- `refresh_policy.rs` / `background_refresh.rs` / `cache/entry.rs` の Hot・Warm・Cold 各分岐を E2E テスト（5 本）でカバー
- `evaluation/infrastructure/git.rs` の親ディレクトリ探索を E2E テストでカバー
- `watch.rs` / `edit.rs` / `socket_listener.rs` の到達困難パスをユニットテストでカバー

### 追加した E2E テスト（`tests/e2e/scenarios/`）

| ファイル | カバー対象 |
|---|---|
| `entry_eviction.rs` | `is_expired`、eviction ループ |
| `terminal_pr_reset.rs` | `reset_to_warm`、Terminal stale → 再フェッチ |
| `hot_mode.rs` | `RefreshMode::Hot`、`has_recent_query` (true) |
| `cold_mode.rs` | `increment_cold_count`、Cold 初期/後期分岐 |
| `git_subdir.rs` | `is_git_repo` の親ディレクトリ探索 |

### 追加したユニットテスト

| ファイル | テスト |
|---|---|
| `watch.rs` | `draw()` Some 分岐・`run()` ループ継続・`visible_len()` ANSI 除去 |
| `edit.rs` | `ensure_config_file` が親ディレクトリを作成する |
| `socket_listener.rs` | オーバーサイズパスでの bind 失敗（デーモン実行中はスキップ、Issue #299） |

### 設計上テスト不可と判断した箇所（別 Issue で対応）

- `socket_listener.rs` lock_path ハードコード → Issue #299
- `daemon_lifecycle.rs` PID path 注入不可 → Issue #300
- `DaemonLifecycle::entries` DaemonClient 注入不可 → Issue #301
- `restart::restart_once` 副作用結合 → Issue #302
- `edit::run` エディタパス env var 依存 → Issue #303

## Test plan

- [x] `cargo nextest run --workspace` — 261 passed
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — No issues
- [x] `cargo fmt --check --all` — No diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)