### PR TITLE
test(socket_listener): bind の OS-level エラー経路をユニットテストでカバー

### DIFF
--- a/src/contexts/daemon/infrastructure/socket_listener.rs
+++ b/src/contexts/daemon/infrastructure/socket_listener.rs
@@ -8,6 +8,18 @@ const BIND_RETRY_INTERVAL_MS: u64 = 100;
 const BIND_RETRY_MAX: usize = 10;
 
 pub(super) fn bind(paths: &Paths) -> Result<UnixListener, DaemonError> {
+    bind_with(
+        paths,
+        BIND_RETRY_MAX,
+        Duration::from_millis(BIND_RETRY_INTERVAL_MS),
+    )
+}
+
+fn bind_with(
+    paths: &Paths,
+    retry_max: usize,
+    retry_interval: Duration,
+) -> Result<UnixListener, DaemonError> {
     let socket_path = paths.socket_path();
     let startup_lock = std::fs::OpenOptions::new()
         .read(true)
@@ -42,20 +54,34 @@ pub(super) fn bind(paths: &Paths) -> Result<UnixListener, DaemonError> {
         }
     }
 
+    let listener = bind_with_retry(
+        || UnixListener::bind(&socket_path),
+        retry_max,
+        retry_interval,
+    )?;
+    pid::write(std::process::id(), &pid_path);
+    Ok(listener)
+}
+
+fn bind_with_retry<F>(
+    mut try_bind: F,
+    retry_max: usize,
+    retry_interval: Duration,
+) -> Result<UnixListener, DaemonError>
+where
+    F: FnMut() -> std::io::Result<UnixListener>,
+{
     let mut retries = 0;
     loop {
-        match UnixListener::bind(&socket_path) {
-            Ok(l) => {
-                pid::write(std::process::id(), &pid_path);
-                return Ok(l);
-            }
+        match try_bind() {
+            Ok(l) => return Ok(l),
             Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
-                if retries >= BIND_RETRY_MAX {
+                if retries >= retry_max {
                     log::error!("socket already in use after retries, giving up");
                     return Err(DaemonError::AlreadyRunning);
                 }
                 retries += 1;
-                std::thread::sleep(Duration::from_millis(BIND_RETRY_INTERVAL_MS));
+                std::thread::sleep(retry_interval);
             }
             Err(e) => {
                 log::error!("failed to bind socket: {e}");
@@ -63,5 +89,54 @@ pub(super) fn bind(paths: &Paths) -> Result<UnixListener, DaemonError> {
                 return Err(DaemonError::Failure);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Error, ErrorKind};
+    use tempfile::tempdir;
+
+    #[test]
+    fn bind_returns_failure_when_lock_file_cannot_be_opened() {
+        // base_dir 自体が存在しない場合、`OpenOptions::create(true).open(lock_path)` は
+        // 親ディレクトリ不在で ENOENT になり、open() の map_err 経路を踏む。
+        let tmp = tempdir().unwrap();
+        let bogus = tmp.path().join("does-not-exist-dir");
+        let paths = Paths::new(bogus);
+
+        let err = bind(&paths).unwrap_err();
+        assert!(matches!(err, DaemonError::Failure));
+    }
+
+    #[test]
+    fn bind_with_retry_returns_failure_on_non_addr_in_use_error() {
+        let err = bind_with_retry(
+            || -> std::io::Result<UnixListener> {
+                Err(Error::new(ErrorKind::PermissionDenied, "denied"))
+            },
+            3,
+            Duration::ZERO,
+        )
+        .unwrap_err();
+        assert!(matches!(err, DaemonError::Failure));
+    }
+
+    #[test]
+    fn bind_with_retry_returns_already_running_after_exhausting_retries() {
+        let mut calls = 0_usize;
+        let err = bind_with_retry(
+            || -> std::io::Result<UnixListener> {
+                calls += 1;
+                Err(Error::new(ErrorKind::AddrInUse, "addr in use"))
+            },
+            2,
+            Duration::ZERO,
+        )
+        .unwrap_err();
+        assert!(matches!(err, DaemonError::AlreadyRunning));
+        // retry_max=2 のため、初回 + 2 リトライ = 計 3 回試行してから上限到達。
+        assert_eq!(calls, 3);
     }
 }


### PR DESCRIPTION
## Summary

`src/contexts/daemon/infrastructure/socket_listener.rs` の `bind()` で未カバーになっていた OS-level エラー経路を、ユニットテストでカバーする。

- リトライループを `bind_with_retry` として抽出し、バインド試行をクロージャで注入できる構造に変更
- ロック / PID 管理部はそのまま、リトライ定数のみ `bind_with` で差し替え可能に

これにより以下の経路がカバーされる:

- L19-22: `lock_path` の `OpenOptions::open` 失敗 → `DaemonError::Failure`
- L52-58: `AddrInUse` リトライ上限到達 → `DaemonError::AlreadyRunning`
- L60-63: `AddrInUse` 以外の bind エラー → `DaemonError::Failure`

## 設計判断

未カバー経路を **FS 権限操作などで実 OS 側のエラーを引き起こすセットアップ** ではなく、**`bind_with_retry` への関数注入** で踏ませる方針を採用した。理由:

- read-only 親ディレクトリ等で `AddrInUse` を起こそうとすると `remove_file` の silent fail に依存し、別の `Permission denied` が先に出るなど再現が脆い
- リトライ定数 (`BIND_RETRY_MAX=10`, `INTERVAL=100ms`) を持ち込むとテストが秒オーダーで遅くなる
- クロージャ注入なら OS 挙動に依存せず決定的・高速・プラットフォーム非依存

CONTRIBUTING の「Unit tests are reserved for logic that E2E tests cannot reach — for example, OS-level error injection」方針に沿う。

## 未カバーのまま残る経路

`startup_lock.lock()` の `map_err` 経路は引き続き未カバー。これは `File::lock()` がブロッキング API で、Err になるのは flock 非対応 FS / ENOLCK / EIO 等 OS・FS レベル異常時のみのためで、別 PR (#323) で意図的に未カバーである旨をコードコメントとして記録済み。

## 関連

- #323: 未カバー経路のコメント記録（マージ順は #323 が先想定。同一行への加筆ではないので衝突なし）
- #322: `evaluation/infrastructure/git.rs` の walk-up カバレッジ（別件）

## Test plan

- [x] `cargo nextest run --workspace` 全 265 件 pass
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check --all` clean
- [x] `bash scripts/check-layer-deps.sh` / `check-no-mod-rs.sh` / `check-no-clippy-allow.sh` 全て pass