### PR TITLE
test(e2e): daemon stop の異常系フォールバック経路をカバーする

### DIFF
--- a/tests/e2e/daemon/lifecycle.rs
+++ b/tests/e2e/daemon/lifecycle.rs
@@ -522,14 +522,7 @@ fn test_daemon_stop_falls_back_to_sigterm_when_socket_removed() {
     let env = TestEnv::new(OPEN_PR_VIEW_JSON, Some(CI_PASS_JSON));
     let _daemon = DaemonHandle::start(&env);
 
-    // DaemonHandle::start は socket 出現で完了判定するが、pid ファイルは bind 直後の
-    // 別ステップで書かれるため、ごく短い窓で pid が未書き込みのことがある。
-    let pid_path = versioned_pid(env.home());
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
-    while !pid_path.exists() && std::time::Instant::now() < deadline {
-        std::thread::sleep(std::time::Duration::from_millis(20));
-    }
-    let pid: u32 = std::fs::read_to_string(&pid_path)
+    let pid: u32 = std::fs::read_to_string(versioned_pid(env.home()))
         .expect("read pid file")
         .trim()
         .parse()

--- a/tests/e2e/daemon/lifecycle.rs
+++ b/tests/e2e/daemon/lifecycle.rs
@@ -475,6 +475,90 @@ fn test_daemon_status_format() {
     );
 }
 
