### PR TITLE
fix(watch): right-align CACHED AT column

### DIFF
--- a/src/contexts/daemon/interface/cli/watch.rs
+++ b/src/contexts/daemon/interface/cli/watch.rs
@@ -99,7 +99,7 @@ fn format_table(entries: &[EntryView]) -> String {
     let mut out = String::new();
     let _ = writeln!(
         out,
-        "{:<cwd_width$}  {:<branch_width$}  {:<pr_width$}  {:<status_width$}  {}",
+        "{:<cwd_width$}  {:<branch_width$}  {:<pr_width$}  {:<status_width$}  {:>cached_at_width$}",
         header.cwd,
         header.branch,
         header.pr,
@@ -109,12 +109,15 @@ fn format_table(entries: &[EntryView]) -> String {
         branch_width = widths.branch,
         pr_width = widths.pr,
         status_width = widths.status,
+        cached_at_width = widths.cached_at,
     );
     for row in &rows {
-        let status_pad = widths.status - visible_len(&row.status) + row.status.len();
+        // Rust の幅指定子は `chars()` 数ベース。ANSI 込みの status を
+        // 見た目幅 `widths.status` で揃えるため、不可視 char 分を足し戻す。
+        let status_pad = widths.status - visible_len(&row.status) + row.status.chars().count();
         let _ = writeln!(
             out,
-            "{:<cwd_width$}  {:<branch_width$}  {:<pr_width$}  {:<status_pad$}  {}",
+            "{:<cwd_width$}  {:<branch_width$}  {:<pr_width$}  {:<status_pad$}  {:>cached_at_width$}",
             row.cwd,
             row.branch,
             row.pr,
@@ -123,6 +126,7 @@ fn format_table(entries: &[EntryView]) -> String {
             cwd_width = widths.cwd,
             branch_width = widths.branch,
             pr_width = widths.pr,
+            cached_at_width = widths.cached_at,
         );
     }
     out
@@ -153,6 +157,7 @@ struct TableWidths {
     branch: usize,
     pr: usize,
     status: usize,
+    cached_at: usize,
 }
 
 impl TableWidths {
@@ -164,6 +169,10 @@ impl TableWidths {
             status: max_width(
                 rows.iter().map(|row| visible_len(&row.status)),
                 header.status.len(),
+            ),
+            cached_at: max_width(
+                rows.iter().map(|row| row.cached_at.len()),
+                header.cached_at.len(),
             ),
         }
     }
@@ -344,5 +353,42 @@ mod tests {
     #[case(7200, "2h ago")]
     fn format_elapsed_various_durations(#[case] elapsed_secs: u64, #[case] expected: &str) {
         assert_eq!(format_elapsed(elapsed_secs), expected);
+    }
+
+    #[test]
+    fn format_table_right_aligns_cached_at_column() {
+        // status は ASCII（visible_len == len）にして他列の幅ぶれを排除し、
+        // CACHED AT 列の右揃えのみを検証する。
+        let rows = vec![
+            make_view("/repo", "main", Some(1), "Ready", 5),
+            make_view("/repo", "main", Some(2), "Ready", 7200),
+        ];
+        let table = format_table(&rows);
+        let lines: Vec<&str> = table.lines().collect();
+        assert_eq!(lines.len(), 3, "header + 2 rows: {table:?}");
+
+        let widths: Vec<usize> = lines.iter().map(|l| visible_len(l)).collect();
+        assert!(
+            widths.windows(2).all(|w| w[0] == w[1]),
+            "全行の表示幅が揃うべき: {widths:?} / {table:?}",
+        );
+
+        // "CACHED AT" (9 文字) がヘッダーで最長。短い値 "5s ago" (6 文字) は
+        // 3 文字の左パディングが付与された形で末尾に現れる。
+        assert!(
+            lines[0].ends_with("CACHED AT"),
+            "ヘッダーも右端で揃うべき: {:?}",
+            lines[0],
+        );
+        assert!(
+            lines[1].ends_with("   5s ago"),
+            "短い相対時刻は右揃えされるべき: {:?}",
+            lines[1],
+        );
+        assert!(
+            lines[2].ends_with("   2h ago"),
+            "短い相対時刻は右揃えされるべき: {:?}",
+            lines[2],
+        );
     }
 }

--- a/tests/e2e/daemon/watch.rs
+++ b/tests/e2e/daemon/watch.rs
@@ -185,6 +185,51 @@ fn spawn_watch_and_read_multi(env: &MultiRepoEnv, n: usize, timeout: Duration) -
     output
 }
 
+/// 画面クリア + カーソル移動の CSI。watch は描画ごとに先頭に挿入する。
+const SCREEN_CLEAR: &str = "\x1b[2J\x1b[1;1H";
+
+/// SGR カラーコード（`...m` 終端）を除いた可視文字数を返す。
+fn visible_len(s: &str) -> usize {
+    let mut len = 0;
+    let mut in_esc = false;
+    for c in s.chars() {
+        if c == '\x1b' {
+            in_esc = true;
+        } else if in_esc {
+            if c == 'm' {
+                in_esc = false;
+            }
+        } else {
+            len += 1;
+        }
+    }
+    len
+}
+
+/// CACHED AT 列はヘッダーも値も右揃えで描画される（末尾位置で揃う）
+#[test]
+fn test_watch_right_aligns_cached_at_column() {
+    let env = TestEnv::new(OPEN_PR_VIEW_JSON, Some(CI_PASS_JSON));
+    let _daemon = DaemonHandle::start(&env);
+    DaemonHandle::wait_for_cache(&env, 5000);
+
+    let output = spawn_watch_and_read(&env, 2, Duration::from_secs(5));
+    let lines: Vec<&str> = output.lines().collect();
+    assert!(lines.len() >= 2, "header + data 行が読めるべき: {output:?}");
+
+    let header = lines[0].strip_prefix(SCREEN_CLEAR).unwrap_or(lines[0]);
+    let data = lines[1];
+
+    assert!(header.ends_with("CACHED AT"), "header tail: {header:?}");
+    assert!(data.ends_with("ago"), "data tail: {data:?}");
+
+    assert_eq!(
+        visible_len(header),
+        visible_len(data),
+        "ヘッダー行とデータ行の表示幅が一致すべき (右端揃え): header={header:?}, data={data:?}",
+    );
+}
+
 /// #W7: 複数リポジトリがある場合、watch は CWD 昇順でソートして表示する
 #[test]
 fn test_watch_entries_sorted_by_cwd() {


### PR DESCRIPTION
## Summary

- `merge-ready watch` の `CACHED AT` 列を右揃えに変更し、`"18m ago"`/`"2m ago"`/`"31s ago"` のように長さが異なる相対時刻でも末尾が揃って読みやすくなるようにした。
- 合わせて、`status_pad` が `String::len()`（バイト数）ベースだったために `✓` を含む status (= multi-byte UTF-8) のときヘッダー行とデータ行の表示幅が 2 文字ズレる既存の不具合を `chars().count()` ベースに修正。CACHED AT の右揃え化で初めて目に見える形でズレが現れるため、同時に解消する。

## Before / After

Before（右端がガタつく）:

```
... STATUS               CACHED AT
... ✓ Ready for merge      18m ago
...                        2m ago
... ✓ Ready for merge      3m ago
...                        31s ago
```

After（末尾揃い）:

```
... STATUS             CACHED AT
... ✓ Ready for merge    18m ago
...                       2m ago
... ✓ Ready for merge     3m ago
...                      31s ago
```

## Test plan

- [x] `cargo nextest run --workspace`（既知 flaky の `test_rate_limit_exhausted_pauses_refresh_until_reset` を除き全 pass）
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --check --all`
- [x] `scripts/check-layer-deps.sh` / `scripts/check-no-mod-rs.sh` / `scripts/check-no-clippy-allow.sh`
- [x] 単体テスト追加: `format_table_right_aligns_cached_at_column`
- [x] E2E テスト追加: `test_watch_right_aligns_cached_at_column`
- [ ] 実環境で `merge-ready watch` を起動し目視で右端整列を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)