### PR TITLE
docs(socket_listener): startup_lock の Err 経路が未カバーである理由を残す

### DIFF
--- a/src/contexts/daemon/infrastructure/socket_listener.rs
+++ b/src/contexts/daemon/infrastructure/socket_listener.rs
@@ -20,6 +20,10 @@ pub(super) fn bind(paths: &Paths) -> Result<UnixListener, DaemonError> {
             eprintln!("merge-ready daemon: failed to open lock file: {e}");
             DaemonError::Failure
         })?;
+    // `File::lock()` はブロッキングのため、ロック競合では Err にならず待機する。
+    // Err になるのは flock 非対応 FS / ENOLCK / EIO 等 OS・FS レベル異常時のみで、
+    // 通常のテスト環境では再現手段が無いため、この map_err 経路は意図的に未カバー。
+    // `try_lock()` に変えると起動直列化の意図が壊れるため変更しない。
     startup_lock.lock().map_err(|e| {
         log::error!("failed to lock daemon startup: {e}");
         eprintln!("merge-ready daemon: failed to acquire startup lock: {e}");


### PR DESCRIPTION
## Summary

- `bind()` 内の `startup_lock.lock().map_err(...)` 経路がカバレッジレポートで未カバーとなっている件について、**意図的に未カバーである旨と理由**をコード上に記録する。
- 動作変更は無し。コメント追加のみ。

## 背景

`std::fs::File::lock()` はブロッキング API で、ロック競合では Err にならず待機する。Err を返すのは以下のような OS / FS レベルの異常時に限られる:

- FS が flock 非対応（NFS without lockd、一部 FUSE、FAT、SMB 等）
- `ENOLCK` / `EIO` 等のカーネル/ディスク異常
- `EBADF`（コード上、直前に取得した File を使うため発生不能）

このため標準的な開発・CI 環境では Err 経路を踏むテストを書く手段が無い。`try_lock()` への置換は「daemon の起動を直列化する」という現状の意図を壊すため採用しない、という結論に至った。

将来の調査の二度手間を避けるため、未カバーが意図的であることをコメントとして残す。

関連 Issue: #322（こちらは git.rs 側の walk-up カバレッジ、別件）

## Test plan

- [x] `cargo fmt --check --all`
- [x] コメント追加のみで挙動変更なし