+// ── #S1: stale PID のみ・socket 無しでの daemon stop ────────────────────────
+
+/// #S1: 死んだ PID ファイルだけが残り socket が存在しない状態で `daemon stop` を実行すると、
+/// stale PID ファイルを削除して "daemon is not running" を stderr に出力する。
+///
+/// `DaemonLifecycle::stop` の dead-PID クリーンアップ経路を覆う。
+#[test]
+fn test_daemon_stop_with_stale_pid_and_no_socket() {
+    let env = TestEnv::new(OPEN_PR_VIEW_JSON, Some(CI_PASS_JSON));
+
+    let mut dead = std::process::Command::new("true")
+        .spawn()
+        .expect("spawn true");
+    let dead_pid = dead.id();
+    dead.wait().expect("wait for dead process");
+
+    let pid_path = versioned_pid(env.home());
+    std::fs::write(&pid_path, dead_pid.to_string()).expect("write stale pid file");
+    assert!(
+        !versioned_socket(env.home()).exists(),
+        "socket should not exist for this scenario"
+    );
+
+    let output = daemon_stop_output(&env);
+    assert!(output.status.success(), "daemon stop should exit 0");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("daemon is not running"),
+        "expected 'daemon is not running' in stderr, got: {stderr:?}"
+    );
+    assert!(
+        !pid_path.exists(),
+        "stale pid file should be removed by daemon stop"
+    );
+}
+
+// ── #S2: socket 削除済み・daemon プロセス生存での daemon stop ────────────────
+
+/// #S2: 起動済み daemon の socket ファイルだけを外部から削除した状態で `daemon stop` を実行すると、
+/// SIGTERM フォールバックで daemon プロセスを停止させる。
+///
+/// `DaemonLifecycle::stop` の `terminate_and_wait` 経路を覆う。
+#[test]
+fn test_daemon_stop_falls_back_to_sigterm_when_socket_removed() {
+    let env = TestEnv::new(OPEN_PR_VIEW_JSON, Some(CI_PASS_JSON));
+    let _daemon = DaemonHandle::start(&env);
+
+    // DaemonHandle::start は socket 出現で完了判定するが、pid ファイルは bind 直後の
+    // 別ステップで書かれるため、ごく短い窓で pid が未書き込みのことがある。
+    let pid_path = versioned_pid(env.home());
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    while !pid_path.exists() && std::time::Instant::now() < deadline {
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    let pid: u32 = std::fs::read_to_string(&pid_path)
+        .expect("read pid file")
+        .trim()
+        .parse()
+        .expect("parse pid");
+    assert!(is_pid_alive(pid), "daemon should be alive before stop");
+
+    std::fs::remove_file(versioned_socket(env.home())).expect("remove socket file");
+
+    let output = daemon_stop_output(&env);
+    assert!(output.status.success(), "daemon stop should exit 0");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("stopped"),
+        "expected 'stopped' in stdout, got: {stdout:?}"
+    );
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+    while std::time::Instant::now() < deadline {
+        if !is_pid_alive(pid) {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    assert!(
+        !is_pid_alive(pid),
+        "daemon (pid={pid}) should be terminated by SIGTERM fallback"
+    );
+}
+
 // ── #18: stale PID ファイルのクリーンアップ ──────────────────────────────────
 
 /// #18: 前回クラッシュした daemon が残した stale な PID ファイルがある状態で

--- a/tests/e2e/helpers/daemon_handle.rs
+++ b/tests/e2e/helpers/daemon_handle.rs
@@ -1,13 +1,16 @@
 //! daemon プロセスを管理するテストヘルパー。
 
 use std::fs;
+use std::io::Read;
 use std::path::Path;
 
 use super::{TestEnv, run_prompt_with_timeout};
 
 /// daemon プロセスを管理するテストヘルパー。
 ///
-/// socket ファイルの出現をポーリングして起動完了を検知する（固定 sleep は使わない）。
+/// `merge-ready daemon start` CLI の正常終了を起動完了シグナルとして使う。
+/// CLI は内部 daemon の `"ready\n"` ハンドシェイクを読んだ後に exit するため、
+/// pid と socket が両方書き込まれてから起動完了とみなせる。
 /// Drop 時に daemon を停止する。
 pub struct DaemonHandle {
     process: std::process::Child,
@@ -21,9 +24,10 @@ impl DaemonHandle {
 }
 
 const STOP_WAIT_MS: u64 = 2000;
+const START_WAIT_MS: u64 = 5000;
 
 impl DaemonHandle {
-    /// daemon を起動し、socket が出現するまで最大 2000ms ポーリングする。
+    /// daemon を起動し、CLI が exit するまで最大 5000ms 待機する。
     #[must_use]
     pub fn start(env: &TestEnv) -> Self {
         Self::start_with_env(env, &[])
@@ -43,24 +47,47 @@ impl DaemonHandle {
             .env("XDG_CONFIG_HOME", env.home().join(".config"))
             .current_dir(env.repo.path())
             .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null());
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
         for (k, v) in extra_envs {
             cmd.env(k, v);
         }
         let mut child = cmd.spawn().expect("daemon spawn failed");
 
-        let socket = socket_path(env.home_tmp.path());
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
-        while std::time::Instant::now() < deadline {
-            if socket.exists() {
-                return DaemonHandle::new(child, env.home_tmp.path().to_path_buf());
+        // CLI 親プロセスの exit を待つ。socket ファイル存在ポーリングだと
+        // (1) pid 書き込み前に socket が観測される race と
+        // (2) 同一バージョンの旧 daemon stop ハンドラが新 daemon の socket を
+        //     消してしまう race の双方を引き当てる。CLI の "ready" ハンドシェイク
+        //     完了後の exit を待つことで両方を回避する。
+        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(START_WAIT_MS);
+        loop {
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    if status.success() {
+                        return DaemonHandle::new(child, env.home_tmp.path().to_path_buf());
+                    }
+                    let stderr = read_pipe(child.stderr.as_mut());
+                    let stdout = read_pipe(child.stdout.as_mut());
+                    panic!(
+                        "daemon CLI exited non-zero: status={:?}, stdout={stdout:?}, stderr={stderr:?}",
+                        status.code()
+                    );
+                }
+                Ok(None) => {
+                    if std::time::Instant::now() >= deadline {
+                        let _ = child.kill();
+                        let stderr = read_pipe(child.stderr.as_mut());
+                        let stdout = read_pipe(child.stdout.as_mut());
+                        let _ = child.wait();
+                        panic!(
+                            "daemon did not start within {START_WAIT_MS}ms; stdout={stdout:?}, stderr={stderr:?}"
+                        );
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                }
+                Err(e) => panic!("daemon try_wait failed: {e}"),
             }
-            std::thread::sleep(std::time::Duration::from_millis(10));
         }
-        let _ = child.kill();
-        let _ = child.wait();
-        panic!("daemon did not start within 2000ms");
     }
 
     /// キャッシュに有効な値が入るまで最大 `max_ms` ミリ秒ポーリングする。
@@ -175,6 +202,15 @@ fn is_pid_alive(pid: u32) -> bool {
         .stderr(std::process::Stdio::null())
         .status()
         .is_ok_and(|s| s.success())
+}
+
+fn read_pipe<R: Read>(pipe: Option<&mut R>) -> String {
+    let Some(pipe) = pipe else {
+        return String::new();
+    };
+    let mut buf = String::new();
+    let _ = pipe.read_to_string(&mut buf);
+    buf
 }
 
 fn wait_until_socket_removed(base_dir: &Path, max_ms: u64) -> bool {


### PR DESCRIPTION
Closes #318

## Summary

- `DaemonLifecycle::stop` の socket 経由 Stop 失敗時フォールバック経路（行 55–57, 59, 84, 86–91）を覆う E2E シナリオを 2 件追加（Issue 本文の S1 / S2）。
- 並列負荷下で再現する既存 flaky（#16 `test_daemon_start_sends_stop_to_live_old_version_daemon`、main でも 3 回中 2 回失敗）の原因を切り分け、テストヘルパー側で修正。

## 追加テスト

| シナリオ | カバー範囲 |
| --- | --- |
| `test_daemon_stop_with_stale_pid_and_no_socket` | 死んだ PID のみ残り socket 無し → stale PID ファイル削除と "daemon is not running" 出力（行 55–57） |
| `test_daemon_stop_falls_back_to_sigterm_when_socket_removed` | 起動済み daemon の socket だけを削除 → SIGTERM フォールバックでプロセス停止（行 59, 84, 86–91） |

範囲外（Issue 明記）: 行 80–81 の \`wait_or_terminate\` タイムアウト経路は E2E で精密タイミング制御不可。

## 副次修正: \`DaemonHandle::start\` の flaky 修正

実装中に #16 が並列負荷で頻繁に失敗することを確認。原因は socket ファイル存在ポーリングで以下の 2 race を引き当てるため。

1. **pid 書き込み前 race**: \`socket_listener::bind\` は \`UnixListener::bind\` 直後に \`pid::write\` するため、socket は存在するが pid 未書き込みの窓がある。テスト #16 が 0.3 秒前後で「pid ファイル No such file」失敗。
2. **socket 削除 race**: テスト #16 は同一バージョンの旧/新 daemon を共存させるが、\`Paths::socket_path()\` はコンパイル時バージョンで決まるので、旧 daemon の Stop ハンドラ \`restart::cleanup(paths)\` が新 daemon の socket を削除する。CLI が \"daemon started\" を出力しても、socket ポーリングが見る前に消える（8 秒タイムアウト失敗）。

修正: \`DaemonHandle::start\` で socket ポーリングをやめ、\`merge-ready daemon start\` CLI 親プロセスの正常終了を起動完了シグナルとして使う。CLI は内部で \`\"ready\\n\"\` ハンドシェイクを既に実装しており（\`src/contexts/daemon/interface/cli/daemon.rs:54-91\`）、\`ready\` を読んだ後に exit するため、pid+socket 両方が書かれた時点が保証される。socket の一時削除にも影響されない。**本番コード変更なし**。

## Test plan

- [x] 新規 2 件パス: \`rtk cargo nextest run --workspace -E 'test(test_daemon_stop_with_stale_pid_and_no_socket) + test(test_daemon_stop_falls_back_to_sigterm_when_socket_removed)'\`
- [x] daemon E2E 5 回連続パス: 全 22 件 × 5 連続 OK（修正前は 3 回中 2 回 #16 が失敗）
- [x] 全 262 件パス: \`rtk cargo nextest run --workspace\`
- [x] lint: \`rtk cargo clippy --workspace --all-targets --all-features -- -D warnings\`
- [x] fmt: \`rtk cargo fmt --check --all\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)