### PR TITLE
feat(prompt)!: aggregate identical statuses and list PR numbers in prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,15 @@ Example output:
 
 ### Multiple Pull Requests
 
-When a branch has **multiple open pull requests**, all statuses are displayed in PR-number ascending order, each suffixed with `#<number>`:
+When a branch has **multiple open pull requests**, statuses are **aggregated by kind**: each distinct status is shown once, followed by the PR numbers that share it (ascending). Status groups appear in the order each kind is first seen when scanning PRs in ascending number order:
+
+```text
+⧖ Wait for status #1734 #2669 #2788 #3275 ✗ Fix CI failure #3512 #3693
+```
+
+If a PR has more than one status, its number appears in each relevant group.
+
+For distinct statuses across PRs, each group simply lists its single PR number:
 
 ```text
 ✓ Ready for merge #200 ✎ Ready for review #201
@@ -152,7 +160,7 @@ All fields are optional — omitting any field falls back to the default shown b
 [merge_ready]
 symbol = "✓"
 label = "Ready for merge"
-format = "[$symbol $label( #$pr_id)](bold green)"
+format = "[$symbol $label( $pr_ids)](bold green)"
 
 [no_pull_request]
 symbol = "+"
@@ -162,57 +170,57 @@ format = "[$symbol $label](cyan)"
 [conflict]
 symbol = "✗"
 label = "Resolve conflict"
-format = "[$symbol $label( #$pr_id)](bold red)"
+format = "[$symbol $label( $pr_ids)](bold red)"
 
 [update_branch]
 symbol = "✗"
 label = "Update branch"
-format = "[$symbol $label( #$pr_id)](yellow)"
+format = "[$symbol $label( $pr_ids)](yellow)"
 
 # [sync_unknown]
 # symbol = "?"
 # label = "Check branch sync"
-# format = "[$symbol $label( #$pr_id)](yellow)"
+# format = "[$symbol $label( $pr_ids)](yellow)"
 
 [ci_fail]
 symbol = "✗"
 label = "Fix CI failure"
-format = "[$symbol $label( #$pr_id)](bold red)"
+format = "[$symbol $label( $pr_ids)](bold red)"
 
 # [ci_action]
 # symbol = "⚠"
 # label = "Run CI action"
-# format = "[$symbol $label( #$pr_id)](yellow)"
+# format = "[$symbol $label( $pr_ids)](yellow)"
 
 [ci_pending]
 symbol = "⧖"
 label = "Wait for CI"
-format = "[$symbol $label( #$pr_id)](cyan)"
+format = "[$symbol $label( $pr_ids)](cyan)"
 
 [changes_requested]
 symbol = "⚠"
 label = "Resolve review"
-format = "[$symbol $label( #$pr_id)](yellow)"
+format = "[$symbol $label( $pr_ids)](yellow)"
 
 [review_required]
 symbol = "@"
 label = "Assign reviewer"
-format = "[$symbol $label( #$pr_id)](cyan)"
+format = "[$symbol $label( $pr_ids)](cyan)"
 
 [draft]
 symbol = "✎"
 label = "Ready for review"
-format = "[$symbol $label( #$pr_id)](dimmed)"
+format = "[$symbol $label( $pr_ids)](dimmed)"
 
 # [status_calculating]
 # symbol = "⧖"
 # label = "Wait for status"
-# format = "[$symbol $label( #$pr_id)](dimmed)"
+# format = "[$symbol $label( $pr_ids)](dimmed)"
 
 # [blocked_unknown]
 # symbol = "?"
 # label = "Check merge blocker"
-# format = "[$symbol $label( #$pr_id)](yellow)"
+# format = "[$symbol $label( $pr_ids)](yellow)"
 
 [error]
 symbol = "✗"
@@ -242,24 +250,26 @@ The following variables are available in `format` templates:
 |----------|-------------|--------------|
 | `$symbol` | Leading symbol | all tokens |
 | `$label` | Status text | PR state tokens, `no_pull_request` |
-| `$pr_id` | PR number string; empty `""` when only one open PR exists | PR state tokens (12 types) |
+| `$pr_ids` | PR numbers sharing this status, `#`-prefixed and space-separated (e.g. `#1734 #2669`); empty `""` when only one open PR exists on the branch | PR state tokens (12 types) |
 | `$message` | Error message | `[error]` only |
 
