### PR TITLE
chore(coverage): E2E のサブプロセス coverage を計測できるようにする

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
  "mio",
  "parking_lot",
  "rustix",
- "signal-hook",
+ "signal-hook 0.3.18",
  "signal-hook-mio",
  "winapi",
 ]
@@ -632,7 +632,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
- "signal-hook",
+ "signal-hook 0.4.4",
  "simplelog",
  "tempfile",
  "toml",
@@ -1064,6 +1064,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
 name = "signal-hook-mio"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1071,7 +1081,7 @@ checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
  "mio",
- "signal-hook",
+ "signal-hook 0.3.18",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,6 +632,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
+ "signal-hook",
  "simplelog",
  "tempfile",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ simplelog = "0.12"
 toml = "1.1.2"
 crossterm = "0.29.0"
 bitflags = "2.11.1"
+signal-hook = { version = "0.3.18", default-features = false }
 
 [lib]
 name = "merge_ready"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ simplelog = "0.12"
 toml = "1.1.2"
 crossterm = "0.29.0"
 bitflags = "2.11.1"
-signal-hook = { version = "0.3.18", default-features = false }
+signal-hook = { version = "0.4.4", default-features = false }
 
 [lib]
 name = "merge_ready"

--- a/src/contexts/daemon/interface/cli/watch.rs
+++ b/src/contexts/daemon/interface/cli/watch.rs
@@ -1,5 +1,7 @@
 use std::fmt::Write as _;
 use std::process::ExitCode;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crossterm::{
@@ -11,15 +13,42 @@ use crate::contexts::daemon::application::port::{EntryView, WatchPort};
 use crate::contexts::daemon::application::watch;
 
 const POLL_INTERVAL: Duration = Duration::from_secs(1);
+// POLL_INTERVAL を細切れに sleep し、間で shutdown フラグをポーリングする。
+// SIGINT 受信から終了までの遅延上限 = SHUTDOWN_TICK。
+const SHUTDOWN_TICK: Duration = Duration::from_millis(50);
 
 pub fn run(port: &impl WatchPort) -> ExitCode {
-    loop {
+    let shutdown = Arc::new(AtomicBool::new(false));
+    register_shutdown_signals(&shutdown);
+
+    while !shutdown.load(Ordering::SeqCst) {
         clear_screen();
         if !draw(port) {
             return ExitCode::FAILURE;
         }
-        std::thread::sleep(POLL_INTERVAL);
+        if !sleep_until(POLL_INTERVAL, &shutdown) {
+            break;
+        }
     }
+    ExitCode::SUCCESS
+}
+
+fn register_shutdown_signals(shutdown: &Arc<AtomicBool>) {
+    for sig in [signal_hook::consts::SIGINT, signal_hook::consts::SIGTERM] {
+        let _ = signal_hook::flag::register(sig, Arc::clone(shutdown));
+    }
+}
+
+/// 指定 duration を細切れに sleep する。途中で shutdown が立てば false を返す。
+fn sleep_until(duration: Duration, shutdown: &AtomicBool) -> bool {
+    let deadline = std::time::Instant::now() + duration;
+    while std::time::Instant::now() < deadline {
+        if shutdown.load(Ordering::SeqCst) {
+            return false;
+        }
+        std::thread::sleep(SHUTDOWN_TICK);
+    }
+    true
 }
 
 fn clear_screen() {

--- a/tests/e2e/daemon/lifecycle.rs
+++ b/tests/e2e/daemon/lifecycle.rs
@@ -5,7 +5,7 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
 
-use super::super::helpers::{DaemonHandle, TestEnv};
+use super::super::helpers::{DaemonHandle, TestEnv, apply_coverage_env};
 
 const BIN: &str = "merge-ready";
 const PROMPT_BIN: &str = "merge-ready-prompt";
@@ -33,17 +33,17 @@ fn is_pid_alive(pid: u32) -> bool {
 
 fn status_output_with_timeout(env: &TestEnv) -> std::process::Output {
     let bin = assert_cmd::cargo::cargo_bin(BIN);
-    let mut child = std::process::Command::new(bin)
-        .args(["daemon", "status"])
+    let mut cmd = std::process::Command::new(bin);
+    cmd.args(["daemon", "status"])
         .env("PATH", env.path_env())
         .env("HOME", env.home())
         .env("TMPDIR", env.home())
         .env("MERGE_READY_BASE_DIR", env.home())
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .spawn()
-        .expect("spawn daemon status");
+        .stderr(std::process::Stdio::piped());
+    apply_coverage_env(&mut cmd);
+    let mut child = cmd.spawn().expect("spawn daemon status");
     let deadline = std::time::Instant::now() + std::time::Duration::from_millis(COMMAND_TIMEOUT_MS);
     loop {
         if child.try_wait().is_ok_and(|status| status.is_some()) {
@@ -62,8 +62,8 @@ fn status_output_with_timeout(env: &TestEnv) -> std::process::Output {
 
 fn daemon_stop_output(env: &TestEnv) -> std::process::Output {
     let bin = assert_cmd::cargo::cargo_bin(BIN);
-    let mut child = std::process::Command::new(bin)
-        .args(["daemon", "stop"])
+    let mut cmd = std::process::Command::new(bin);
+    cmd.args(["daemon", "stop"])
         .env("PATH", env.path_env())
         .env("HOME", env.home())
         .env("TMPDIR", env.home())
@@ -72,9 +72,9 @@ fn daemon_stop_output(env: &TestEnv) -> std::process::Output {
         .current_dir(env.repo.path())
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .spawn()
-        .expect("spawn daemon stop");
+        .stderr(std::process::Stdio::piped());
+    apply_coverage_env(&mut cmd);
+    let mut child = cmd.spawn().expect("spawn daemon stop");
     let deadline = std::time::Instant::now() + std::time::Duration::from_millis(COMMAND_TIMEOUT_MS);
     loop {
         if child.try_wait().is_ok_and(|status| status.is_some()) {
@@ -128,17 +128,17 @@ fn prompt_output_with_timeout(
     let stdout_for_child = stdout_file.try_clone().expect("clone stdout file");
     let stderr_for_child = stderr_file.try_clone().expect("clone stderr file");
 
-    let mut child = std::process::Command::new(bin)
-        .env("PATH", path)
+    let mut cmd = std::process::Command::new(bin);
+    cmd.env("PATH", path)
         .env("HOME", home)
         .env("TMPDIR", home)
         .env("MERGE_READY_BASE_DIR", home)
         .current_dir(repo)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::from(stdout_for_child))
-        .stderr(std::process::Stdio::from(stderr_for_child))
-        .spawn()
-        .expect("run prompt");
+        .stderr(std::process::Stdio::from(stderr_for_child));
+    apply_coverage_env(&mut cmd);
+    let mut child = cmd.spawn().expect("run prompt");
 
     let deadline = std::time::Instant::now() + std::time::Duration::from_millis(COMMAND_TIMEOUT_MS);
     let status = loop {

--- a/tests/e2e/daemon/watch.rs
+++ b/tests/e2e/daemon/watch.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use assert_cmd::Command;
 use predicates::prelude::*;
 
-use super::super::helpers::{DaemonHandle, MultiRepoEnv, TestEnv};
+use super::super::helpers::{DaemonHandle, MultiRepoEnv, TestEnv, apply_coverage_env};
 
 const BIN: &str = "merge-ready";
 const OPEN_PR_VIEW_JSON: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}"#;
@@ -18,8 +18,8 @@ const CI_PASS_JSON: &str = r#"[{"bucket":"pass","state":"SUCCESS","name":"ci","l
 /// 読み取り後に SIGINT を送りプロセスを終了させる。
 fn spawn_watch_and_read(env: &TestEnv, n: usize, timeout: Duration) -> String {
     let bin = assert_cmd::cargo::cargo_bin(BIN);
-    let mut child = std::process::Command::new(bin)
-        .args(["watch"])
+    let mut cmd = std::process::Command::new(bin);
+    cmd.args(["watch"])
         .env("PATH", env.path_env())
         .env("HOME", env.home())
         .env("TMPDIR", env.home())
@@ -27,9 +27,9 @@ fn spawn_watch_and_read(env: &TestEnv, n: usize, timeout: Duration) -> String {
         .env("XDG_CONFIG_HOME", env.home().join(".config"))
         .current_dir(env.repo.path())
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-        .expect("failed to spawn merge-ready watch");
+        .stderr(Stdio::null());
+    apply_coverage_env(&mut cmd);
+    let mut child = cmd.spawn().expect("failed to spawn merge-ready watch");
 
     let stdout = child.stdout.take().expect("stdout not captured");
     let (tx, rx) = mpsc::channel::<String>();
@@ -145,8 +145,8 @@ fn test_watch_leaves_pr_column_empty_without_pr() {
 
 fn spawn_watch_and_read_multi(env: &MultiRepoEnv, n: usize, timeout: Duration) -> String {
     let bin = assert_cmd::cargo::cargo_bin(BIN);
-    let mut child = std::process::Command::new(bin)
-        .args(["watch"])
+    let mut cmd = std::process::Command::new(bin);
+    cmd.args(["watch"])
         .env("PATH", env.path_env())
         .env("HOME", env.home())
         .env("TMPDIR", env.home())
@@ -154,9 +154,9 @@ fn spawn_watch_and_read_multi(env: &MultiRepoEnv, n: usize, timeout: Duration) -
         .env("XDG_CONFIG_HOME", env.home().join(".config"))
         .current_dir(env.repo_a.path())
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-        .expect("failed to spawn merge-ready watch");
+        .stderr(Stdio::null());
+    apply_coverage_env(&mut cmd);
+    let mut child = cmd.spawn().expect("failed to spawn merge-ready watch");
 
     let stdout = child.stdout.take().expect("stdout not captured");
     let (tx, rx) = mpsc::channel::<String>();

--- a/tests/e2e/helpers/coverage.rs
+++ b/tests/e2e/helpers/coverage.rs
@@ -1,0 +1,31 @@
+//! cargo-llvm-cov 配下で実行されるとき、subprocess に `LLVM_PROFILE_FILE` を
+//! `%p` 付きで明示伝播するためのヘルパ。
+//!
+//! `std::process::Command` は環境変数を継承するため伝播自体は通常通り動くが、
+//! E2E テストは並列に多数の `merge-ready` プロセスを起動する。`%p` を含めない
+//! pattern だと profraw が衝突しうるため、ここで pattern を補正してから明示的に
+//! 渡し直す。cargo-llvm-cov 配下でないとき (env 未設定) は何もしない。
+
+/// `std::process::Command` 用。
+pub(crate) fn apply_coverage_env(cmd: &mut std::process::Command) {
+    if let Ok(value) = std::env::var("LLVM_PROFILE_FILE") {
+        cmd.env("LLVM_PROFILE_FILE", ensure_per_process_pattern(&value));
+    }
+}
+
+/// `assert_cmd::Command` 用。
+pub(crate) fn apply_coverage_env_assert(cmd: &mut assert_cmd::Command) {
+    if let Ok(value) = std::env::var("LLVM_PROFILE_FILE") {
+        cmd.env("LLVM_PROFILE_FILE", ensure_per_process_pattern(&value));
+    }
+}
+
+fn ensure_per_process_pattern(path: &str) -> String {
+    if path.contains("%p") {
+        path.to_owned()
+    } else if let Some(stem) = path.strip_suffix(".profraw") {
+        format!("{stem}-%p.profraw")
+    } else {
+        format!("{path}-%p")
+    }
+}

--- a/tests/e2e/helpers/daemon_handle.rs
+++ b/tests/e2e/helpers/daemon_handle.rs
@@ -4,7 +4,7 @@ use std::fs;
 use std::io::Read;
 use std::path::Path;
 
-use super::{TestEnv, run_prompt_with_timeout};
+use super::{TestEnv, apply_coverage_env, run_prompt_with_timeout};
 
 /// daemon プロセスを管理するテストヘルパー。
 ///
@@ -52,6 +52,7 @@ impl DaemonHandle {
         for (k, v) in extra_envs {
             cmd.env(k, v);
         }
+        apply_coverage_env(&mut cmd);
         let mut child = cmd.spawn().expect("daemon spawn failed");
 
         // CLI 親プロセスの exit を待つ。socket ファイル存在ポーリングだと
@@ -95,14 +96,14 @@ impl DaemonHandle {
         let bin = assert_cmd::cargo::cargo_bin("merge-ready-prompt");
         let deadline = std::time::Instant::now() + std::time::Duration::from_millis(max_ms);
         loop {
-            let out = run_prompt_with_timeout(
-                std::process::Command::new(&bin)
-                    .env("PATH", env.path_env())
-                    .env("HOME", env.home())
-                    .env("TMPDIR", env.home())
-                    .env("MERGE_READY_BASE_DIR", env.home())
-                    .current_dir(env.repo.path()),
-            );
+            let mut cmd = std::process::Command::new(&bin);
+            cmd.env("PATH", env.path_env())
+                .env("HOME", env.home())
+                .env("TMPDIR", env.home())
+                .env("MERGE_READY_BASE_DIR", env.home())
+                .current_dir(env.repo.path());
+            apply_coverage_env(&mut cmd);
+            let out = run_prompt_with_timeout(&mut cmd);
             let stdout = String::from_utf8_lossy(&out.stdout);
             if stdout != "? loading" {
                 return;
@@ -129,6 +130,7 @@ impl DaemonHandle {
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null());
+        apply_coverage_env(&mut stop);
         let _ = run_command_to_exit(&mut stop, STOP_WAIT_MS);
 
         if let Some(pid) = pid

--- a/tests/e2e/helpers/env.rs
+++ b/tests/e2e/helpers/env.rs
@@ -7,7 +7,7 @@ use std::fs;
 use std::path::Path;
 use tempfile::{TempDir, tempdir};
 
-use super::write_executable;
+use super::{apply_coverage_env_assert, write_executable};
 
 /// `.git` を持つ一時ディレクトリ群を生成する。fixture モジュールからの呼び出し用。
 pub(crate) fn setup_git_dirs(branch: &str) -> (TempDir, TempDir, TempDir) {
@@ -193,6 +193,7 @@ impl TestEnv {
         cmd.env("MERGE_READY_BASE_DIR", self.home());
         cmd.env("XDG_CONFIG_HOME", self.home().join(".config"));
         cmd.current_dir(self.repo.path());
+        apply_coverage_env_assert(cmd);
     }
 
     /// `Command` に環境変数を設定する（`merge-ready-prompt` バイナリ用）。
@@ -204,6 +205,7 @@ impl TestEnv {
         cmd.env("TMPDIR", self.home());
         cmd.env("MERGE_READY_BASE_DIR", self.home());
         cmd.current_dir(self.repo.path());
+        apply_coverage_env_assert(cmd);
     }
 
     /// `~/.config/merge-ready.toml` に TOML 設定を書き込む。

--- a/tests/e2e/helpers/mod.rs
+++ b/tests/e2e/helpers/mod.rs
@@ -1,7 +1,9 @@
+mod coverage;
 mod daemon_handle;
 mod env;
 mod multi_repo;
 
+pub(crate) use coverage::{apply_coverage_env, apply_coverage_env_assert};
 pub use daemon_handle::DaemonHandle;
 pub use env::TestEnv;
 pub(crate) use env::{setup_empty_dirs, setup_git_dirs};

--- a/tests/e2e/helpers/multi_repo.rs
+++ b/tests/e2e/helpers/multi_repo.rs
@@ -4,7 +4,7 @@ use std::fs;
 use std::path::Path;
 use tempfile::{TempDir, tempdir};
 
-use super::{DaemonHandle, run_prompt_with_timeout, write_executable};
+use super::{DaemonHandle, apply_coverage_env, run_prompt_with_timeout, write_executable};
 
 pub struct MultiRepoEnv {
     pub bin: TempDir,
@@ -70,8 +70,8 @@ impl MultiRepoEnv {
     /// daemon を `repo_a` の cwd で起動し、socket 出現まで最大 2000ms 待つ。
     pub fn start_daemon(&self) -> DaemonHandle {
         let bin = assert_cmd::cargo::cargo_bin("merge-ready");
-        let mut child = std::process::Command::new(&bin)
-            .args(["daemon", "start"])
+        let mut cmd = std::process::Command::new(&bin);
+        cmd.args(["daemon", "start"])
             .env("PATH", self.path_env())
             .env("HOME", self.home())
             .env("TMPDIR", self.home())
@@ -79,9 +79,9 @@ impl MultiRepoEnv {
             .current_dir(self.repo_a.path())
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .spawn()
-            .expect("daemon spawn failed");
+            .stderr(std::process::Stdio::null());
+        apply_coverage_env(&mut cmd);
+        let mut child = cmd.spawn().expect("daemon spawn failed");
 
         let socket = self
             .home()
@@ -103,14 +103,14 @@ impl MultiRepoEnv {
         let bin = assert_cmd::cargo::cargo_bin("merge-ready-prompt");
         let deadline = std::time::Instant::now() + std::time::Duration::from_millis(max_ms);
         loop {
-            let out = run_prompt_with_timeout(
-                std::process::Command::new(&bin)
-                    .env("PATH", self.path_env())
-                    .env("HOME", self.home())
-                    .env("TMPDIR", self.home())
-                    .env("MERGE_READY_BASE_DIR", self.home())
-                    .current_dir(repo.path()),
-            );
+            let mut cmd = std::process::Command::new(&bin);
+            cmd.env("PATH", self.path_env())
+                .env("HOME", self.home())
+                .env("TMPDIR", self.home())
+                .env("MERGE_READY_BASE_DIR", self.home())
+                .current_dir(repo.path());
+            apply_coverage_env(&mut cmd);
+            let out = run_prompt_with_timeout(&mut cmd);
             let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
             if stdout != "? loading" {
                 return;
@@ -126,14 +126,14 @@ impl MultiRepoEnv {
     /// `repo` から `merge-ready-prompt` を実行してその出力を返す。
     pub fn prompt_output(&self, repo: &TempDir) -> String {
         let bin = assert_cmd::cargo::cargo_bin("merge-ready-prompt");
-        let out = run_prompt_with_timeout(
-            std::process::Command::new(&bin)
-                .env("PATH", self.path_env())
-                .env("HOME", self.home())
-                .env("TMPDIR", self.home())
-                .env("MERGE_READY_BASE_DIR", self.home())
-                .current_dir(repo.path()),
-        );
+        let mut cmd = std::process::Command::new(&bin);
+        cmd.env("PATH", self.path_env())
+            .env("HOME", self.home())
+            .env("TMPDIR", self.home())
+            .env("MERGE_READY_BASE_DIR", self.home())
+            .current_dir(repo.path());
+        apply_coverage_env(&mut cmd);
+        let out = run_prompt_with_timeout(&mut cmd);
         String::from_utf8_lossy(&out.stdout).into_owned()
     }
 }


### PR DESCRIPTION
## Summary

E2E が `std::process::Command` で起動する `merge-ready` / `merge-ready-prompt` サブプロセスの coverage が `cargo llvm-cov nextest` のレポートに反映されない問題を修正する。原因は 2 つ:

1. **profraw のファイル衝突**: 並列に多数の subprocess を起動する E2E で、`LLVM_PROFILE_FILE` の pattern に `%p` が確実に含まれている保証がなく profraw が衝突しうる。テスト側のヘルパで `%p` を付与した pattern を明示的に伝播する。
2. **`merge-ready watch` の atexit hook が走らない**: 無限ループの watch CLI を E2E が SIGINT で kill するため、LLVM の atexit hook (profraw flush) が走らず coverage が失われる。signal-hook で SIGINT/SIGTERM を捕捉して graceful 終了する。

## 効果

| 対象 | Before | After |
|---|---|---|
| `daemon_lifecycle.rs` (line cov) | 86.66% | **97.14%** |
| `WatchPort::entries()` (98–107) | 未カバー | **カバー** |
| 全体 (line cov) | 94.83% | **95.35%** |

`request_handler.rs` (100%), `daemon_server.rs` (95%), `daemon_client.rs` (100%) など他の subprocess 経路もカバーされるようになった。

## 変更内容

- `tests/e2e/helpers/coverage.rs` を新設し、`LLVM_PROFILE_FILE` を `%p` 付きで子プロセスに伝播する共通ヘルパを追加
- 既存ヘルパ (`env.rs` / `daemon_handle.rs` / `multi_repo.rs`) と E2E (`watch.rs` / `lifecycle.rs`) の全 subprocess spawn 箇所で `apply_coverage_env` を呼ぶ
- `src/contexts/daemon/interface/cli/watch.rs`: signal-hook で SIGINT/SIGTERM を捕捉して graceful 終了させる (watch サブプロセスで atexit hook が走るようにするため)
- `signal-hook = "0.4.4"` を依存に追加 (default-features = false)

## 既知の注意点

- 本変更は subprocess の coverage 計測のみを目的としており、watch の Ctrl+C 時の体感 UX は変わらない (修正前も raw mode を使っていなかったので端末状態の復元は不要、見た目は同じ)。違いは exit code が `130` → `0` になることと atexit hook が走るようになる点のみ。

## Test plan

- [x] `cargo nextest run --workspace` 262 passed
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check --all` clean
- [x] `cargo deny check` clean
- [x] `cargo llvm-cov nextest --workspace` で `daemon_lifecycle.rs::WatchPort::entries()` がカバーされること確認

close #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)