### PR TITLE
chore(evaluation): drop unused Default impl for StyleSpec

### DIFF
--- a/src/contexts/evaluation/domain/style_spec.rs
+++ b/src/contexts/evaluation/domain/style_spec.rs
@@ -15,16 +15,6 @@ pub(crate) enum StyleSpec {
     },
 }
 
-impl Default for StyleSpec {
-    fn default() -> Self {
-        Self::Styled {
-            fg: None,
-            bg: None,
-            modifiers: StyleModifiers::empty(),
-        }
-    }
-}
-
 impl StyleSpec {
     pub(crate) fn parse(s: &str) -> Self {
         let mut fg = None;


### PR DESCRIPTION
## Summary
- `StyleSpec::default()` がコードベース内のどこからも呼び出されていなかったため、`impl Default for StyleSpec` を削除しました。
- 唯一のコンストラクタである `StyleSpec::parse` に集約され、投機的な抽象を残さない方針に揃えます。

## Test plan
- [x] cargo build
- [x] cargo clippy --workspace --all-targets --all-features -- -D warnings
- [x] cargo fmt --check --all
- [x] cargo nextest run --workspace (310 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)