-`$pr_id` is not present in `no_pull_request` or `[error]` tokens. Writing `$pr_id` in those format strings leaves the literal text `$pr_id` in the output.
+`$pr_ids` is not present in `no_pull_request` or `[error]` tokens. Writing `$pr_ids` in those format strings leaves the literal text `$pr_ids` in the output.
+
+> **Breaking change:** the singular `$pr_id` variable was removed in favour of `$pr_ids`. Configs that still reference `$pr_id` are treated as an unknown variable — a `( #$pr_id)` block becomes always-hidden, so PR numbers simply stop appearing (no crash). Update such configs to `( $pr_ids)`.
 
 ### Conditional Format Strings
 
 The `format` field supports a `(...)` syntax that hides the block when all variables inside are empty. This follows [Starship's conditional format strings](https://starship.rs/config/#conditional-format-strings).
 
 ```toml
-# `( #$pr_id)` is shown only when $pr_id is non-empty (i.e., multiple PRs on the branch)
+# `( $pr_ids)` is shown only when $pr_ids is non-empty (i.e., multiple PRs on the branch)
 [merge_ready]
-format = "$symbol $label( #$pr_id)"
+format = "$symbol $label( $pr_ids)"
 ```
 
-| `$pr_id` value | Output |
-|----------------|--------|
-| `"200"` (multiple PRs) | `✓ Ready for merge #200` |
+| `$pr_ids` value | Output |
+|-----------------|--------|
+| `"#200 #201"` (multiple PRs) | `✓ Ready for merge #200 #201` |
 | `""` (single PR) | `✓ Ready for merge` |
 
 Rules:
@@ -272,10 +282,10 @@ Conditional blocks can also appear inside a `[text](style)` block:
 
 ```toml
 [merge_ready]
-format = "[$symbol $label( #$pr_id)](bold green)"
+format = "[$symbol $label( $pr_ids)](bold green)"
 ```
 
-This applies the style to the whole output while still hiding `( #$pr_id)` when `$pr_id` is empty.
+This applies the style to the whole output while still hiding `( $pr_ids)` when `$pr_ids` is empty.
 
 ### Style Strings
 

--- a/src/contexts/evaluation/application/prompt/display_item.rs
+++ b/src/contexts/evaluation/application/prompt/display_item.rs
@@ -4,6 +4,7 @@ use crate::contexts::evaluation::domain::prompt::pull_request::state::blocked::{
 };
 use crate::contexts::evaluation::domain::prompt::pull_request::state::unblocked::UnblockedState;
 
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum DisplayItem {
     Conflict,
     UpdateBranch,

--- a/src/contexts/evaluation/domain/display_config/defaults.rs
+++ b/src/contexts/evaluation/domain/display_config/defaults.rs
@@ -1,7 +1,7 @@
 use super::{DisplayConfig, ErrorConfig, TokenConfig};
 
-/// PR 状態トークン 12 種のデフォルトフォーマット。`( #$pr_id)` は複数 PR 時のみ展開される。
-const DEFAULT_PR_FORMAT: &str = "$symbol $label( #$pr_id)";
+/// PR 状態トークン 12 種のデフォルトフォーマット。`( $pr_ids)` は複数 PR 時のみ展開される。
+const DEFAULT_PR_FORMAT: &str = "$symbol $label( $pr_ids)";
 /// `no_pull_request` / `error` トークンのデフォルトフォーマット。
 const DEFAULT_FORMAT: &str = "$symbol $label";
 const DEFAULT_ERROR_FORMAT: &str = "$symbol $message";
@@ -105,6 +105,6 @@ mod tests {
         assert!(toml.contains("[merge_ready]"));
         assert!(toml.contains("[no_pull_request]"));
         assert!(toml.contains("[error]"));
-        assert!(toml.contains("format = \"$symbol $label( #$pr_id)\""));
+        assert!(toml.contains("format = \"$symbol $label( $pr_ids)\""));
     }
 }

--- a/src/contexts/evaluation/domain/display_config/render.rs
+++ b/src/contexts/evaluation/domain/display_config/render.rs
@@ -2,13 +2,14 @@ use super::{ErrorConfig, TokenConfig};
 use crate::contexts::evaluation::domain::format_parser::{Segment, parse_segments};
 use crate::contexts::evaluation::domain::style_spec::StyleSpec;
 
-/// `pr_id` が `Some` の場合は `$pr_id` を置換する。`None` の場合は `$pr_id` を literal のまま残す。
+/// `pr_ids` が `Some` の場合は `$pr_ids` を置換する。`None` の場合は `$pr_ids` を literal のまま残す。
+/// 値は `#1734 #2669` のように `#` 付き・スペース区切り（複数 PR 時）か、空文字（単一 PR 時）。
 /// `(...)` ブロック内の変数がすべて空の場合、そのブロックは出力されない。
 #[must_use]
-pub fn render_token(token: &TokenConfig, pr_id: Option<&str>) -> String {
+pub fn render_token(token: &TokenConfig, pr_ids: Option<&str>) -> String {
     let mut vars: Vec<(&str, &str)> = vec![("symbol", &token.symbol), ("label", &token.label)];
-    if let Some(id) = pr_id {
-        vars.push(("pr_id", id));
+    if let Some(ids) = pr_ids {
+        vars.push(("pr_ids", ids));
     }
     render_with_vars(&token.format, &vars)
 }
@@ -239,31 +240,34 @@ mod tests {
     }
 
     #[test]
-    fn render_token_conditional_shown_when_pr_id_nonempty() {
+    fn render_token_conditional_shown_when_pr_ids_nonempty() {
         let tok = TokenConfig {
             symbol: "✓".to_owned(),
             label: "Ready for merge".to_owned(),
-            format: "$symbol $label( #$pr_id)".to_owned(),
+            format: "$symbol $label( $pr_ids)".to_owned(),
         };
-        assert_eq!(render_token(&tok, Some("200")), "✓ Ready for merge #200");
+        assert_eq!(
+            render_token(&tok, Some("#200 #201")),
+            "✓ Ready for merge #200 #201"
+        );
     }
 
     #[test]
-    fn render_token_conditional_hidden_when_pr_id_empty() {
+    fn render_token_conditional_hidden_when_pr_ids_empty() {
         let tok = TokenConfig {
             symbol: "✓".to_owned(),
             label: "Ready for merge".to_owned(),
-            format: "$symbol $label( #$pr_id)".to_owned(),
+            format: "$symbol $label( $pr_ids)".to_owned(),
         };
         assert_eq!(render_token(&tok, Some("")), "✓ Ready for merge");
     }
 
     #[test]
-    fn render_token_conditional_hidden_when_pr_id_none() {
+    fn render_token_conditional_hidden_when_pr_ids_none() {
         let tok = TokenConfig {
             symbol: "✓".to_owned(),
             label: "Ready for merge".to_owned(),
-            format: "$symbol $label( #$pr_id)".to_owned(),
+            format: "$symbol $label( $pr_ids)".to_owned(),
         };
         assert_eq!(render_token(&tok, None), "✓ Ready for merge");
     }
@@ -279,27 +283,30 @@ mod tests {
     }
 
     #[test]
-    fn render_token_pr_id_substituted_when_some() {
+    fn render_token_pr_ids_substituted_when_some() {
         let tok = TokenConfig {
             symbol: "✓".to_owned(),
             label: "Ready for merge".to_owned(),
-            format: "$symbol $label #$pr_id".to_owned(),
+            format: "$symbol $label $pr_ids".to_owned(),
         };
-        assert_eq!(render_token(&tok, Some("200")), "✓ Ready for merge #200");
+        assert_eq!(
+            render_token(&tok, Some("#200 #201")),
+            "✓ Ready for merge #200 #201"
+        );
     }
 
     #[test]
-    fn render_token_pr_id_empty_string_leaves_hash() {
+    fn render_token_pr_ids_empty_string_substitutes_empty() {
         let tok = TokenConfig {
             symbol: "✓".to_owned(),
             label: "Ready for merge".to_owned(),
-            format: "$symbol $label #$pr_id".to_owned(),
+            format: "$symbol $label$pr_ids".to_owned(),
         };
-        assert_eq!(render_token(&tok, Some("")), "✓ Ready for merge #");
+        assert_eq!(render_token(&tok, Some("")), "✓ Ready for merge");
     }
 
     #[test]
-    fn render_token_pr_id_not_substituted_when_none() {
+    fn render_token_pr_ids_not_substituted_when_none() {
         let tok = TokenConfig {
             symbol: "+".to_owned(),
             label: "Create PR".to_owned(),
@@ -309,13 +316,13 @@ mod tests {
     }
 
     #[test]
-    fn render_token_pr_id_literal_remains_when_none() {
+    fn render_token_pr_ids_literal_remains_when_none() {
         let tok = TokenConfig {
             symbol: "+".to_owned(),
             label: "Create PR".to_owned(),
-            format: "$symbol $label $pr_id".to_owned(),
+            format: "$symbol $label $pr_ids".to_owned(),
         };
-        assert_eq!(render_token(&tok, None), "+ Create PR $pr_id");
+        assert_eq!(render_token(&tok, None), "+ Create PR $pr_ids");
     }
 
     #[test]

--- a/src/contexts/evaluation/domain/format_parser.rs
+++ b/src/contexts/evaluation/domain/format_parser.rs
@@ -116,14 +116,14 @@ mod tests {
 
     #[rstest]
     #[case(
-        "( #$pr_id)",
-        vec![Segment::Conditional(vec![Segment::Text(" #$pr_id".to_owned())])]
+        "( $pr_ids)",
+        vec![Segment::Conditional(vec![Segment::Text(" $pr_ids".to_owned())])]
     )]
     #[case(
-        "$symbol( #$pr_id)",
+        "$symbol( $pr_ids)",
         vec![
             Segment::Text("$symbol".to_owned()),
-            Segment::Conditional(vec![Segment::Text(" #$pr_id".to_owned())]),
+            Segment::Conditional(vec![Segment::Text(" $pr_ids".to_owned())]),
         ]
     )]
     #[case(

--- a/src/contexts/evaluation/interface/prompt.rs
+++ b/src/contexts/evaluation/interface/prompt.rs
@@ -38,22 +38,17 @@ pub fn render(prompt_result: Result<Prompt, ErrorToken>, config: &DisplayConfig)
             pr_outputs: vec![],
         },
         Ok(Prompt::PullRequests(prs)) => {
-            let items = to_display_items(prs);
-            let show_pr_id = items.len() > 1;
-            let mut pr_outputs = Vec::new();
-            let mut all_outputs = Vec::new();
+            let mut items = to_display_items(prs);
+            // 純関数として決定的な並びを保証する。PR 番号昇順で走査することで、
+            // 集約後のグループは初出（= 最小 ID）順、グループ内 ID は昇順になる。
+            items.sort_by_key(|(pr_id, _)| *pr_id);
+            let multiple = items.len() > 1;
 
-            for (pr_id, display_items) in &items {
-                let id_str = if show_pr_id {
-                    pr_id.to_string()
-                } else {
-                    String::new()
-                };
-                let prompt_out = render_display_items(display_items, config, &id_str);
-                let watch_out = render_display_items(display_items, config, "");
-                pr_outputs.push((*pr_id, watch_out));
-                all_outputs.push(prompt_out);
-            }
+            // watch 用: PR ごとに ID なしでレンダリングする（行 = PR で読めるため現状維持）。
+            let pr_outputs: Vec<(PrId, String)> = items
+                .iter()
+                .map(|(pr_id, display_items)| (*pr_id, render_watch_items(display_items, config)))
+                .collect();
 
             let refresh_mode = if items.iter().any(|(_, dis)| {
                 dis.iter()
@@ -64,8 +59,22 @@ pub fn render(prompt_result: Result<Prompt, ErrorToken>, config: &DisplayConfig)
                 RefreshMode::Warm
             };
 
+            // prompt 用: 同一ステータス（DisplayItem）を 1 トークンに集約し PR 番号を列挙する。
+            let output = group_by_display_item(&items)
+                .iter()
+                .map(|(item, ids)| {
+                    let pr_ids = if multiple {
+                        join_pr_ids(ids)
+                    } else {
+                        String::new()
+                    };
+                    render_token(item_to_token(*item, config), Some(&pr_ids))
+                })
+                .collect::<Vec<_>>()
+                .join(" ");
+
             RenderResult {
-                output: all_outputs.join(" "),
+                output,
                 refresh_mode,
                 pr_outputs,
             }
@@ -78,19 +87,43 @@ pub fn render(prompt_result: Result<Prompt, ErrorToken>, config: &DisplayConfig)
     }
 }
 
-fn render_display_items(
-    display_items: &[DisplayItem],
-    config: &DisplayConfig,
-    pr_id: &str,
-) -> String {
+/// watch 表示用に PR の各ステータストークンを ID なしでレンダリングし、スペース区切りで連結する。
+fn render_watch_items(display_items: &[DisplayItem], config: &DisplayConfig) -> String {
     display_items
         .iter()
-        .map(|item| render_token(item_to_token(item, config), Some(pr_id)))
+        .map(|item| render_token(item_to_token(*item, config), Some("")))
         .collect::<Vec<_>>()
         .join(" ")
 }
 
-fn item_to_token<'a>(item: &DisplayItem, config: &'a DisplayConfig) -> &'a TokenConfig {
+/// `(PrId, Vec<DisplayItem>)` の列を `DisplayItem` ごとに反転集約する。
+///
+/// `items` が PR 番号昇順であることを前提に、グループは初出（= 最小 ID）順、
+/// グループ内の PR 番号は昇順で並ぶ。1 PR が複数ステータスを持つ場合、その番号は
+/// 該当する各グループに重複して現れる（情報欠落なし）。
+fn group_by_display_item(items: &[(PrId, Vec<DisplayItem>)]) -> Vec<(DisplayItem, Vec<PrId>)> {
+    let mut groups: Vec<(DisplayItem, Vec<PrId>)> = Vec::new();
+    for (pr_id, display_items) in items {
+        for item in display_items {
+            if let Some((_, ids)) = groups.iter_mut().find(|(d, _)| d == item) {
+                ids.push(*pr_id);
+            } else {
+                groups.push((*item, vec![*pr_id]));
+            }
+        }
+    }
+    groups
+}
+
+/// PR 番号を `#1734 #2669` のように `#` 付き・スペース区切りで連結する。
+fn join_pr_ids(ids: &[PrId]) -> String {
+    ids.iter()
+        .map(|id| format!("#{id}"))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn item_to_token(item: DisplayItem, config: &DisplayConfig) -> &TokenConfig {
     match item {
         DisplayItem::MergeReady => &config.merge_ready,
         DisplayItem::Conflict => &config.conflict,
@@ -117,7 +150,7 @@ mod tests {
     use crate::contexts::evaluation::domain::display_config::DisplayConfig;
     use crate::contexts::evaluation::domain::prompt::{
         PrId, Prompt, PullRequest, State,
-        pull_request::state::blocked::{BlockedState, CiState},
+        pull_request::state::blocked::{BlockedState, BranchSyncState, CiState},
         pull_request::state::unblocked::UnblockedState,
     };
 
@@ -257,6 +290,49 @@ mod tests {
         ]));
         assert_eq!(result.pr_outputs[0].0, PrId::new(200));
         assert_eq!(result.pr_outputs[1].0, PrId::new(201));
+    }
+
+    #[test]
+    fn same_status_prs_aggregated_into_single_token() {
+        let result = render_ok(Prompt::PullRequests(vec![
+            PullRequest {
+                id: PrId::new(200),
+                state: State::Unblocked(UnblockedState::MergeReady),
+            },
+            PullRequest {
+                id: PrId::new(201),
+                state: State::Unblocked(UnblockedState::MergeReady),
+            },
+        ]));
+        assert_eq!(result.output, "✓ Ready for merge #200 #201");
+    }
+
+    #[test]
+    fn pr_with_multiple_statuses_appears_in_each_group() {
+        let result = render_ok(Prompt::PullRequests(vec![
+            PullRequest {
+                id: PrId::new(1),
+                state: State::Blocked(BlockedState {
+                    branch_sync: Some(BranchSyncState::Conflict),
+                    ci: Some(CiState::Fail),
+                    review: None,
+                    generic: None,
+                }),
+            },
+            PullRequest {
+                id: PrId::new(2),
+                state: State::Blocked(BlockedState {
+                    branch_sync: None,
+                    ci: Some(CiState::Fail),
+                    review: None,
+                    generic: None,
+                }),
+            },
+        ]));
+        assert_eq!(
+            result.output,
+            "✗ Resolve conflict #1 ✗ Fix CI failure #1 #2"
+        );
     }
 
     #[test]

--- a/tests/e2e/prompt/style.rs
+++ b/tests/e2e/prompt/style.rs
@@ -45,12 +45,12 @@ fn plain_format_produces_no_ansi() {
 
 /// `[text](style)` の content 内に conditional ブロックを置いた場合の検証。
 ///
-/// `[$symbol $label( #$pr_id)](cyan)` — 単独 PR（`$pr_id` が空）のとき
-/// `( #$pr_id)` ブロックが非表示になり、全体に cyan スタイルが適用される。
+/// `[$symbol $label( $pr_ids)](cyan)` — 単独 PR（`$pr_ids` が空）のとき
+/// `( $pr_ids)` ブロックが非表示になり、全体に cyan スタイルが適用される。
 #[test]
-fn conditional_inside_styled_block_hidden_when_pr_id_empty() {
+fn conditional_inside_styled_block_hidden_when_pr_ids_empty() {
     let env = TestEnv::new(MERGE_READY_JSON, Some(CHECKS_PASS_JSON));
-    env.write_config("[merge_ready]\nformat = \"[$symbol $label( #$pr_id)](cyan)\"");
+    env.write_config("[merge_ready]\nformat = \"[$symbol $label( $pr_ids)](cyan)\"");
 
     let _daemon = DaemonHandle::start(&env);
     DaemonHandle::wait_for_cache(&env, 5000);
@@ -63,15 +63,15 @@ fn conditional_inside_styled_block_hidden_when_pr_id_empty() {
         .stdout(predicate::str::contains("\x1b["))
         .stderr("");
 
-    // `( #)` が出力に含まれないこと（Conditional が非表示）
+    // Conditional が非表示になり、`(` も `$pr_ids` リテラルも残らないこと
     let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
     env.apply_with_cache(&mut cmd);
     cmd.timeout(std::time::Duration::from_secs(5))
         .assert()
         .success()
-        .stdout(predicate::str::contains("( #").not())
-        .stdout(predicate::str::contains("✓ Ready for merge"))
-        .stdout(predicate::str::contains("( #)").not());
+        .stdout(predicate::str::contains("(").not())
+        .stdout(predicate::str::contains("$pr_ids").not())
+        .stdout(predicate::str::contains("✓ Ready for merge"));
 }
 
 /// 複数の色指定形式（Ansi256 / RGB / Named fg+bg）を使った format で、

--- a/tests/e2e/scenarios/multiple_prs.rs
+++ b/tests/e2e/scenarios/multiple_prs.rs
@@ -1,6 +1,8 @@
-//! 複数 PR シナリオ: 1ブランチに複数のオープン PR が存在する場合の表示検証（#256）
+//! 複数 PR シナリオ: 1ブランチに複数のオープン PR が存在する場合の表示検証（#256, #355）
 //!
-//! 複数 PR は番号昇順で並び、各 PR の状態を `#<number>` 付きでスペース区切りに表示する。
+//! 複数 PR では同一ステータス（種別）を 1 トークンに集約し、配下の PR 番号を昇順で
+//! `#<number>` 付きに列挙する。グループはステータスの初出（= 最小 ID）順に並ぶ。
+//! 単一 PR 時は従来どおり `#<number>` を省略する。
 
 const PROMPT_BIN: &str = "merge-ready-prompt";
 
@@ -57,6 +59,57 @@ fn test_multiple_prs_with_mixed_states() {
         .success()
         .stdout(predicate::str::diff(
             "✓ Ready for merge #300 @ Assign reviewer #301",
+        ))
+        .stderr("");
+}
+
+/// 同一ステータスの複数 PR: 1 トークンに集約し PR 番号を昇順で列挙する（#355）
+///
+/// PR #100, #101, #102: いずれも draft
+/// 期待出力: "✎ Ready for review #100 #101 #102"
+#[test]
+fn test_same_status_prs_aggregated_into_single_token() {
+    let pr_list_json = r#"[
+        {"number":100,"state":"OPEN","isDraft":true,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null,"baseRefName":"","headRefName":""},
+        {"number":101,"state":"OPEN","isDraft":true,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null,"baseRefName":"","headRefName":""},
+        {"number":102,"state":"OPEN","isDraft":true,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null,"baseRefName":"","headRefName":""}
+    ]"#;
+    let env = TestEnv::with_pr_list(pr_list_json, Some(r"[]"));
+
+    let _daemon = DaemonHandle::start(&env);
+    DaemonHandle::wait_for_cache(&env, 5000);
+
+    let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
+    env.apply_with_cache(&mut cmd);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::diff("✎ Ready for review #100 #101 #102"))
+        .stderr("");
+}
+
+/// 複数ステータス群の集約: 同一ステータスごとに集約し、グループは初出（最小 ID）順に並ぶ（#355）
+///
+/// PR #100, #101: draft / PR #102, #103: レビュー待ち（`BLOCKED`, `REVIEW_REQUIRED`）
+/// 期待出力: "✎ Ready for review #100 #101 @ Assign reviewer #102 #103"
+#[test]
+fn test_distinct_status_groups_each_aggregated() {
+    let pr_list_json = r#"[
+        {"number":100,"state":"OPEN","isDraft":true,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null,"baseRefName":"","headRefName":""},
+        {"number":101,"state":"OPEN","isDraft":true,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null,"baseRefName":"","headRefName":""},
+        {"number":102,"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"BLOCKED","reviewDecision":"REVIEW_REQUIRED","baseRefName":"","headRefName":""},
+        {"number":103,"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"BLOCKED","reviewDecision":"REVIEW_REQUIRED","baseRefName":"","headRefName":""}
+    ]"#;
+    let env = TestEnv::with_pr_list(pr_list_json, Some(r"[]"));
+
+    let _daemon = DaemonHandle::start(&env);
+    DaemonHandle::wait_for_cache(&env, 5000);
+
+    let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
+    env.apply_with_cache(&mut cmd);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::diff(
+            "✎ Ready for review #100 #101 @ Assign reviewer #102 #103",
         ))
         .stderr("");
 }


### PR DESCRIPTION
## 背景

Closes #355

複数 PR があるブランチでは、従来 `render()` が PR ごとの `$symbol $label #番号` を横並びに連結していたため、同一ステータス（例 `⧖ Wait for status`）が PR 数ぶん丸ごと繰り返され、プロンプトが冗長で状況を把握しにくかった。

```
⧖ Wait for status #1734  ⧖ Wait for status #2669  ⧖ Wait for status #2788  ✗ Fix CI failure #3512  ✗ Fix CI failure #3693
```

## 変更内容

同一ステータス（`DisplayItem`）を 1 トークンに集約し、配下の PR 番号を昇順で列挙する。

```
⧖ Wait for status #1734 #2669 #2788 #3275 ✗ Fix CI failure #3512 #3693
```

- グループ並び順 = PR を昇順走査したときの初出順（= 最小 ID 順）、グループ内 ID は昇順
- 1 PR が複数ステータスを持つ場合、その番号は該当する各グループに重複表示
- 単一 PR 時は従来どおり `#番号` を省略
- グループ間の区切りはシングルスペース（各トークンは symbol 始まりのため境界は明確）
- 適用範囲は **prompt のみ**。`watch` テーブルと `RefreshMode`（Hot/Warm/Terminal）の導出は不変

### 破壊的変更（1.0 前のため許容）

- 新変数 `$pr_ids` を導入（`#1734 #2669 ...` の `#` 付き・スペース区切り。単一 PR 時は空）
- 単数 `$pr_id` は廃止。デフォルト format を `"$symbol $label( #$pr_id)"` → `"$symbol $label( $pr_ids)"` に変更
- 旧 `$pr_id` 設定は未知変数となり条件ブロックが常に非表示（番号が出なくなるだけでクラッシュはしない）

## 変更ファイル

- `application/prompt/display_item.rs` — `DisplayItem` に `derive(Clone, Copy, PartialEq, Eq)`
- `interface/prompt.rs` — `PullRequests` 分岐を集約ロジックへ。`group_by_display_item` / `join_pr_ids` 追加
- `domain/display_config/render.rs` — `render_token` の変数を `pr_id` → `pr_ids`
- `domain/display_config/defaults.rs` — `DEFAULT_PR_FORMAT` を `$pr_ids` 版へ
- `domain/format_parser.rs` — パーサテストのサンプル文字列を統一
- `README.md` — 集約後出力・`$pr_ids`・移行注記へ更新

## テスト

- 集約のユニットテスト 2 件（同一ステータス集約／複数ステータス PR の各グループ重複表示）
- E2E 2 件追加（`tests/e2e/scenarios/multiple_prs.rs`: 3 PR draft 集約／異なる 2 ステータス群の集約）
- 既存ユニット/E2E テストを `$pr_ids` 仕様へ更新

## 受け入れ条件

- [x] 複数 PR で同一ステータスが 1 トークンに集約され、PR 番号が昇順で列挙される
- [x] 1 PR が複数ステータスを持つ場合、その PR 番号が該当する各グループに現れる
- [x] 単一 PR 時は従来どおり `#番号` を省略する
- [x] `watch` テーブルの出力は変更されない
- [x] `RefreshMode`（Hot/Warm/Terminal）の導出が変わらない
- [x] `tests/e2e/` に集約挙動の E2E を追加
- [x] `README.md` の例・設定説明を `$pr_ids` と集約後出力に更新

## 検証

`cargo build` / `nextest run --workspace`（342 passed）/ `clippy -D warnings` / `fmt --check` / layer-deps・no-mod-rs・no-clippy-allow すべてパス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)