### PR TITLE
refactor: edit::run のエディタパスを引数で受け取りユニットテストを可能にする

### DIFF
--- a/src/contexts/evaluation/interface/cli/config.rs
+++ b/src/contexts/evaluation/interface/cli/config.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsString;
 use std::path::Path;
 use std::process::ExitCode;
 
@@ -10,7 +11,10 @@ pub fn run(config_path: Option<&Path>) -> ExitCode {
         );
         return ExitCode::FAILURE;
     };
-    if let Err(e) = edit::run(path) {
+    let editor = std::env::var_os("VISUAL")
+        .or_else(|| std::env::var_os("EDITOR"))
+        .unwrap_or_else(|| OsString::from("vi"));
+    if let Err(e) = edit::run(path, &editor) {
         eprintln!("failed to edit config: {e}");
         return ExitCode::FAILURE;
     }

--- a/src/contexts/evaluation/interface/cli/config/edit.rs
+++ b/src/contexts/evaluation/interface/cli/config/edit.rs
@@ -1,13 +1,9 @@
+use std::ffi::OsStr;
 use std::path::Path;
 
-pub fn run(path: &Path) -> Result<(), std::io::Error> {
-    use std::ffi::OsString;
-    let editor = std::env::var_os("VISUAL")
-        .or_else(|| std::env::var_os("EDITOR"))
-        .unwrap_or_else(|| OsString::from("vi"));
-
+pub fn run(path: &Path, editor: &OsStr) -> Result<(), std::io::Error> {
     ensure_config_file(path)?;
-    let status = std::process::Command::new(&editor)
+    let status = std::process::Command::new(editor)
         .arg(path)
         .status()
         .map_err(|e| {
@@ -33,4 +29,20 @@ fn ensure_config_file(path: &Path) -> Result<(), std::io::Error> {
     let content = toml::to_string_pretty(&config)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
     std::fs::write(path, content.as_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn run_returns_error_when_editor_not_found() {
+        let dir = TempDir::new().unwrap();
+        let config_path = dir.path().join("merge-ready.toml");
+        let result = run(&config_path, OsStr::new("this-editor-does-not-exist-xyz"));
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("failed to launch editor"), "got: {msg}");
+    }
 }


### PR DESCRIPTION
## Summary

- `edit::run(path: &Path)` の内部で読んでいた `VISUAL`/`EDITOR` 環境変数の解決を CLI アダプタ層の `config::run` に移動
- シグネチャを `run(path: &Path, editor: &OsStr)` に変更し、エディタ起動責務のみを持つよう整理
- エディタ起動失敗パス（存在しないバイナリ）のユニットテストを追加（`unsafe_code = "forbid"` の制約下では `std::env::set_var` が使えず、これまで書けなかった）

Closes #303

## Test plan

- [x] 新規ユニットテスト `run_returns_error_when_editor_not_found` がパスすること
- [x] 既存 E2E テスト #51〜#58 (`test_config_edit_*`) がすべてパスすること
- [x] `cargo clippy -- -D warnings` がクリーンであること
- [x] `cargo fmt --check` がクリーンであること

🤖 Generated with [Claude Code](https://claude.com/claude-code)