### PR TITLE
refactor(daemon): convert DaemonClient and ports to async

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,8 +17,8 @@ pub async fn run(cli: &Cli) -> ExitCode {
         }
         Some(Command::Daemon(args)) => match args.subcommand {
             DaemonCommand::Start => merge_ready::daemon_start_command().await,
-            DaemonCommand::Stop => merge_ready::daemon_stop_command(),
-            DaemonCommand::Status => merge_ready::daemon_status_command(),
+            DaemonCommand::Stop => merge_ready::daemon_stop_command().await,
+            DaemonCommand::Status => merge_ready::daemon_status_command().await,
         },
         Some(Command::Watch) => merge_ready::watch_command().await,
         None => {

--- a/src/contexts/daemon/application/port.rs
+++ b/src/contexts/daemon/application/port.rs
@@ -9,5 +9,5 @@ pub struct EntryView {
 
 /// `watch` ユースケースが必要とするアダプタポート。
 pub trait WatchPort {
-    fn entries(&self) -> Option<Vec<EntryView>>;
+    fn entries(&self) -> impl std::future::Future<Output = Option<Vec<EntryView>>> + Send;
 }

--- a/src/contexts/daemon/domain/cache/port.rs
+++ b/src/contexts/daemon/domain/cache/port.rs
@@ -11,5 +11,5 @@ pub trait CachePort {
         output: &str,
         refresh_mode: RefreshMode,
         pr_outputs: Vec<PrOutput>,
-    );
+    ) -> impl std::future::Future<Output = ()> + Send;
 }

--- a/src/contexts/daemon/domain/daemon.rs
+++ b/src/contexts/daemon/domain/daemon.rs
@@ -17,9 +17,9 @@ pub trait DaemonLifecyclePort {
     /// デーモンを起動する。アイドルタイムアウトまたは Stop リクエストで返る。
     fn start(&self) -> impl std::future::Future<Output = Result<(), DaemonError>> + Send;
     /// デーモンを停止する。成功時は `true` を返す。
-    fn stop(&self) -> bool;
+    fn stop(&self) -> impl std::future::Future<Output = bool> + Send;
     /// デーモンのステータスを取得する。起動していない場合は `None` を返す。
-    fn get_status(&self) -> Option<DaemonStatus>;
+    fn get_status(&self) -> impl std::future::Future<Output = Option<DaemonStatus>> + Send;
     /// 実行中デーモンの PID を返す。未起動の場合は `None` を返す。
-    fn get_pid(&self) -> Option<u32>;
+    fn get_pid(&self) -> impl std::future::Future<Output = Option<u32>> + Send;
 }

--- a/src/contexts/daemon/infrastructure/daemon_client.rs
+++ b/src/contexts/daemon/infrastructure/daemon_client.rs
@@ -1,13 +1,14 @@
-use std::io::{BufRead, BufReader, Write};
-use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 use std::time::Duration;
+
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use tokio::time::timeout;
 
 use crate::contexts::daemon::domain::cache::{CachePort, RepoId};
 use crate::shared::protocol::{EntryDto, PrOutput, Request, Response};
 use crate::shared::refresh_mode::RefreshMode;
 
