### PR TITLE
feat(daemon): self-terminate inner daemon when own socket disappears

### DIFF
--- a/src/contexts/daemon/infrastructure/background_refresh.rs
+++ b/src/contexts/daemon/infrastructure/background_refresh.rs
@@ -141,6 +141,7 @@ mod tests {
             refresh_lock_timeout_secs: 120,
             entry_max_age_secs: 60,
             scheduler_tick_secs: 2,
+            socket_check_interval_secs: 5,
             policy: RefreshPolicy {
                 hot_recent_query_secs: 30,
                 hot_with_query_secs: 2,

--- a/src/contexts/daemon/infrastructure/daemon_server.rs
+++ b/src/contexts/daemon/infrastructure/daemon_server.rs
@@ -94,9 +94,23 @@ pub fn run(on_refresh: &RefreshFn, paths: Paths) -> Result<(), DaemonError> {
     // non-blocking で accept し、終了シグナルを 10ms ごとにポーリングする
     listener.set_nonblocking(true).ok();
 
+    // 自身の socket ファイル消失を定期チェックする。テストハーネスが異常終了して
+    // Drop ベースの `daemon stop` が走らず TempDir ごと消えるケースで孤児化しないように、
+    // socket が外部から削除されたら break して自滅する。
+    let socket_check_interval = Duration::from_secs(config.socket_check_interval_secs);
+    let mut last_socket_check = Instant::now();
+
     let should_cleanup = loop {
         if exit_rx.try_recv().is_ok() {
             break false;
+        }
+
+        if last_socket_check.elapsed() >= socket_check_interval {
+            last_socket_check = Instant::now();
+            if !paths.socket_path().exists() {
+                log::info!("daemon socket disappeared, self-terminating");
+                break true;
+            }
         }
 
         match listener.accept() {

--- a/src/contexts/daemon/infrastructure/server_config.rs
+++ b/src/contexts/daemon/infrastructure/server_config.rs
@@ -28,6 +28,11 @@ const DEFAULT_ENTRY_MAX_AGE_SECS: u64 = 2 * 24 * 60 * 60;
 const DEFAULT_STALE_TTL_SECS: u64 = 5;
 const DEFAULT_REFRESH_LOCK_TIMEOUT_SECS: u64 = 120;
 const DEFAULT_SCHEDULER_TICK_SECS: u64 = 2;
+/// 自身の socket ファイル消失を検査する間隔（秒）。
+/// テスト異常終了や外部からの `rm` で消えたら daemon は自己終了する。
+/// `daemon stop` の `terminate_and_wait` 経路 (`STOP_TIMEOUT=2s`) より長く保つことで、
+/// 通常の停止フローと競合しないようにする。
+const DEFAULT_SOCKET_CHECK_INTERVAL_SECS: u64 = 5;
 
 // ── rate_limit 連動スケジューリング ────────────────────────────────────────
 /// `MERGE_READY_RATE_LIMIT_AWARE` のデフォルト値。`0` / `false` で OFF。
@@ -41,6 +46,8 @@ pub(super) struct DaemonServerConfig {
     pub(super) refresh_lock_timeout_secs: u64,
     pub(super) entry_max_age_secs: u64,
     pub(super) scheduler_tick_secs: u64,
+    /// 自身の socket ファイル消失を検査する間隔（秒）。
+    pub(super) socket_check_interval_secs: u64,
     pub(super) policy: RefreshPolicy,
     /// `gh api rate_limit` を観測して動的スケーリングと枯渇時 backoff を有効化する。
     pub(super) rate_limit_aware: bool,
@@ -63,6 +70,10 @@ impl DaemonServerConfig {
             scheduler_tick_secs: env_u64(
                 "MERGE_READY_SCHEDULER_TICK_SECS",
                 DEFAULT_SCHEDULER_TICK_SECS,
+            ),
+            socket_check_interval_secs: env_u64(
+                "MERGE_READY_SOCKET_CHECK_INTERVAL_SECS",
+                DEFAULT_SOCKET_CHECK_INTERVAL_SECS,
             ),
             policy: RefreshPolicy {
                 hot_recent_query_secs: env_u64(

--- a/src/contexts/daemon/infrastructure/server_state.rs
+++ b/src/contexts/daemon/infrastructure/server_state.rs
@@ -57,6 +57,7 @@ mod tests {
             refresh_lock_timeout_secs: 120,
             entry_max_age_secs: 60,
             scheduler_tick_secs: 2,
+            socket_check_interval_secs: 5,
             policy: RefreshPolicy {
                 hot_recent_query_secs: 30,
                 hot_with_query_secs: 2,

--- a/tests/e2e/daemon/lifecycle.rs
+++ b/tests/e2e/daemon/lifecycle.rs
@@ -552,6 +552,50 @@ fn test_daemon_stop_falls_back_to_sigterm_when_socket_removed() {
     );
 }
 
+// ── #S3: socket 消失で daemon が自己終了する ─────────────────────────────────
+
+/// #S3: テスト異常終了などで `base_dir` ごと消えたケースの再現。
+///
+/// 起動済み daemon の socket ファイルを外部から削除すると、accept ループに仕込んだ
+/// ポーリングで消失を検知し、daemon プロセスが自己終了する。
+///
+/// 双方向の保証:
+/// - リーク防止: テストハーネスが Drop を走らせられず socket だけ消えるケースで daemon が孤児化しない
+/// - 同一バージョン同期: 旧 daemon の socket を新 daemon の `restart::cleanup` 等で消したときの
+///   フェイルセーフとしても効く
+#[test]
+fn test_daemon_self_terminates_when_socket_disappears() {
+    let env = TestEnv::new(OPEN_PR_VIEW_JSON, Some(CI_PASS_JSON));
+    // E2E では検出までの待ち時間を短くしたいので、インターバルを 1 秒に縮める。
+    let _daemon =
+        DaemonHandle::start_with_env(&env, &[("MERGE_READY_SOCKET_CHECK_INTERVAL_SECS", "1")]);
+
+    let pid: u32 = std::fs::read_to_string(versioned_pid(env.home()))
+        .expect("read pid file")
+        .trim()
+        .parse()
+        .expect("parse pid");
+    assert!(
+        is_pid_alive(pid),
+        "daemon should be alive before socket removal"
+    );
+
+    std::fs::remove_file(versioned_socket(env.home())).expect("remove socket file");
+
+    // インターバル 1 秒 + リスポンスの猶予を見て 5 秒以内に exit するはず
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while std::time::Instant::now() < deadline {
+        if !is_pid_alive(pid) {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    assert!(
+        !is_pid_alive(pid),
+        "daemon (pid={pid}) should self-terminate within 5s after socket file removed"
+    );
+}
+
 // ── #18: stale PID ファイルのクリーンアップ ──────────────────────────────────
 
 /// #18: 前回クラッシュした daemon が残した stale な PID ファイルがある状態で


### PR DESCRIPTION
## Summary

- `daemon_server::run` の accept ループに自分の socket ファイル存在ポーリングを追加し、外部から socket が削除されたら inner daemon が自滅するようにする
- `MERGE_READY_SOCKET_CHECK_INTERVAL_SECS`（既定 5 秒）でポーリング周期を制御。`daemon stop` の SIGTERM フォールバック (`STOP_TIMEOUT=2s`) と競合しない長さに設定
- E2E テスト `#S3 test_daemon_self_terminates_when_socket_disappears` を追加。インターバルを 1 秒に縮めて 5 秒以内に self-terminate することを検証

Closes #331

## Background

`cargo nextest` のタイムアウト・Ctrl+C やパニック等で `DaemonHandle::drop` が走らないと、double-spawn された inner daemon が PPID=1 で孤児化し続ける問題があった。テストの `TempDir` 削除によって `MERGE_READY_BASE_DIR` 配下の socket/pid ファイルも消えるが、daemon プロセス自身は気付かず生存し続けてしまうため、本対策で「自分の socket が消えたら自滅」を加える。

## Test plan

- [x] `cargo nextest run --workspace`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --check --all`
- [x] `cargo deny check`
- [x] `bash scripts/check-layer-deps.sh`
- [x] `bash scripts/check-no-mod-rs.sh`
- [x] `bash scripts/check-no-clippy-allow.sh`
- [x] Red→Green の TDD で新規 E2E (`#S3`) を先に書いて fail を確認してから実装

🤖 Generated with [Claude Code](https://claude.com/claude-code)