### PR TITLE
refactor(daemon): adopt tokio runtime and async I/O (#346 Phase 0〜2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,6 +641,7 @@ dependencies = [
  "signal-hook 0.4.4",
  "simplelog",
  "tempfile",
+ "tokio",
  "toml",
 ]
 
@@ -1118,6 +1125,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1203,6 +1220,34 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ toml = "1.1.2"
 crossterm = "0.29.0"
 bitflags = "2.11.1"
 signal-hook = { version = "0.4.4", default-features = false }
+tokio = { version = "1", features = ["full"] }
 
 [lib]
 name = "merge_ready"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,7 +7,7 @@ use clap_complete::generate;
 pub use crate::cli_args::{Cli, Command, DaemonCommand};
 
 #[must_use]
-pub fn run(cli: &Cli) -> ExitCode {
+pub async fn run(cli: &Cli) -> ExitCode {
     match &cli.command {
         Some(Command::Config) => merge_ready::config_command(),
         Some(Command::Completions { shell }) => {
@@ -16,7 +16,7 @@ pub fn run(cli: &Cli) -> ExitCode {
             ExitCode::SUCCESS
         }
         Some(Command::Daemon(args)) => match args.subcommand {
-            DaemonCommand::Start => merge_ready::daemon_start_command(),
+            DaemonCommand::Start => merge_ready::daemon_start_command().await,
             DaemonCommand::Stop => merge_ready::daemon_stop_command(),
             DaemonCommand::Status => merge_ready::daemon_status_command(),
         },

--- a/src/contexts/daemon/domain/cache/transition.rs
+++ b/src/contexts/daemon/domain/cache/transition.rs
@@ -302,15 +302,25 @@ fn ratio_bp(remaining: u32, limit: u32) -> u64 {
     (u64::from(remaining).saturating_mul(RATIO_SCALE_BP)) / u64::from(limit)
 }
 
-/// `snapshot.reset_at`（壁時計）を `Instant`（モノトニック）へ変換する。
+/// `snapshot.reset_at`（壁時計）を `Instant`（モノトニック）へ変換し、
+/// `BACKOFF_SAFETY_MARGIN` を追加した値を返す。
+///
+/// `gh api rate_limit` が返す `reset` は秒単位の Unix epoch なので、reset の瞬間に
+/// resume すると整数秒の境界に複数の refresh が集中しうる。`SCHEDULER_TICK_SECS` の
+/// 整数秒境界 (テスト config の場合 1s) と reset 時刻が同一秒境界に並ぶと
+/// scheduler tick と backoff 解除のタイミング race も発生する。
+/// この安全マージンによって両方を一括で回避する。
 fn reset_instant_from_snapshot(
     snapshot: &RateLimitSnapshot,
     now_instant: Instant,
     now_wall: SystemTime,
 ) -> Option<Instant> {
     let delta = snapshot.reset_at.duration_since(now_wall).ok()?;
-    Some(now_instant + delta)
+    Some(now_instant + delta + BACKOFF_SAFETY_MARGIN)
 }
+
+/// `backoff_until` に追加する安全マージン。詳細は [`reset_instant_from_snapshot`] を参照。
+const BACKOFF_SAFETY_MARGIN: Duration = Duration::from_millis(1500);
 
 // ───────────────────────────────────────────────────────────────
 // 純粋述語ヘルパ（旧 getter の `now` 引数化版）。daemon::domain 内で共有する

--- a/src/contexts/daemon/domain/daemon.rs
+++ b/src/contexts/daemon/domain/daemon.rs
@@ -15,7 +15,7 @@ pub struct DaemonStatus {
 /// デーモンのライフサイクル管理ポート
 pub trait DaemonLifecyclePort {
     /// デーモンを起動する。アイドルタイムアウトまたは Stop リクエストで返る。
-    fn start(&self) -> Result<(), DaemonError>;
+    fn start(&self) -> impl std::future::Future<Output = Result<(), DaemonError>> + Send;
     /// デーモンを停止する。成功時は `true` を返す。
     fn stop(&self) -> bool;
     /// デーモンのステータスを取得する。起動していない場合は `None` を返す。

--- a/src/contexts/daemon/infrastructure/connection.rs
+++ b/src/contexts/daemon/infrastructure/connection.rs
@@ -1,8 +1,10 @@
-use std::io::{BufRead, BufReader, Write};
-use std::os::unix::net::UnixStream;
-use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
+
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use tokio::runtime::Handle;
+use tokio::sync::mpsc::UnboundedSender;
 
 use super::daemon_server::RefreshFn;
 use super::paths::Paths;
@@ -11,17 +13,18 @@ use super::restart;
 use super::server_state::DaemonState;
 use crate::shared::protocol::Request;
 
-pub(super) fn handle(
+pub(super) async fn handle(
     mut stream: UnixStream,
     state: &Arc<Mutex<DaemonState>>,
     on_refresh: RefreshFn,
-    exit_tx: &mpsc::Sender<()>,
+    exit_tx: &UnboundedSender<()>,
     paths: &Paths,
+    handle: &Handle,
 ) {
     let mut buf = String::new();
     {
-        let mut reader = BufReader::new(&stream);
-        if reader.read_line(&mut buf).is_err() || buf.is_empty() {
+        let mut reader = BufReader::new(&mut stream);
+        if reader.read_line(&mut buf).await.is_err() || buf.is_empty() {
             return;
         }
     }
@@ -52,17 +55,17 @@ pub(super) fn handle(
     };
 
     if let Ok(json) = serde_json::to_string(&response) {
-        let _ = stream.write_all(format!("{json}\n").as_bytes());
+        let _ = stream.write_all(format!("{json}\n").as_bytes()).await;
     }
     drop(stream);
 
     if let (Some(repo_id), Some(cwd)) = (refresh_repo_id, refresh_cwd) {
-        super::daemon_server::spawn_refresh(&repo_id, &cwd, on_refresh);
+        super::daemon_server::spawn_refresh(&repo_id, &cwd, on_refresh, handle);
     }
 
     if stop {
         restart::cleanup(paths);
-        std::thread::sleep(Duration::from_millis(50));
+        tokio::time::sleep(Duration::from_millis(50)).await;
         let _ = exit_tx.send(());
     }
 }

--- a/src/contexts/daemon/infrastructure/daemon_lifecycle.rs
+++ b/src/contexts/daemon/infrastructure/daemon_lifecycle.rs
@@ -1,4 +1,6 @@
-use std::path::Path;
+use std::future::Future;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
 use std::time::Duration;
 
 use crate::contexts::daemon::application::port::{EntryView, WatchPort};
@@ -9,8 +11,8 @@ use super::paths::Paths;
 use super::{daemon_client::DaemonClient, daemon_server, pid};
 
 /// Imperative Shell から渡される、副作用を含むリフレッシュ実装。
-/// 関数ポインタとして受け取ることで、キャプチャを禁じ依存を明示する。
-pub type RefreshFn = fn(&RepoId, &Path);
+/// async 関数ポインタとして受け取ることで、キャプチャを禁じ依存を明示する。
+pub type RefreshFn = fn(RepoId, PathBuf) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
 const STOP_TIMEOUT: Duration = Duration::from_secs(2);
 
 pub struct DaemonLifecycle {
@@ -33,8 +35,8 @@ impl DaemonLifecycle {
 }
 
 impl DaemonLifecyclePort for DaemonLifecycle {
-    fn start(&self) -> Result<(), DaemonError> {
-        daemon_server::run(self.on_refresh, self.paths.clone())
+    async fn start(&self) -> Result<(), DaemonError> {
+        daemon_server::run(self.on_refresh, self.paths.clone()).await
     }
 
     fn stop(&self) -> bool {
@@ -109,8 +111,15 @@ mod tests {
 
     use super::*;
 
+    fn noop_refresh(
+        _repo_id: RepoId,
+        _cwd: PathBuf,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>> {
+        Box::pin(async move {})
+    }
+
     fn noop_lifecycle(paths: Paths) -> DaemonLifecycle {
-        DaemonLifecycle::with_paths(|_, _| {}, paths)
+        DaemonLifecycle::with_paths(noop_refresh, paths)
     }
 
     #[test]

--- a/src/contexts/daemon/infrastructure/daemon_server.rs
+++ b/src/contexts/daemon/infrastructure/daemon_server.rs
@@ -1,7 +1,14 @@
+use std::future::Future;
+use std::path::PathBuf;
+use std::pin::Pin;
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant, SystemTime};
+
+use tokio::runtime::Handle;
+use tokio::sync::mpsc as tokio_mpsc;
+use tokio::time::MissedTickBehavior;
 
 use super::background_refresh;
 use super::connection;
@@ -15,20 +22,24 @@ use super::socket_listener;
 use crate::contexts::daemon::domain::cache::RepoId;
 use crate::contexts::daemon::domain::daemon::DaemonError;
 
-pub(super) type RefreshFn = fn(&RepoId, &std::path::Path);
+/// Imperative Shell から渡される、副作用を含むリフレッシュ実装。
+/// async 関数ポインタとして受け取り、キャプチャを禁じ依存を明示する。
+pub(super) type RefreshFn =
+    fn(RepoId, PathBuf) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
 
 /// デーモンのメインループ。ソケットをバインドして接続を待ち受ける。
 ///
-/// `on_refresh` はキャッシュ更新が必要になったときにスレッドで呼ばれる。
+/// `on_refresh` はキャッシュ更新が必要になったときに tokio タスクとして spawn される。
 /// Stop リクエストで `Ok(())` を返す。
-pub fn run(on_refresh: RefreshFn, paths: Paths) -> Result<(), DaemonError> {
+pub async fn run(on_refresh: RefreshFn, paths: Paths) -> Result<(), DaemonError> {
+    let handle = Handle::current();
     let config = server_config::DaemonServerConfig::from_env();
     let socket_path = paths.socket_path();
     if let Some(parent) = socket_path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
 
-    let listener = socket_listener::bind(&paths)?;
+    let listener = socket_listener::bind(&paths).await?;
 
     // 外側プロセスへ起動完了を通知する（stdout pipe 経由）
     {
@@ -50,12 +61,13 @@ pub fn run(on_refresh: RefreshFn, paths: Paths) -> Result<(), DaemonError> {
     }
 
     let state = Arc::new(Mutex::new(DaemonState::new(config)));
-    let (exit_tx, exit_rx) = mpsc::channel::<()>();
+    let (exit_tx, mut exit_rx) = tokio_mpsc::unbounded_channel::<()>();
     let (scheduler_stop_tx, scheduler_stop_rx) = mpsc::channel::<()>();
     let (rate_limit_stop_tx, rate_limit_stop_rx) = mpsc::channel::<()>();
 
     let scheduler = {
         let state = Arc::clone(&state);
+        let scheduler_handle = handle.clone();
         std::thread::spawn(move || {
             loop {
                 match scheduler_stop_rx
@@ -66,7 +78,7 @@ pub fn run(on_refresh: RefreshFn, paths: Paths) -> Result<(), DaemonError> {
                 }
                 let refresh_targets = background_refresh::collect_targets(&state);
                 for (repo_id, cwd) in refresh_targets {
-                    spawn_refresh(&repo_id, &cwd, on_refresh);
+                    spawn_refresh(&repo_id, &cwd, on_refresh, &scheduler_handle);
                 }
             }
         })
@@ -79,6 +91,7 @@ pub fn run(on_refresh: RefreshFn, paths: Paths) -> Result<(), DaemonError> {
             Arc::new(RateLimitClient::new(interval)),
             interval,
             rate_limit_stop_rx,
+            handle.clone(),
         ))
     } else {
         // OFF 時もスレッドを生やさないが、stop チャネルは drop しても害なし
@@ -86,53 +99,50 @@ pub fn run(on_refresh: RefreshFn, paths: Paths) -> Result<(), DaemonError> {
         None
     };
 
-    // non-blocking で accept し、終了シグナルを 10ms ごとにポーリングする
-    listener.set_nonblocking(true).ok();
-
     // 自身の socket ファイル消失を定期チェックする。テストハーネスが異常終了して
     // Drop ベースの `daemon stop` が走らず TempDir ごと消えるケースで孤児化しないように、
     // socket が外部から削除されたら break して自滅する。
-    let socket_check_interval = Duration::from_secs(config.socket_check_interval_secs);
-    let mut last_socket_check = Instant::now();
+    let mut socket_check =
+        tokio::time::interval(Duration::from_secs(config.socket_check_interval_secs));
+    socket_check.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
     let should_cleanup = loop {
-        if exit_rx.try_recv().is_ok() {
-            break false;
-        }
-
-        if last_socket_check.elapsed() >= socket_check_interval {
-            last_socket_check = Instant::now();
-            if !paths.socket_path().exists() {
-                log::info!("daemon socket disappeared, self-terminating");
-                break true;
+        tokio::select! {
+            biased;
+            _ = exit_rx.recv() => break false,
+            _ = socket_check.tick() => {
+                if !paths.socket_path().exists() {
+                    log::info!("daemon socket disappeared, self-terminating");
+                    break true;
+                }
             }
-        }
-
-        match listener.accept() {
-            Ok((s, _)) => {
-                let state = Arc::clone(&state);
-                let exit_tx = exit_tx.clone();
-                let paths = Arc::clone(&paths);
-                std::thread::spawn(move || {
-                    connection::handle(s, &state, on_refresh, &exit_tx, &paths);
-                });
-            }
-            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                std::thread::sleep(Duration::from_millis(10));
-            }
-            Err(e) => {
-                log::error!("listener error: {e}");
-                break true;
+            accept_result = listener.accept() => match accept_result {
+                Ok((s, _)) => {
+                    let state = Arc::clone(&state);
+                    let exit_tx = exit_tx.clone();
+                    let paths = Arc::clone(&paths);
+                    let conn_handle = handle.clone();
+                    tokio::spawn(async move {
+                        connection::handle(s, &state, on_refresh, &exit_tx, &paths, &conn_handle).await;
+                    });
+                }
+                Err(e) => {
+                    log::error!("listener error: {e}");
+                    break true;
+                }
             }
         }
     };
 
     let _ = scheduler_stop_tx.send(());
-    let _ = scheduler.join();
     let _ = rate_limit_stop_tx.send(());
-    if let Some(t) = rate_limit_thread {
-        let _ = t.join();
-    }
+    // std::thread の join は async ワーカーをブロックしないよう block_in_place で
+    tokio::task::block_in_place(|| {
+        let _ = scheduler.join();
+        if let Some(t) = rate_limit_thread {
+            let _ = t.join();
+        }
+    });
 
     if should_cleanup {
         restart::cleanup(&paths);
@@ -148,11 +158,14 @@ fn spawn_rate_limit_fetcher(
     client: Arc<RateLimitClient>,
     interval: Duration,
     stop_rx: mpsc::Receiver<()>,
+    handle: Handle,
 ) -> JoinHandle<()> {
     std::thread::spawn(move || {
         loop {
-            // 初回は起動直後に取得し、その後は `interval` 間隔で繰り返す
-            if let Some(snapshot) = client.fetch_or_cached() {
+            // 初回は起動直後に取得し、その後は `interval` 間隔で繰り返す。
+            // async fn `fetch_or_cached` を専用 std::thread から実行するため
+            // tokio runtime Handle で block_on する（Phase 4 で async task 化予定）。
+            if let Some(snapshot) = handle.block_on(client.fetch_or_cached()) {
                 update_state_from_snapshot(&state, &snapshot);
             }
             match stop_rx.recv_timeout(interval) {
@@ -192,11 +205,16 @@ fn update_state_from_snapshot(
 
 /// リフレッシュ後に `cwd` から `repo_id` を再導出してコールバックを呼ぶ。
 /// ブランチが変わっていれば新しい `repo_id` に対してキャッシュを更新する。
-pub(super) fn spawn_refresh(stored_repo_id: &RepoId, cwd: &std::path::Path, on_refresh: RefreshFn) {
+pub(super) fn spawn_refresh(
+    stored_repo_id: &RepoId,
+    cwd: &std::path::Path,
+    on_refresh: RefreshFn,
+    handle: &Handle,
+) {
     let current_repo_id = cwd
         .to_str()
         .and_then(repo_id::repo_id_from_cwd)
         .map_or_else(|| stored_repo_id.clone(), RepoId::new);
     let cwd = cwd.to_path_buf();
-    std::thread::spawn(move || on_refresh(&current_repo_id, &cwd));
+    handle.spawn(on_refresh(current_repo_id, cwd));
 }

--- a/src/contexts/daemon/infrastructure/rate_limit_client.rs
+++ b/src/contexts/daemon/infrastructure/rate_limit_client.rs
@@ -46,16 +46,16 @@ impl RateLimitClient {
 
     /// キャッシュが新鮮なら再利用し、そうでなければ `gh api rate_limit` を呼ぶ。
     /// 取得失敗時は `None` を返す（呼び出し側でフォールバック挙動）。
-    pub(super) fn fetch_or_cached(&self) -> Option<RateLimitSnapshot> {
+    pub(super) async fn fetch_or_cached(&self) -> Option<RateLimitSnapshot> {
         if let Some(snap) = self.cached_if_fresh() {
             return Some(snap);
         }
-        self.force_refresh()
+        self.force_refresh().await
     }
 
     /// 強制的に再取得する（403 受信時の即時参照用）。
-    pub(super) fn force_refresh(&self) -> Option<RateLimitSnapshot> {
-        let snap = raw_fetch()?;
+    pub(super) async fn force_refresh(&self) -> Option<RateLimitSnapshot> {
+        let snap = raw_fetch().await?;
         let mut guard = self.cache.lock().unwrap_or_else(PoisonError::into_inner);
         *guard = Some(snap);
         Some(snap)
@@ -72,8 +72,8 @@ impl RateLimitClient {
     }
 }
 
-fn raw_fetch() -> Option<RateLimitSnapshot> {
-    match run_gh(&["api", "rate_limit"], None) {
+async fn raw_fetch() -> Option<RateLimitSnapshot> {
+    match run_gh(&["api", "rate_limit"], None).await {
         Ok(bytes) => {
             let parsed = parse_rate_limit_json(&bytes, Instant::now());
             if parsed.is_none() {

--- a/src/contexts/daemon/infrastructure/socket_listener.rs
+++ b/src/contexts/daemon/infrastructure/socket_listener.rs
@@ -1,5 +1,6 @@
-use std::os::unix::net::UnixListener;
 use std::time::Duration;
+
+use tokio::net::UnixListener;
 
 use super::{paths::Paths, pid};
 use crate::contexts::daemon::domain::daemon::DaemonError;
@@ -7,15 +8,16 @@ use crate::contexts::daemon::domain::daemon::DaemonError;
 const BIND_RETRY_INTERVAL_MS: u64 = 100;
 const BIND_RETRY_MAX: usize = 10;
 
-pub(super) fn bind(paths: &Paths) -> Result<UnixListener, DaemonError> {
+pub(super) async fn bind(paths: &Paths) -> Result<UnixListener, DaemonError> {
     bind_with(
         paths,
         BIND_RETRY_MAX,
         Duration::from_millis(BIND_RETRY_INTERVAL_MS),
     )
+    .await
 }
 
-fn bind_with(
+async fn bind_with(
     paths: &Paths,
     retry_max: usize,
     retry_interval: Duration,
@@ -62,12 +64,13 @@ fn bind_with(
         || UnixListener::bind(&socket_path),
         retry_max,
         retry_interval,
-    )?;
+    )
+    .await?;
     pid::write(std::process::id(), &pid_path);
     Ok(listener)
 }
 
-fn bind_with_retry<F>(
+async fn bind_with_retry<F>(
     mut try_bind: F,
     retry_max: usize,
     retry_interval: Duration,
@@ -85,7 +88,7 @@ where
                     return Err(DaemonError::AlreadyRunning);
                 }
                 retries += 1;
-                std::thread::sleep(retry_interval);
+                tokio::time::sleep(retry_interval).await;
             }
             Err(e) => {
                 log::error!("failed to bind socket: {e}");
@@ -102,20 +105,20 @@ mod tests {
     use std::io::{Error, ErrorKind};
     use tempfile::tempdir;
 
-    #[test]
-    fn bind_returns_failure_when_lock_file_cannot_be_opened() {
+    #[tokio::test]
+    async fn bind_returns_failure_when_lock_file_cannot_be_opened() {
         // base_dir 自体が存在しない場合、`OpenOptions::create(true).open(lock_path)` は
         // 親ディレクトリ不在で ENOENT になり、open() の map_err 経路を踏む。
         let tmp = tempdir().unwrap();
         let bogus = tmp.path().join("does-not-exist-dir");
         let paths = Paths::new(bogus);
 
-        let err = bind(&paths).unwrap_err();
+        let err = bind(&paths).await.unwrap_err();
         assert!(matches!(err, DaemonError::Failure));
     }
 
-    #[test]
-    fn bind_with_retry_returns_failure_on_non_addr_in_use_error() {
+    #[tokio::test]
+    async fn bind_with_retry_returns_failure_on_non_addr_in_use_error() {
         let err = bind_with_retry(
             || -> std::io::Result<UnixListener> {
                 Err(Error::new(ErrorKind::PermissionDenied, "denied"))
@@ -123,12 +126,13 @@ mod tests {
             3,
             Duration::ZERO,
         )
+        .await
         .unwrap_err();
         assert!(matches!(err, DaemonError::Failure));
     }
 
-    #[test]
-    fn bind_with_retry_returns_already_running_after_exhausting_retries() {
+    #[tokio::test]
+    async fn bind_with_retry_returns_already_running_after_exhausting_retries() {
         let mut calls = 0_usize;
         let err = bind_with_retry(
             || -> std::io::Result<UnixListener> {
@@ -138,6 +142,7 @@ mod tests {
             2,
             Duration::ZERO,
         )
+        .await
         .unwrap_err();
         assert!(matches!(err, DaemonError::AlreadyRunning));
         // retry_max=2 のため、初回 + 2 リトライ = 計 3 回試行してから上限到達。

--- a/src/contexts/daemon/interface/cli/daemon.rs
+++ b/src/contexts/daemon/interface/cli/daemon.rs
@@ -18,9 +18,9 @@ const START_TIMEOUT_SECS: u64 = 2;
 // 欠点は setsid() を呼べないため SIGHUP を受ける可能性があること。
 // ただしプロンプト統合の用途では端末クローズ時にデーモンが終了しても
 // 次回 prompt 呼び出し時に lazy_start() が再起動するため実害はない。
-pub(crate) fn start(port: &impl DaemonLifecyclePort) -> ExitCode {
+pub(crate) async fn start(port: &impl DaemonLifecyclePort) -> ExitCode {
     if std::env::var(DAEMON_INNER_ENV).is_ok() {
-        return match port.start() {
+        return match port.start().await {
             Ok(()) => ExitCode::SUCCESS,
             Err(_) => ExitCode::FAILURE,
         };

--- a/src/contexts/evaluation/infrastructure/gh.rs
+++ b/src/contexts/evaluation/infrastructure/gh.rs
@@ -3,12 +3,13 @@ mod fetch;
 mod mapper;
 mod schema;
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use error::{GhError, classify_gh_error};
 use fetch::fetch_behind_by;
 use mapper::{aggregate_ci, translate_review, translate_sync, translate_unblocked};
 use schema::{CheckBucket, GhCheckItem, GhPrListItem, GhRepoViewFull, translate_bucket};
+use tokio::task::JoinSet;
 
 use crate::contexts::evaluation::domain::error::RepositoryError;
 use crate::contexts::evaluation::domain::prompt::pull_request::state::blocked::CiState;
@@ -17,8 +18,8 @@ use crate::contexts::evaluation::domain::prompt::{PrId, Prompt, PullRequest, Sta
 use crate::contexts::evaluation::infrastructure::git::{current_branch, is_git_repo};
 use crate::contexts::evaluation::infrastructure::logger::{ErrorCategory, LogRecord, log_record};
 
-fn run_gh(cwd: &Path, args: &[&str]) -> Result<Vec<u8>, GhError> {
-    match crate::shared::process_gh::run_gh(args, Some(cwd)) {
+async fn run_gh(cwd: &Path, args: &[&str]) -> Result<Vec<u8>, GhError> {
+    match crate::shared::process_gh::run_gh(args, Some(cwd)).await {
         Ok(bytes) => Ok(bytes),
         Err(crate::shared::process_gh::GhProcessError::NotInstalled) => Err(GhError::NotInstalled),
         Err(crate::shared::process_gh::GhProcessError::Timeout) => Err(GhError::Timeout),
@@ -53,8 +54,8 @@ fn log_and_convert(e: GhError) -> RepositoryError {
     RepositoryError::from(e)
 }
 
-fn default_branch(cwd: &Path) -> String {
-    match run_gh(cwd, &["repo", "view", "--json", "defaultBranchRef"]) {
+async fn default_branch(cwd: &Path) -> String {
+    match run_gh(cwd, &["repo", "view", "--json", "defaultBranchRef"]).await {
         Ok(bytes) => match serde_json::from_slice::<GhRepoViewFull>(&bytes) {
             Ok(v) => v.default_branch_ref.name,
             Err(_) => String::new(),
@@ -63,16 +64,16 @@ fn default_branch(cwd: &Path) -> String {
     }
 }
 
-fn is_default_branch(cwd: &Path) -> bool {
-    let branch = current_branch(cwd).unwrap_or_default();
+async fn is_default_branch(cwd: &Path) -> bool {
+    let branch = current_branch(cwd).await.unwrap_or_default();
     if branch.is_empty() {
         return false;
     }
-    branch == default_branch(cwd)
+    branch == default_branch(cwd).await
 }
 
-fn fetch_pr_list(cwd: &Path) -> Result<Vec<GhPrListItem>, GhError> {
-    let branch = current_branch(cwd).unwrap_or_default();
+async fn fetch_pr_list(cwd: &Path) -> Result<Vec<GhPrListItem>, GhError> {
+    let branch = current_branch(cwd).await.unwrap_or_default();
     let bytes = run_gh(
         cwd,
         &[
@@ -85,7 +86,8 @@ fn fetch_pr_list(cwd: &Path) -> Result<Vec<GhPrListItem>, GhError> {
             "--json",
             "number,state,isDraft,mergeable,mergeStateStatus,reviewDecision,baseRefName,headRefName",
         ],
-    )?;
+    )
+    .await?;
     let mut items: Vec<GhPrListItem> = serde_json::from_slice(&bytes).map_err(|e| {
         log_record(&LogRecord {
             category: ErrorCategory::Unknown,
@@ -97,12 +99,17 @@ fn fetch_pr_list(cwd: &Path) -> Result<Vec<GhPrListItem>, GhError> {
     Ok(items)
 }
 
-fn fetch_ci_state_for(cwd: &Path, pr_number: u64) -> Result<Option<CiState>, RepositoryError> {
+async fn fetch_ci_state_for(
+    cwd: &Path,
+    pr_number: u64,
+) -> Result<Option<CiState>, RepositoryError> {
     let pr_num_str = pr_number.to_string();
     let bytes = match run_gh(
         cwd,
         &["pr", "checks", &pr_num_str, "--json", "bucket,state"],
-    ) {
+    )
+    .await
+    {
         Ok(b) => b,
         Err(GhError::ApiError(msg)) if msg.contains("no checks reported") => {
             return Ok(None);
@@ -120,27 +127,27 @@ fn fetch_ci_state_for(cwd: &Path, pr_number: u64) -> Result<Option<CiState>, Rep
     Ok(aggregate_ci(&buckets))
 }
 
-fn evaluate_single_pr(cwd: &Path, pr_view: &GhPrListItem) -> Result<PullRequest, RepositoryError> {
+async fn evaluate_single_pr(
+    cwd: PathBuf,
+    pr_view: GhPrListItem,
+) -> Result<PullRequest, RepositoryError> {
     let id = PrId::new(pr_view.number);
 
     // branch_sync と ci を並列取得
-    let (branch_sync, ci_result) = std::thread::scope(|s| {
-        let base = pr_view.base_ref_name.as_str();
-        let head = pr_view.head_ref_name.as_str();
-        let mergeable = pr_view.mergeable.as_str();
-        let pr_number = pr_view.number;
+    let base = pr_view.base_ref_name.clone();
+    let head = pr_view.head_ref_name.clone();
+    let mergeable = pr_view.mergeable.clone();
+    let pr_number = pr_view.number;
+    let cwd_for_sync = cwd.clone();
+    let cwd_for_ci = cwd.clone();
 
-        let sync_handle = s.spawn(move || {
-            let behind_by = fetch_behind_by(base, head, Some(cwd));
-            translate_sync(mergeable, behind_by)
-        });
-        let ci_handle = s.spawn(move || fetch_ci_state_for(cwd, pr_number));
-
-        (
-            sync_handle.join().expect("sync thread panicked"),
-            ci_handle.join().expect("ci thread panicked"),
-        )
-    });
+    let (branch_sync, ci_result) = tokio::join!(
+        async move {
+            let behind_by = fetch_behind_by(&base, &head, Some(&cwd_for_sync)).await;
+            translate_sync(&mergeable, behind_by)
+        },
+        async move { fetch_ci_state_for(&cwd_for_ci, pr_number).await },
+    );
 
     let ci = ci_result?;
 
@@ -170,12 +177,12 @@ fn evaluate_single_pr(cwd: &Path, pr_view: &GhPrListItem) -> Result<PullRequest,
 ///
 /// # Errors
 /// gh コマンドの失敗や API レート制限などインフラ起因のエラーを返す。
-pub fn fetch_prompt(cwd: &Path) -> Result<Prompt, RepositoryError> {
+pub async fn fetch_prompt(cwd: &Path) -> Result<Prompt, RepositoryError> {
     if !is_git_repo(cwd) {
         return Ok(Prompt::NoRepository);
     }
 
-    let all_prs = match fetch_pr_list(cwd) {
+    let all_prs = match fetch_pr_list(cwd).await {
         Ok(list) => list,
         Err(GhError::NoPr) => return Ok(Prompt::NoPullRequest),
         Err(GhError::NotGithubRepository) => return Ok(Prompt::UnsupportedRepository),
@@ -184,31 +191,38 @@ pub fn fetch_prompt(cwd: &Path) -> Result<Prompt, RepositoryError> {
 
     // PR が一度も作られていない場合
     if all_prs.is_empty() {
-        if is_default_branch(cwd) {
+        if is_default_branch(cwd).await {
             return Ok(Prompt::DefaultBranch);
         }
         return Ok(Prompt::NoPullRequest);
     }
 
-    let open_prs: Vec<&GhPrListItem> = all_prs.iter().filter(|p| p.state == "OPEN").collect();
+    let open_prs: Vec<GhPrListItem> = all_prs.into_iter().filter(|p| p.state == "OPEN").collect();
 
     // オープン PR がなく全て MERGED/CLOSED → ターミナル状態（空 Vec で表現）
     if open_prs.is_empty() {
         return Ok(Prompt::PullRequests(vec![]));
     }
 
-    // オープン PR のみを evaluate
-    let results: Vec<Result<PullRequest, RepositoryError>> = std::thread::scope(|s| {
-        let handles: Vec<_> = open_prs
-            .iter()
-            .map(|pr_view| s.spawn(|| evaluate_single_pr(cwd, pr_view)))
-            .collect();
-        handles
-            .into_iter()
-            .map(|h| h.join().expect("pr evaluation thread panicked"))
-            .collect()
-    });
+    // オープン PR のみを evaluate（順序を保つため index を付与）
+    let mut set: JoinSet<(usize, Result<PullRequest, RepositoryError>)> = JoinSet::new();
+    for (idx, pr_view) in open_prs.into_iter().enumerate() {
+        let cwd = cwd.to_path_buf();
+        set.spawn(async move {
+            let result = evaluate_single_pr(cwd, pr_view).await;
+            (idx, result)
+        });
+    }
 
-    let prs: Result<Vec<PullRequest>, RepositoryError> = results.into_iter().collect();
+    let mut indexed: Vec<(usize, Result<PullRequest, RepositoryError>)> =
+        Vec::with_capacity(set.len());
+    while let Some(join_result) = set.join_next().await {
+        let pair = join_result.expect("pr evaluation task panicked");
+        indexed.push(pair);
+    }
+    indexed.sort_by_key(|(idx, _)| *idx);
+
+    let prs: Result<Vec<PullRequest>, RepositoryError> =
+        indexed.into_iter().map(|(_, r)| r).collect();
     Ok(Prompt::PullRequests(prs?))
 }

--- a/src/contexts/evaluation/infrastructure/gh/fetch.rs
+++ b/src/contexts/evaluation/infrastructure/gh/fetch.rs
@@ -7,12 +7,16 @@ use crate::shared::process_gh::run_gh;
 ///
 /// `base_ref` / `head_ref` が空の場合は `Some(0)` を返す（追跡不要）。
 /// 失敗した場合は `None` を返す（呼び出し元が `SyncUnknown` として扱う）。
-pub(super) fn fetch_behind_by(base_ref: &str, head_ref: &str, cwd: Option<&Path>) -> Option<u64> {
+pub(super) async fn fetch_behind_by(
+    base_ref: &str,
+    head_ref: &str,
+    cwd: Option<&Path>,
+) -> Option<u64> {
     if base_ref.is_empty() || head_ref.is_empty() {
         return Some(0);
     }
 
-    let name_with_owner = match run_gh(&["repo", "view", "--json", "nameWithOwner"], cwd) {
+    let name_with_owner = match run_gh(&["repo", "view", "--json", "nameWithOwner"], cwd).await {
         Ok(bytes) => match serde_json::from_slice::<GhRepoView>(&bytes) {
             Ok(r) => r.name_with_owner,
             Err(_) => return None,
@@ -22,7 +26,7 @@ pub(super) fn fetch_behind_by(base_ref: &str, head_ref: &str, cwd: Option<&Path>
 
     let path = format!("repos/{name_with_owner}/compare/{base_ref}...{head_ref}");
 
-    match run_gh(&["api", &path], cwd) {
+    match run_gh(&["api", &path], cwd).await {
         Ok(bytes) => serde_json::from_slice::<GhCompare>(&bytes)
             .map(|c| c.behind_by)
             .ok(),

--- a/src/contexts/evaluation/infrastructure/git.rs
+++ b/src/contexts/evaluation/infrastructure/git.rs
@@ -1,5 +1,7 @@
 use std::path::Path;
-use std::process::{Command, Stdio};
+use std::process::Stdio;
+
+use tokio::process::Command;
 
 pub fn is_git_repo(cwd: &Path) -> bool {
     let mut current = cwd;
@@ -14,13 +16,15 @@ pub fn is_git_repo(cwd: &Path) -> bool {
     }
 }
 
-pub fn current_branch(cwd: &Path) -> Option<String> {
+pub async fn current_branch(cwd: &Path) -> Option<String> {
     let out = Command::new("git")
         .args(["branch", "--show-current"])
         .current_dir(cwd)
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
+        .kill_on_drop(true)
         .output()
+        .await
         .ok()?;
     if out.status.success() {
         Some(String::from_utf8_lossy(&out.stdout).trim().to_string())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,9 @@ pub(crate) mod shared;
 
 pub use shared::prompt_ipc;
 
-use std::path::Path;
+use std::future::Future;
+use std::path::PathBuf;
+use std::pin::Pin;
 use std::process::ExitCode;
 
 use crate::contexts::daemon::domain::cache::{CachePort, RepoId};
@@ -21,28 +23,33 @@ use crate::shared::protocol::PrOutput;
 
 /// Imperative Shell: 副作用（gh サブプロセス、TOML 読み込み、ログ書き込み、
 /// daemon キャッシュ更新）を集約して純関数 `render` を駆動する。
-fn refresh_callback(repo_id: &RepoId, cwd: &Path) {
-    let prompt_result = fetch_prompt(cwd).map_err(|e| {
-        log_repository_error(e);
-        into_token(e)
-    });
-    let config = load_display_config();
-    let result = render(prompt_result, &config);
+fn refresh_callback(
+    repo_id: RepoId,
+    cwd: PathBuf,
+) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>> {
+    Box::pin(async move {
+        let prompt_result = fetch_prompt(&cwd).await.map_err(|e| {
+            log_repository_error(e);
+            into_token(e)
+        });
+        let config = load_display_config();
+        let result = render(prompt_result, &config);
 
-    let pr_outputs = result
-        .pr_outputs
-        .into_iter()
-        .map(|(pr_id, output)| PrOutput {
-            pr_id: pr_id.as_u64(),
-            output,
-        })
-        .collect();
-    DaemonClient::new(Paths::default().socket_path()).update(
-        repo_id,
-        &result.output,
-        result.refresh_mode,
-        pr_outputs,
-    );
+        let pr_outputs = result
+            .pr_outputs
+            .into_iter()
+            .map(|(pr_id, output)| PrOutput {
+                pr_id: pr_id.as_u64(),
+                output,
+            })
+            .collect();
+        DaemonClient::new(Paths::default().socket_path()).update(
+            &repo_id,
+            &result.output,
+            result.refresh_mode,
+            pr_outputs,
+        );
+    })
 }
 
 fn build_daemon_lifecycle() -> DaemonLifecycle {
@@ -64,11 +71,10 @@ pub fn config_command() -> ExitCode {
 ///
 /// The daemon fetches PR merge-readiness in the background and caches the result
 /// so that `merge-ready-prompt` can respond instantly.
-#[must_use]
-pub fn daemon_start_command() -> ExitCode {
+pub async fn daemon_start_command() -> ExitCode {
     contexts::evaluation::infrastructure::logger::init();
     let lifecycle = build_daemon_lifecycle();
-    contexts::daemon::interface::cli::daemon::start(&lifecycle)
+    contexts::daemon::interface::cli::daemon::start(&lifecycle).await
 }
 
 /// Stops the running background cache daemon.

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,5 +8,5 @@ use clap::Parser;
 #[tokio::main]
 async fn main() -> ExitCode {
     let cli = cli::Cli::parse();
-    cli::run(&cli)
+    cli::run(&cli).await
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,8 @@ use std::process::ExitCode;
 
 use clap::Parser;
 
-fn main() -> ExitCode {
+#[tokio::main]
+async fn main() -> ExitCode {
     let cli = cli::Cli::parse();
     cli::run(&cli)
 }

--- a/src/shared/process_gh.rs
+++ b/src/shared/process_gh.rs
@@ -6,11 +6,13 @@
 //! エラー分類は呼び出し側の関心事として保持し、ここでは
 //! `NotInstalled` / `Timeout` / `Failed { exit_code, stderr }` の 3 種類だけを返す。
 
-use std::io::{ErrorKind, Read};
+use std::io::ErrorKind;
 use std::path::Path;
-use std::process::{Command, Stdio};
-use std::sync::mpsc;
-use std::time::{Duration, Instant};
+use std::process::Stdio;
+use std::time::Duration;
+
+use tokio::process::Command;
+use tokio::time::timeout;
 
 #[derive(Debug)]
 pub enum GhProcessError {
@@ -30,7 +32,7 @@ fn gh_timeout() -> Duration {
     Duration::from_secs(secs)
 }
 
-pub fn run_gh(args: &[&str], cwd: Option<&Path>) -> Result<Vec<u8>, GhProcessError> {
+pub async fn run_gh(args: &[&str], cwd: Option<&Path>) -> Result<Vec<u8>, GhProcessError> {
     let mut cmd = Command::new("gh");
     cmd.args(args);
     cmd.stdout(Stdio::piped());
@@ -38,8 +40,11 @@ pub fn run_gh(args: &[&str], cwd: Option<&Path>) -> Result<Vec<u8>, GhProcessErr
     if let Some(dir) = cwd {
         cmd.current_dir(dir);
     }
+    // kill_on_drop=true で、タイムアウトで future を drop した瞬間に
+    // 子プロセスへ SIGKILL を送る。明示的な kill+wait のボイラープレートを削減。
+    cmd.kill_on_drop(true);
 
-    let mut child = match cmd.spawn() {
+    let child = match cmd.spawn() {
         Err(e) if e.kind() == ErrorKind::NotFound => return Err(GhProcessError::NotInstalled),
         Err(e) => {
             return Err(GhProcessError::Failed {
@@ -50,50 +55,25 @@ pub fn run_gh(args: &[&str], cwd: Option<&Path>) -> Result<Vec<u8>, GhProcessErr
         Ok(c) => c,
     };
 
-    let mut stdout_pipe = child.stdout.take().expect("piped");
-    let mut stderr_pipe = child.stderr.take().expect("piped");
-
-    let (tx_out, rx_out) = mpsc::channel::<Vec<u8>>();
-    let (tx_err, rx_err) = mpsc::channel::<Vec<u8>>();
-    std::thread::spawn(move || {
-        let mut buf = Vec::new();
-        let _ = stdout_pipe.read_to_end(&mut buf);
-        let _ = tx_out.send(buf);
-    });
-    std::thread::spawn(move || {
-        let mut buf = Vec::new();
-        let _ = stderr_pipe.read_to_end(&mut buf);
-        let _ = tx_err.send(buf);
-    });
-
-    let deadline = Instant::now() + gh_timeout();
-    loop {
-        match child.try_wait() {
-            Ok(Some(status)) => {
-                let stdout = rx_out.recv().unwrap_or_default();
-                let stderr = rx_err.recv().unwrap_or_default();
-                if status.success() {
-                    return Ok(stdout);
-                }
-                let exit_code = status.code().unwrap_or(1);
-                let stderr_str = String::from_utf8_lossy(&stderr).into_owned();
-                return Err(GhProcessError::Failed {
-                    exit_code,
-                    stderr: stderr_str,
-                });
-            }
-            Ok(None) if Instant::now() >= deadline => {
-                let _ = child.kill();
-                let _ = child.wait();
-                return Err(GhProcessError::Timeout);
-            }
-            Ok(None) => std::thread::sleep(Duration::from_millis(50)),
-            Err(e) => {
-                return Err(GhProcessError::Failed {
-                    exit_code: -1,
-                    stderr: e.to_string(),
-                });
-            }
+    let output = match timeout(gh_timeout(), child.wait_with_output()).await {
+        Ok(Ok(out)) => out,
+        Ok(Err(e)) => {
+            return Err(GhProcessError::Failed {
+                exit_code: -1,
+                stderr: e.to_string(),
+            });
         }
+        Err(_) => return Err(GhProcessError::Timeout),
+    };
+
+    if output.status.success() {
+        Ok(output.stdout)
+    } else {
+        let exit_code = output.status.code().unwrap_or(1);
+        let stderr_str = String::from_utf8_lossy(&output.stderr).into_owned();
+        Err(GhProcessError::Failed {
+            exit_code,
+            stderr: stderr_str,
+        })
     }
 }


### PR DESCRIPTION
## Summary

Sub-issue A (#346) の Phase 0〜2 を一括で実装し、`merge-ready` の daemon と evaluation 配下の subprocess/socket I/O を tokio 非同期化する。`Arc<Mutex<DaemonState>>` の撤廃と scheduler/rate_limit_fetcher の async タスク化は Sub-issue B (#347) に残す。

### Phase 0: tokio runtime 導入 (`0b80430`)
- `Cargo.toml` に `tokio = { version = "1", features = ["full"] }` を追加
- `src/main.rs` を `#[tokio::main] async fn main` に変更

### Phase 1: gh subprocess の async 化 (`790404f`)
- `src/shared/process_gh.rs` を `tokio::process::Command` + `tokio::time::timeout` で書き直し、2 reader thread / mpsc channels / `try_wait`+50ms ポーリングループを削除
- `src/contexts/evaluation/infrastructure/gh.rs` / `gh/fetch.rs` の `fetch_pr_list` / `default_branch` / `fetch_ci_state_for` / `fetch_behind_by` を async 化
  - PR ごとの branch_sync + CI 取得を `tokio::join!` に
  - 複数 PR の並列評価を `std::thread::scope` から `tokio::task::JoinSet` に置換（順序は index タグ付けで保持）
- `src/contexts/evaluation/infrastructure/git.rs::current_branch` も `tokio::process::Command` ベース
- `src/contexts/daemon/infrastructure/rate_limit_client.rs` の `fetch_or_cached` / `force_refresh` / `raw_fetch` を async 化

### Phase 2: socket I/O の async 化 (`790404f`)
- `socket_listener.rs` を `tokio::net::UnixListener` ベースに変更、bind リトライは `tokio::time::sleep`
- `connection.rs::handle` を `async fn` 化、`tokio::net::UnixStream` で I/O。`exit_tx` は `tokio::sync::mpsc::UnboundedSender<()>`
- `daemon_server.rs::run` の accept ループを `tokio::select!` で書き直し、`listener.accept().await` / `exit_rx.recv()` / `socket_check.tick()` を 1 ループに統合。**10ms sleep WouldBlock ポーリングを撤廃**
- per-connection は `tokio::spawn` で実行
- scheduler / rate_limit_fetcher は **このサブイシューでは std::thread のまま**（Sub-issue B Phase 4 で移行予定）。これらの `join()` は `tokio::task::block_in_place` で囲む
- `RefreshFn` は `fn(RepoId, PathBuf) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>` に変わり、`Handle::spawn` で起動
- `DaemonLifecyclePort::start` を async 化、呼び出し連鎖 `main → cli::run → daemon_start_command → daemon::interface::cli::daemon::start` に `.await` を伝播

### Fix: `backoff_until` の race condition 修正 (`590d066`)
- 初回 CI で `tests/e2e/scenarios/rate_limit_aware::test_rate_limit_exhausted_pauses_refresh_until_reset` が fail
- 原因: `gh api rate_limit` の `reset` は整数 Unix epoch 秒で返るため、`reset_at` をそのまま `backoff_until` に変換すると整数秒の境界に張り付く。`MERGE_READY_SCHEDULER_TICK_SECS=1` のテスト設定下では scheduler tick の +1s/+2s 境界と `backoff_until` が同時刻に並び、tick と backoff 解除タイミングの race が発生
- 修正: `reset_instant_from_snapshot` で `backoff_until` に **1.5s の安全マージン** を追加 (`BACKOFF_SAFETY_MARGIN`)。本番でも reset 瞬間に refresh が殺到するのを避ける防御的挙動として妥当
- ローカルで 10/10 グリーン、フル workspace nextest は 328 件 green、CI 9/9 pass

### スコープ外（Sub-issue B に残す）
- `Arc<Mutex<DaemonState>>` の撤廃 → Phase 3
- scheduler / rate_limit_fetcher / socket-watcher の async 化 → Phase 4
- `signal-hook` → `tokio::signal::unix` 置換 → Phase 5
- `merge-ready-prompt` バイナリの async 化（**ベンチ温存目的で sync 維持**）
- daemon-side `DaemonClient` の async 化（restart / daemon stop / status / watch から呼ばれる sync コンテキストが残っているため Phase 5 でまとめる）

## Test plan

- [x] `rtk cargo nextest run --workspace`: **328 passed**
- [x] `rtk cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean
- [x] `rtk cargo fmt --check --all` / `rtk cargo deny check`: green
- [x] `bash scripts/check-layer-deps.sh` / `check-no-mod-rs.sh` / `check-no-clippy-allow.sh`: green
- [x] `rtk cargo bench --bench hot_path`: 12.36 ms → **1.51 ms** (median, −87%)
  - 旧実装の accept ループ 10ms sleep ポーリングが warm prompt レイテンシの大半を占めていたため、async select! 化で大幅短縮
- [x] **race fix 後 `test_rate_limit_exhausted_pauses_refresh_until_reset` を 10/10 ローカルで pass**
- [x] **CI 9/9 pass**（test / clippy / fmt / deny / dependency-rules / no-mod-rs / no-clippy-allow / check-e2e / check-pr-title）

## E2E timing-sensitive シナリオの確認

`tests/e2e/daemon/lifecycle.rs` の以下 4 件が含まれる nextest workspace 全体が green:
- `test_concurrent_prompt_starts_only_one_daemon`
- `test_daemon_self_terminates_when_socket_disappears`
- `test_daemon_stop_does_not_wait_for_scheduler_tick`
- `test_daemon_stop_falls_back_to_sigterm_when_socket_removed`

## Refs

- 親 Issue: #338
- このサブイシュー: #346
- 兄弟 サブイシュー: #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)