-/// デーモンソケットへの接続タイムアウト（ms）
 const READ_TIMEOUT_MS: u64 = 500;
 
 pub struct DaemonClient {
@@ -21,29 +22,31 @@ impl DaemonClient {
 }
 
 impl CachePort for DaemonClient {
-    fn update(
+    async fn update(
         &self,
         repo_id: &RepoId,
         output: &str,
         refresh_mode: RefreshMode,
         pr_outputs: Vec<PrOutput>,
     ) {
-        let _ = self.send(&Request::Update {
-            repo_id: repo_id.as_str().to_owned(),
-            output: output.to_owned(),
-            refresh_mode,
-            pr_outputs,
-        });
+        let _ = self
+            .send(&Request::Update {
+                repo_id: repo_id.as_str().to_owned(),
+                output: output.to_owned(),
+                refresh_mode,
+                pr_outputs,
+            })
+            .await;
     }
 }
 
 impl DaemonClient {
-    pub(super) fn stop(&self) -> bool {
-        self.send(&Request::Stop).is_ok()
+    pub(super) async fn stop(&self) -> bool {
+        self.send(&Request::Stop).await.is_ok()
     }
 
-    pub(super) fn status_raw(&self) -> Option<(usize, u64, String)> {
-        match self.send(&Request::Status) {
+    pub(super) async fn status_raw(&self) -> Option<(usize, u64, String)> {
+        match self.send(&Request::Status).await {
             Ok(Response::Status {
                 entries,
                 uptime_secs,
@@ -53,29 +56,35 @@ impl DaemonClient {
         }
     }
 
-    pub(crate) fn entries_raw(&self) -> Option<Vec<EntryDto>> {
-        match self.send(&Request::Entries) {
+    pub(crate) async fn entries_raw(&self) -> Option<Vec<EntryDto>> {
+        match self.send(&Request::Entries).await {
             Ok(Response::Entries { entries }) => Some(entries),
             _ => None,
         }
     }
 
-    fn send(&self, request: &Request) -> Result<Response, ()> {
-        let stream = UnixStream::connect(&self.socket_path).map_err(|_| ())?;
-        stream
-            .set_read_timeout(Some(Duration::from_millis(READ_TIMEOUT_MS)))
+    async fn send(&self, request: &Request) -> Result<Response, ()> {
+        let stream = UnixStream::connect(&self.socket_path)
+            .await
             .map_err(|_| ())?;
-        let mut stream = stream;
+        let (read_half, mut write_half) = stream.into_split();
 
         let json = serde_json::to_string(request).map_err(|_| ())?;
-        stream
+        write_half
             .write_all(format!("{json}\n").as_bytes())
+            .await
             .map_err(|_| ())?;
 
+        let mut reader = BufReader::new(read_half);
         let mut buf = String::new();
-        BufReader::new(&stream)
-            .read_line(&mut buf)
-            .map_err(|_| ())?;
+        // std 版の set_read_timeout 相当を tokio::time::timeout で再現。
+        timeout(
+            Duration::from_millis(READ_TIMEOUT_MS),
+            reader.read_line(&mut buf),
+        )
+        .await
+        .map_err(|_| ())?
+        .map_err(|_| ())?;
 
         serde_json::from_str(buf.trim()).map_err(|_| ())
     }

--- a/src/contexts/daemon/infrastructure/daemon_lifecycle.rs
+++ b/src/contexts/daemon/infrastructure/daemon_lifecycle.rs
@@ -39,26 +39,33 @@ impl DaemonLifecyclePort for DaemonLifecycle {
         daemon_server::run(self.on_refresh, self.paths.clone()).await
     }
 
-    fn stop(&self) -> bool {
+    async fn stop(&self) -> bool {
         let pid_path = self.paths.pid_path();
         let client = DaemonClient::new(self.paths.socket_path());
-        let running_pid = pid::read(&pid_path).filter(|&p| pid::is_alive(p));
-        if client.stop() {
-            return running_pid.is_none_or(|p| wait_or_terminate(p, &pid_path));
+        let running_pid = match pid::read(&pid_path) {
+            Some(p) if pid::is_alive(p).await => Some(p),
+            _ => None,
+        };
+        if client.stop().await {
+            return match running_pid {
+                None => true,
+                Some(p) => wait_or_terminate(p, &pid_path).await,
+            };
         }
         let Some(p) = running_pid.or_else(|| pid::read(&pid_path)) else {
             return false;
         };
-        if !pid::is_alive(p) {
+        if !pid::is_alive(p).await {
             pid::remove(&pid_path);
             return false;
         }
-        terminate_and_wait(p, &pid_path)
+        terminate_and_wait(p, &pid_path).await
     }
 
-    fn get_status(&self) -> Option<DaemonStatus> {
+    async fn get_status(&self) -> Option<DaemonStatus> {
         DaemonClient::new(self.paths.socket_path())
             .status_raw()
+            .await
             .map(|(entries, uptime_secs, version)| DaemonStatus {
                 entries,
                 uptime_secs,
@@ -66,31 +73,36 @@ impl DaemonLifecyclePort for DaemonLifecycle {
             })
     }
 
-    fn get_pid(&self) -> Option<u32> {
-        pid::read(&self.paths.pid_path()).filter(|&p| pid::is_alive(p))
+    async fn get_pid(&self) -> Option<u32> {
+        match pid::read(&self.paths.pid_path()) {
+            Some(p) if pid::is_alive(p).await => Some(p),
+            _ => None,
+        }
     }
 }
 
-fn wait_or_terminate(p: u32, pid_path: &Path) -> bool {
-    if pid::wait_until_gone(p, pid_path, STOP_TIMEOUT) {
+async fn wait_or_terminate(p: u32, pid_path: &Path) -> bool {
+    if pid::wait_until_gone(p, pid_path, STOP_TIMEOUT).await {
         return true;
     }
-    terminate_and_wait(p, pid_path)
+    terminate_and_wait(p, pid_path).await
 }
 
-fn terminate_and_wait(p: u32, pid_path: &Path) -> bool {
+async fn terminate_and_wait(p: u32, pid_path: &Path) -> bool {
     // ソケット経由が失敗した、または終了が遅い場合は SIGTERM でフォールバックする。
-    let signalled = std::process::Command::new("kill")
+    let signalled = tokio::process::Command::new("kill")
         .args(["-TERM", &p.to_string()])
         .status()
+        .await
         .is_ok_and(|s| s.success());
-    signalled && pid::wait_until_gone(p, pid_path, STOP_TIMEOUT)
+    signalled && pid::wait_until_gone(p, pid_path, STOP_TIMEOUT).await
 }
 
 impl WatchPort for DaemonLifecycle {
-    fn entries(&self) -> Option<Vec<EntryView>> {
+    async fn entries(&self) -> Option<Vec<EntryView>> {
         DaemonClient::new(self.paths.socket_path())
             .entries_raw()
+            .await
             .map(|dtos| {
                 dtos.into_iter()
                     .map(|dto| EntryView {
@@ -122,33 +134,33 @@ mod tests {
         DaemonLifecycle::with_paths(noop_refresh, paths)
     }
 
-    #[test]
-    fn get_pid_returns_none_when_no_pid_file() {
+    #[tokio::test]
+    async fn get_pid_returns_none_when_no_pid_file() {
         let dir = tempdir().unwrap();
         let lifecycle = noop_lifecycle(Paths::new(dir.path().to_path_buf()));
-        assert_eq!(lifecycle.get_pid(), None);
+        assert_eq!(lifecycle.get_pid().await, None);
     }
 
-    #[test]
-    fn get_pid_returns_some_when_pid_is_alive() {
+    #[tokio::test]
+    async fn get_pid_returns_some_when_pid_is_alive() {
         let dir = tempdir().unwrap();
         let paths = Paths::new(dir.path().to_path_buf());
         pid::write(std::process::id(), &paths.pid_path());
         let lifecycle = noop_lifecycle(paths);
-        assert_eq!(lifecycle.get_pid(), Some(std::process::id()));
+        assert_eq!(lifecycle.get_pid().await, Some(std::process::id()));
     }
 
-    #[test]
-    fn stop_returns_false_when_daemon_not_running() {
+    #[tokio::test]
+    async fn stop_returns_false_when_daemon_not_running() {
         let dir = tempdir().unwrap();
         let lifecycle = noop_lifecycle(Paths::new(dir.path().to_path_buf()));
-        assert!(!lifecycle.stop());
+        assert!(!lifecycle.stop().await);
     }
 
-    #[test]
-    fn get_status_returns_none_when_daemon_not_running() {
+    #[tokio::test]
+    async fn get_status_returns_none_when_daemon_not_running() {
         let dir = tempdir().unwrap();
         let lifecycle = noop_lifecycle(Paths::new(dir.path().to_path_buf()));
-        assert!(lifecycle.get_status().is_none());
+        assert!(lifecycle.get_status().await.is_none());
     }
 }

--- a/src/contexts/daemon/infrastructure/daemon_server.rs
+++ b/src/contexts/daemon/infrastructure/daemon_server.rs
@@ -57,8 +57,8 @@ pub async fn run(on_refresh: RefreshFn, paths: Paths) -> Result<(), DaemonError>
     // 旧デーモンの停止完了まで待たせない（生きている旧デーモンには Stop を送信）。
     {
         let cleanup_paths = Arc::clone(&paths);
-        tokio::task::spawn_blocking(move || {
-            restart::cleanup_old_versions(&cleanup_paths);
+        tokio::spawn(async move {
+            restart::cleanup_old_versions(&cleanup_paths).await;
         });
     }
 

--- a/src/contexts/daemon/infrastructure/pid.rs
+++ b/src/contexts/daemon/infrastructure/pid.rs
@@ -20,27 +20,26 @@ pub fn remove(path: &Path) {
     let _ = fs::remove_file(path);
 }
 
-#[must_use]
-pub fn is_alive(pid: u32) -> bool {
-    std::process::Command::new("kill")
+pub async fn is_alive(pid: u32) -> bool {
+    tokio::process::Command::new("kill")
         .args(["-0", &pid.to_string()])
         .stderr(std::process::Stdio::null())
         .status()
+        .await
         .is_ok_and(|s| s.success())
 }
 
-#[must_use]
-pub fn wait_until_gone(pid: u32, path: &Path, timeout: Duration) -> bool {
+pub async fn wait_until_gone(pid: u32, path: &Path, timeout: Duration) -> bool {
     let deadline = Instant::now() + timeout;
     loop {
-        if !is_alive(pid) {
+        if !is_alive(pid).await {
             remove(path);
             return true;
         }
         if Instant::now() >= deadline {
             return false;
         }
-        std::thread::sleep(Duration::from_millis(20));
+        tokio::time::sleep(Duration::from_millis(20)).await;
     }
 }
 

--- a/src/contexts/daemon/infrastructure/restart.rs
+++ b/src/contexts/daemon/infrastructure/restart.rs
@@ -21,26 +21,26 @@ pub(super) fn cleanup(paths: &Paths) {
 /// - PID が生きていれば socket 経由で Stop を送り、終了を待つ
 /// - PID が死んでいる stale ファイルは即削除する
 ///
-/// 新デーモンが自分のソケットを bind した後にバックグラウンドスレッドで実行することで、
+/// 新デーモンが自分のソケットを bind した後にバックグラウンドタスクで実行することで、
 /// `merge-ready-prompt` のレスポンスを旧デーモン停止の完了まで待たせない。
-pub(super) fn cleanup_old_versions(paths: &Paths) {
+pub(super) async fn cleanup_old_versions(paths: &Paths) {
     for old_pid_path in paths.old_daemon_pid_files() {
-        cleanup_one(&old_pid_path);
+        cleanup_one(&old_pid_path).await;
     }
 }
 
-fn cleanup_one(old_pid_path: &std::path::Path) {
+async fn cleanup_one(old_pid_path: &std::path::Path) {
     let Some(stem) = old_pid_path.file_stem().and_then(|s| s.to_str()) else {
         return;
     };
     let old_sock = old_pid_path.with_file_name(format!("{stem}.sock"));
 
     match pid::read(old_pid_path) {
-        Some(p) if pid::is_alive(p) => {
+        Some(p) if pid::is_alive(p).await => {
             let client = DaemonClient::new(old_sock.clone());
-            let _ = client.stop();
+            let _ = client.stop().await;
             // 旧デーモンが Stop を完了するまで待ち、ファイルを掃除する
-            let _ = pid::wait_until_gone(p, old_pid_path, OLD_DAEMON_STOP_TIMEOUT);
+            let _ = pid::wait_until_gone(p, old_pid_path, OLD_DAEMON_STOP_TIMEOUT).await;
             let _ = std::fs::remove_file(&old_sock);
             // pid::wait_until_gone は成功時に pid ファイルを削除するが、失敗時にも残骸を残さない
             let _ = std::fs::remove_file(old_pid_path);
@@ -58,8 +58,8 @@ mod tests {
     use super::*;
     use std::fs;
 
-    #[test]
-    fn cleanup_old_versions_removes_stale_files() {
+    #[tokio::test]
+    async fn cleanup_old_versions_removes_stale_files() {
         let dir = tempfile::tempdir().unwrap();
         let version = env!("CARGO_PKG_VERSION");
 
@@ -76,7 +76,7 @@ mod tests {
         fs::write(dir.path().join("daemon-0.0.0.pid"), b"9999999").unwrap();
 
         let paths = Paths::new(dir.path().to_path_buf());
-        cleanup_old_versions(&paths);
+        cleanup_old_versions(&paths).await;
 
         // 旧バージョンは削除
         assert!(!dir.path().join("daemon-0.0.0.sock").exists());

--- a/src/contexts/daemon/infrastructure/socket_listener.rs
+++ b/src/contexts/daemon/infrastructure/socket_listener.rs
@@ -46,7 +46,7 @@ async fn bind_with(
 
     let pid_path = paths.pid_path();
     match pid::read(&pid_path) {
-        Some(p) if pid::is_alive(p) => {
+        Some(p) if pid::is_alive(p).await => {
             log::error!("daemon is already running (pid {p})");
             eprintln!("merge-ready daemon is already running (pid {p})");
             return Err(DaemonError::AlreadyRunning);

--- a/src/contexts/daemon/interface/cli/daemon.rs
+++ b/src/contexts/daemon/interface/cli/daemon.rs
@@ -106,8 +106,8 @@ pub(crate) async fn start(port: &impl DaemonLifecyclePort) -> ExitCode {
     }
 }
 
-pub(crate) fn stop(port: &impl DaemonLifecyclePort) -> ExitCode {
-    if port.stop() {
+pub(crate) async fn stop(port: &impl DaemonLifecyclePort) -> ExitCode {
+    if port.stop().await {
         println!("daemon stopped");
     } else {
         eprintln!("daemon is not running");
@@ -115,11 +115,12 @@ pub(crate) fn stop(port: &impl DaemonLifecyclePort) -> ExitCode {
     ExitCode::SUCCESS
 }
 
-pub(crate) fn status(port: &impl DaemonLifecyclePort) -> ExitCode {
-    match port.get_status() {
+pub(crate) async fn status(port: &impl DaemonLifecyclePort) -> ExitCode {
+    match port.get_status().await {
         Some(s) => {
             let pid = port
                 .get_pid()
+                .await
                 .map_or_else(|| "-".to_owned(), |p| p.to_string());
             println!(
                 "running  pid={}  entries={}  uptime={}s  version={}",

--- a/src/contexts/daemon/interface/cli/watch.rs
+++ b/src/contexts/daemon/interface/cli/watch.rs
@@ -18,7 +18,7 @@ pub async fn run(port: &impl WatchPort) -> ExitCode {
 
     loop {
         clear_screen();
-        if !draw(port) {
+        if !draw(port).await {
             return ExitCode::FAILURE;
         }
         tokio::select! {
@@ -49,8 +49,8 @@ fn clear_screen() {
     );
 }
 
-fn draw(port: &impl WatchPort) -> bool {
-    match port.entries() {
+async fn draw(port: &impl WatchPort) -> bool {
+    match port.entries().await {
         None => {
             println!("daemon is not running");
             false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,12 +43,9 @@ fn refresh_callback(
                 output,
             })
             .collect();
-        DaemonClient::new(Paths::default().socket_path()).update(
-            &repo_id,
-            &result.output,
-            result.refresh_mode,
-            pr_outputs,
-        );
+        DaemonClient::new(Paths::default().socket_path())
+            .update(&repo_id, &result.output, result.refresh_mode, pr_outputs)
+            .await;
     })
 }
 
@@ -78,19 +75,17 @@ pub async fn daemon_start_command() -> ExitCode {
 }
 
 /// Stops the running background cache daemon.
-#[must_use]
-pub fn daemon_stop_command() -> ExitCode {
+pub async fn daemon_stop_command() -> ExitCode {
     contexts::evaluation::infrastructure::logger::init();
     let lifecycle = build_daemon_lifecycle();
-    contexts::daemon::interface::cli::daemon::stop(&lifecycle)
+    contexts::daemon::interface::cli::daemon::stop(&lifecycle).await
 }
 
 /// Shows the current status of the background cache daemon.
-#[must_use]
-pub fn daemon_status_command() -> ExitCode {
+pub async fn daemon_status_command() -> ExitCode {
     contexts::evaluation::infrastructure::logger::init();
     let lifecycle = build_daemon_lifecycle();
-    contexts::daemon::interface::cli::daemon::status(&lifecycle)
+    contexts::daemon::interface::cli::daemon::status(&lifecycle).await
 }
 
 /// Watches daemon cache entries in real time.


### PR DESCRIPTION
## Summary

Closes #349

- `DaemonClient` を `tokio::net::UnixStream` ベースに書き換え
- `CachePort::update` / `WatchPort::entries` / `DaemonLifecyclePort::{stop, get_status, get_pid}` を Rust 1.95+ native AFIT で `async fn` 化
- `pid::is_alive` / `wait_until_gone` を `tokio::time::sleep` + `tokio::process::Command` ベースに
- `restart::cleanup_one` を async 化、`daemon_server.rs` の `spawn_blocking` → `tokio::spawn`

## 背景

#347 (PR #350) で daemon は tokio + actor に統一されたが、`async fn run` (watch.rs) 内で sync な `WatchPort::entries()` を呼ぶ不整合が残っていた。本 PR でその積み残しを解消し、daemon コードベース全体の tokio 化を完了させる。

## 設計判断

- Plan では 2 atomic commits を想定したが、`daemon_lifecycle.rs` 内の暫定 `Handle::current().block_on(...)` ブリッジを経由するコミット間状態が見苦しい上に過渡的だったため **1 commit に統合**
- `async fn` in trait は Rust 1.95+ native AFIT (`fn ... -> impl Future + Send`) を使用。`async-trait` クレート追加なし
- `merge-ready-prompt` バイナリは `DaemonClient` を使わず独自の `UnixStream` 実装。本 PR では 1 行も変更せず、ベンチへの影響なし

## ベンチ (`merge_ready_prompt_warm_startup`)

| | 中央値 |
|---|---|
| before-349 baseline | 1.4602 ms |
| after | 1.3699 ms |

criterion: `No change in performance detected` (p=0.66 > 0.05)。

## Test plan

- [x] `cargo nextest run --workspace --no-fail-fast` (336 passed)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --check --all`
- [x] `bash scripts/check-layer-deps.sh`
- [x] `bash scripts/check-no-mod-rs.sh`
- [x] `bash scripts/check-no-clippy-allow.sh`
- [x] `cargo bench --bench hot_path -- --baseline before-349` (悪化なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)