### PR TITLE
perf(evaluation): PR 不在パスでの git branch --show-current 重複呼び出しを解消する

### DIFF
--- a/src/contexts/evaluation/infrastructure/gh.rs
+++ b/src/contexts/evaluation/infrastructure/gh.rs
@@ -64,23 +64,21 @@ async fn default_branch(cwd: &Path) -> String {
     }
 }
 
-async fn is_default_branch(cwd: &Path) -> bool {
-    let branch = current_branch(cwd).await.unwrap_or_default();
+async fn is_default_branch(cwd: &Path, branch: &str) -> bool {
     if branch.is_empty() {
         return false;
     }
     branch == default_branch(cwd).await
 }
 
-async fn fetch_pr_list(cwd: &Path) -> Result<Vec<GhPrListItem>, GhError> {
-    let branch = current_branch(cwd).await.unwrap_or_default();
+async fn fetch_pr_list(cwd: &Path, branch: &str) -> Result<Vec<GhPrListItem>, GhError> {
     let bytes = run_gh(
         cwd,
         &[
             "pr",
             "list",
             "--head",
-            &branch,
+            branch,
             "--state",
             "all",
             "--json",
@@ -182,7 +180,10 @@ pub async fn fetch_prompt(cwd: &Path) -> Result<Prompt, RepositoryError> {
         return Ok(Prompt::NoRepository);
     }
 
-    let all_prs = match fetch_pr_list(cwd).await {
+    // `git branch --show-current` は 1 回だけ起動し、結果を両ヘルパーで使い回す。
+    let branch = current_branch(cwd).await.unwrap_or_default();
+
+    let all_prs = match fetch_pr_list(cwd, &branch).await {
         Ok(list) => list,
         Err(GhError::NoPr) => return Ok(Prompt::NoPullRequest),
         Err(GhError::NotGithubRepository) => return Ok(Prompt::UnsupportedRepository),
@@ -191,7 +192,7 @@ pub async fn fetch_prompt(cwd: &Path) -> Result<Prompt, RepositoryError> {
 
     // PR が一度も作られていない場合
     if all_prs.is_empty() {
-        if is_default_branch(cwd).await {
+        if is_default_branch(cwd, &branch).await {
             return Ok(Prompt::DefaultBranch);
         }
         return Ok(Prompt::NoPullRequest);


### PR DESCRIPTION
## 概要

`fetch_prompt`（`src/contexts/evaluation/infrastructure/gh.rs`）の「PR が 1 件も存在しない」パスで、`git branch --show-current`（`current_branch`）が 1 回の refresh につき 2 回起動されていた重複を解消する。

## 変更内容

- `fetch_prompt` で `is_git_repo` ガード直後に `current_branch` を **1 回だけ**解決し、結果を両ヘルパーで使い回す。
- `fetch_pr_list` / `is_default_branch` は `branch: &str` を引数で受け取るよう変更し、内部の `current_branch` 呼び出しを削除。
- 変更は `gh.rs` 内で完結（両ヘルパーはモジュール外から呼ばれていない）。

## 効果

- PR 不在パスの `git branch --show-current` 起動が **2 回 → 1 回**。
- `current_branch` は `git` を起動する唯一の箇所（`git.rs`）。`is_git_repo` はファイルシステム参照のみ。

## 挙動の同一性

- branch 解決は従来どおり `unwrap_or_default()`（git 失敗・detached HEAD 時は空文字列）。空文字列時の `pr list --head ""` と `is_default_branch == false` も不変。
- `current_branch` の起動は従来も今後も `is_git_repo == true` のとき（=`fetch_pr_list` 到達時）のみ。`NoRepository` パスで余分に呼ばれない。

## 受け入れ条件

- [x] PR 不在パスで `git branch --show-current` の起動が 1 回になる（`current_branch` 呼び出し箇所を `fetch_prompt` の 1 か所に集約）
- [x] 既存の判定（DefaultBranch / NoPullRequest の出し分け）が不変であることを E2E で固定
  - `tests/e2e/scenarios/default_branch.rs`（main/master → `DefaultBranch`、`is_default_branch == true`）
  - `tests/e2e/scenarios/no_pr.rs::test_daemon_no_pr_shows_nothing_after_refresh`（feat ブランチ + PR 無し → `NoPullRequest`、`is_default_branch == false`）
- [x] `cargo nextest run --workspace` green（342 passed）
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` green
- [x] `bash scripts/check-layer-deps.sh` green

## 関連

親トラッキング: #362
Closes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)