### PR TITLE
test(git): is_git_repo の walk-up 経路をカバーする

### DIFF
--- a/src/contexts/evaluation/infrastructure/git.rs
+++ b/src/contexts/evaluation/infrastructure/git.rs
@@ -28,3 +28,15 @@ pub fn current_branch(cwd: &Path) -> Option<String> {
         None
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn is_git_repo_returns_false_when_no_git_dir() {
+        let dir = tempdir().unwrap();
+        assert!(!is_git_repo(dir.path()));
+    }
+}

--- a/tests/e2e/scenarios/mod.rs
+++ b/tests/e2e/scenarios/mod.rs
@@ -17,6 +17,7 @@ mod refresh_interval_fixtures;
 mod refresh_timeout;
 mod refresh_timeout_fixtures;
 mod stale;
+mod sub_repo;
 mod terminal_pr;
 mod terminal_pr_fixtures;
 mod terminal_reopen;

--- a/tests/e2e/scenarios/sub_repo.rs
+++ b/tests/e2e/scenarios/sub_repo.rs
@@ -1,0 +1,46 @@
+//! サブディレクトリシナリオ
+//!
+//! リポジトリのサブディレクトリで `merge-ready-prompt` を実行したとき、
+//! `is_git_repo` が親ディレクトリを遡って `.git` を見つける経路（walk-up）をカバーする。
+
+use std::fs;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+use super::super::helpers::{DaemonHandle, TestEnv};
+
+const PROMPT_BIN: &str = "merge-ready-prompt";
+const OPEN_PR_VIEW_JSON: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}"#;
+const CI_PASS_JSON: &str = r#"[{"bucket":"pass","state":"SUCCESS","name":"ci","link":""}]"#;
+
+/// サブディレクトリから実行したとき walk-up で `.git` を検出して通常動作する
+#[test]
+fn test_prompt_from_subdirectory_finds_parent_git() {
+    let env = TestEnv::new(OPEN_PR_VIEW_JSON, Some(CI_PASS_JSON));
+
+    // git root の中にサブディレクトリを作成し、そこを cwd にする
+    let sub_dir = env.repo.path().join("sub/dir");
+    fs::create_dir_all(&sub_dir).expect("create sub/dir");
+
+    let _daemon = DaemonHandle::start(&env);
+
+    // サブディレクトリから初回実行 → ? loading（バックグラウンドで is_git_repo の walk-up が走る）
+    let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
+    env.apply_with_cache(&mut cmd);
+    cmd.current_dir(&sub_dir);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::diff("? loading"));
+
+    // キャッシュが温まるまで待つ
+    DaemonHandle::wait_for_cache(&env, 5000);
+
+    // サブディレクトリから再実行 → walk-up で .git を見つけて通常の結果を返す
+    let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
+    env.apply_with_cache(&mut cmd);
+    cmd.current_dir(&sub_dir);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::diff("✓ Ready for merge"));
+}


### PR DESCRIPTION
## Summary

- `src/contexts/evaluation/infrastructure/git.rs` の `is_git_repo` において walk-up 経路（L9/L10/L11）とルート到達経路（L12）が未カバーだった問題に対応
- 既存の `no_repo` シナリオでカバーできない理由：daemon の `repo_info_from_cwd()` が先に `.git` を探して `None` の場合は早期 return し `GhClient::fetch()` が呼ばれないため

## Changes

- **新規** `tests/e2e/scenarios/sub_repo.rs`: サブディレクトリから `merge-ready-prompt` を実行するE2Eシナリオ（L9/L10/L11をカバー）
- **追記** `src/contexts/evaluation/infrastructure/git.rs`: `tempdir` を使ったユニットテスト（L12をカバー、E2Eでは到達不能なため）

## Test plan

- [ ] `cargo nextest run --workspace -E 'test(sub_repo) | test(is_git_repo_returns_false)'` が 2 passed
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` がエラーなし

Closes #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)