### PR TITLE
chore: rust-analyzer-lsp プラグインをこのリポジトリで有効化する

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -95,7 +95,11 @@
       "Bash(PR_TITLE=\"test\\(e2e\\): daemon stop の異常系フォールバック経路をカバーする\" bash scripts/check-pr-title.sh)",
       "Bash(PR_TITLE=\"chore\\(coverage\\): subprocess に LLVM_PROFILE_FILE を明示伝播してカバレッジ計測する\" bash scripts/check-pr-title.sh)",
       "Bash(cargo search *)",
-      "Bash(gh repo *)"
+      "Bash(gh repo *)",
+      "Skill(update-config)"
     ]
+  },
+  "enabledPlugins": {
+    "rust-analyzer-lsp@claude-plugins-official": true
   }
 }


### PR DESCRIPTION
## Summary
- `.claude/settings.local.json` の `enabledPlugins` に `rust-analyzer-lsp@claude-plugins-official` を追加し、このリポジトリで rust-analyzer LSP プラグインを有効化する。

## Test plan
- [ ] Claude Code 再起動後、`/plugin` で `rust-analyzer-lsp@claude-plugins-official` が enabled として表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)