### PR TITLE
perf(evaluation): refresh 時の PR ごとの `gh repo view --json nameWithOwner` を撤廃する

### DIFF
--- a/src/contexts/evaluation/infrastructure/gh/fetch.rs
+++ b/src/contexts/evaluation/infrastructure/gh/fetch.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use super::schema::{GhCompare, GhRepoView};
+use super::schema::GhCompare;
 use crate::shared::process_gh::run_gh;
 
 /// GitHub Compare API でベースブランチとの差分コミット数を取得する。
@@ -16,15 +16,9 @@ pub(super) async fn fetch_behind_by(
         return Some(0);
     }
 
-    let name_with_owner = match run_gh(&["repo", "view", "--json", "nameWithOwner"], cwd).await {
-        Ok(bytes) => match serde_json::from_slice::<GhRepoView>(&bytes) {
-            Ok(r) => r.name_with_owner,
-            Err(_) => return None,
-        },
-        Err(_) => return None,
-    };
-
-    let path = format!("repos/{name_with_owner}/compare/{base_ref}...{head_ref}");
+    // owner/repo は gh が cwd のリポジトリ（または GH_REPO）から補完する placeholder。
+    // PR ごとの `gh repo view --json nameWithOwner` を撤廃するために使う。
+    let path = format!("repos/{{owner}}/{{repo}}/compare/{base_ref}...{head_ref}");
 
     match run_gh(&["api", &path], cwd).await {
         Ok(bytes) => serde_json::from_slice::<GhCompare>(&bytes)

--- a/src/contexts/evaluation/infrastructure/gh/schema.rs
+++ b/src/contexts/evaluation/infrastructure/gh/schema.rs
@@ -35,12 +35,6 @@ pub(super) struct GhCheckItem {
 }
 
 #[derive(Deserialize)]
-pub(super) struct GhRepoView {
-    #[serde(rename = "nameWithOwner")]
-    pub(super) name_with_owner: String,
-}
-
-#[derive(Deserialize)]
 pub(super) struct GhCompare {
     pub(super) behind_by: u64,
 }

--- a/tests/e2e/prompt/branch_sync.rs
+++ b/tests/e2e/prompt/branch_sync.rs
@@ -68,9 +68,9 @@ fn test_compare_api_error() {
     assert_prompt(&env, "? Check branch sync");
 }
 
-/// `gh repo view --json nameWithOwner` が exit 0 で不正な JSON を返す → `? Check branch sync`
+/// compare API が exit 0 で不正な JSON を返す → `? Check branch sync`
 #[test]
-fn test_repo_view_invalid_json_shows_check_branch_sync() {
-    let env = branch_sync_fixtures::with_invalid_repo_view_json(MERGEABLE_BLOCKED, PASS_JSON);
+fn test_compare_invalid_json_shows_check_branch_sync() {
+    let env = branch_sync_fixtures::with_invalid_compare_json(MERGEABLE_BLOCKED, PASS_JSON);
     assert_prompt(&env, "? Check branch sync");
 }

--- a/tests/e2e/prompt/branch_sync_fixtures.rs
+++ b/tests/e2e/prompt/branch_sync_fixtures.rs
@@ -21,9 +21,6 @@ pub fn with_behind_by(pr_view_json: &str, pr_checks_json: Option<&str>, behind_b
            *'pr checks'*)\n\
              {checks_block}\
              ;;\n\
-           *'repo view'*)\n\
-             printf '{{\"nameWithOwner\":\"owner/repo\"}}'\n\
-             ;;\n\
            *'api'*'compare'*)\n\
              printf '{{\"behind_by\":{behind_by}}}'\n\
              ;;\n\
@@ -63,9 +60,6 @@ pub fn with_compare_error(pr_view_json: &str, pr_checks_json: Option<&str>) -> T
            *'pr checks'*)\n\
              {checks_block}\
              ;;\n\
-           *'repo view'*)\n\
-             printf '{{\"nameWithOwner\":\"owner/repo\"}}'\n\
-             ;;\n\
            *'api'*'compare'*)\n\
              printf 'API error' >&2\n\
              exit 1\n\
@@ -85,9 +79,9 @@ pub fn with_compare_error(pr_view_json: &str, pr_checks_json: Option<&str>) -> T
     }
 }
 
-/// `gh pr list` / `gh pr checks` が成功するが `gh repo view --json nameWithOwner` が
-/// exit 0 で不正な JSON を返すシナリオ（compare API への到達前に失敗）
-pub fn with_invalid_repo_view_json(pr_view_json: &str, pr_checks_json: &str) -> TestEnv {
+/// `gh pr list` / `gh pr checks` が成功するが compare API が
+/// exit 0 で不正な JSON を返すシナリオ（`GhCompare` パース失敗で `None`）
+pub fn with_invalid_compare_json(pr_view_json: &str, pr_checks_json: &str) -> TestEnv {
     let (bin, home_tmp, repo) = setup_git_dirs("feat/my-feature");
     let inner = pr_view_json.strip_prefix('{').unwrap_or(pr_view_json);
     let pr_list_json = format!(r#"[{{"number":1,{inner}]"#);
@@ -101,7 +95,7 @@ pub fn with_invalid_repo_view_json(pr_view_json: &str, pr_checks_json: &str) -> 
            *'pr checks'*)\n\
              printf '%s' '{checks_json}'\n\
              ;;\n\
-           *'repo view'*'nameWithOwner'*)\n\
+           *'api'*'compare'*)\n\
              printf 'not-valid-json'\n\
              ;;\n\
            *)\n\


### PR DESCRIPTION
## 概要

daemon の refresh パスで PR ごとに発火していた `gh repo view --json nameWithOwner` を撤廃する。compare API のパスを `gh` の `{owner}` / `{repo}` placeholder で組み立て、gh が cwd のリポジトリ（または `GH_REPO`）から補完するようにした。

Closes #358

## 変更内容

- **`gh/fetch.rs`**: `fetch_behind_by` から `gh repo view --json nameWithOwner` 呼び出しを削除し、compare API パスを `repos/{owner}/{repo}/compare/{base}...{head}` に変更。空 ref 時の `Some(0)` 早期 return・失敗時 `None` のロジックは不変。
- **`gh/schema.rs`**: 未使用になった `GhRepoView` 構造体を削除（`GhRepoViewFull`（`defaultBranchRef`）は別物のため残置）。
- **E2E (`tests/e2e/prompt/`)**:
  - `branch_sync_fixtures.rs`: 発火しなくなる `repo view` ケースを `with_behind_by` / `with_compare_error` から削除。`with_invalid_repo_view_json` を `with_invalid_compare_json` に転用し、compare が exit 0 で不正 JSON を返す = `GhCompare` パース失敗 → `None` の分岐をカバー。
  - `branch_sync.rs`: 旧 `test_repo_view_invalid_json...` を `test_compare_invalid_json_shows_check_branch_sync` に置換。`test_update_branch`（behind_by>0）/ `test_compare_api_error`（exit 1）は維持。

## 効果

- refresh あたりの gh 呼び出しが `3N+1` → `2N+1`（PR 数 N）
- `nameWithOwner → compare` の逐次依存が消え、PR 1 件でもクリティカルパスが「gh 2 回直列」→「gh 1 回」に短縮
- 観測可能な挙動は不変

## 受け入れ条件

- [x] `fetch_behind_by` から `gh repo view --json nameWithOwner` 呼び出しを撤廃
- [x] `{owner}` / `{repo}` placeholder で compare API を呼ぶ
- [x] 既存の挙動（behind_by の判定、空 ref 時の `Some(0)`、失敗時の `None`）が不変であることを E2E で固定
- [x] `cargo nextest run --workspace` green（342 passed）
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` green
- [x] `bash scripts/check-layer-deps.sh` green

## 補足

- 空 ref 時 `Some(0)` の挙動は gh 呼び出し前の早期 return であり本変更で触れておらず、`multiple_prs.rs` / `pr_state.rs` / `errors.rs` の空 `baseRefName`/`headRefName` PR で既に E2E カバー済み。
- placeholder 解決は gh 2.92.0 で確認済み（Issue 記載）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)