### PR TITLE
perf(daemon): レート制限コストモデルを実 API コール数に整合させる

### DIFF
--- a/src/contexts/daemon/domain/cache/transition.rs
+++ b/src/contexts/daemon/domain/cache/transition.rs
@@ -241,7 +241,10 @@ fn total_refresh_cost<'a, I: IntoIterator<Item = &'a CacheEntryState>>(entries: 
             continue;
         }
         let pr_count = u64::try_from(e.pr_outputs().len()).unwrap_or(u64::MAX);
-        total = total.saturating_add(pr_count.saturating_add(2));
+        // 1 リフレッシュあたりの実 gh API コール数:
+        //   `gh pr list` 1 + PR ごとに `gh api compare` + `gh pr checks` の 2 = 2N + 1。
+        // 取得方法（#360 GraphQL 集約など）の変更時はこの係数を追従させる。
+        total = total.saturating_add(pr_count.saturating_mul(2).saturating_add(1));
     }
     total
 }
@@ -825,13 +828,22 @@ mod tests {
     }
 
     #[test]
+    fn total_refresh_cost_two_calls_per_pr_plus_one() {
+        // 1 リフレッシュあたり `gh pr list` 1 + PR ごとに 2 コール = 2N + 1。
+        // 単独 active エントリ（3 PR）→ 2*3 + 1 = 7。
+        let entries = vec![entry_with_pr_count(3, RefreshMode::Warm)];
+        assert_eq!(super::total_refresh_cost(&entries), 7);
+    }
+
+    #[test]
     fn total_refresh_cost_excludes_terminal() {
+        // active: (2*3+1) + (2*1+1) = 7 + 3 = 10、Terminal は除外。
         let entries = vec![
-            entry_with_pr_count(2, RefreshMode::Warm),
-            entry_with_pr_count(0, RefreshMode::Warm),
+            entry_with_pr_count(3, RefreshMode::Warm),
+            entry_with_pr_count(1, RefreshMode::Warm),
             entry_with_pr_count(3, RefreshMode::Terminal),
         ];
-        assert_eq!(super::total_refresh_cost(&entries), 6);
+        assert_eq!(super::total_refresh_cost(&entries), 10);
     }
 
     #[test]

--- a/src/contexts/daemon/domain/refresh_policy.rs
+++ b/src/contexts/daemon/domain/refresh_policy.rs
@@ -126,7 +126,7 @@ impl RefreshPolicy {
     /// - **予算項**: `total_cost_per_cycle * secs_until_reset / safety_budget * weight`
     ///
     /// `total_cost_per_cycle` は全 active エントリの「1 リフレッシュあたりの API
-    /// コール数」総和（呼び出し側が `pr_count + 2` の総和を渡す）。
+    /// コール数」総和（呼び出し側が `2 * pr_count + 1` の総和を渡す）。
     ///
     /// `is_exhausted()` のとき、結果は最低でも `cold_late_secs` 以上に保証する。
     ///


### PR DESCRIPTION
## 概要

`total_refresh_cost`（`src/contexts/daemon/domain/cache/transition.rs`）のエントリごとの API コール見積もりを `pr_count + 2`（= N+2）から **`2 * pr_count + 1`**（= 2N+1）に修正します。

## 背景

実際の `fetch_prompt`（`evaluation/infrastructure/gh.rs`）の `gh` API コール数:

- `gh pr list` … 1
- PR ごとに `gh api compare`（`fetch_behind_by`）+ `gh pr checks`（`fetch_ci_state_for`）… 2N

合計 **`2N + 1`**。`current_branch`（`git branch --show-current`）は git コマンドのため gh レート制限を消費せずカウント外。per-PR の `gh repo view` は #358/#363 で撤廃済み、GraphQL 集約（#360）は未適用のため、現時点の正しい係数は `2 * pr_count + 1` です。

従来の `N + 2` は過小見積もりで、レート制限スケーリングが「実際より安い」と判断して refresh を過剰発火し、レート制限到達 → backoff 遅延を招くリスクがありました。

## 変更内容

- `total_refresh_cost` の係数を `pr_count.saturating_mul(2).saturating_add(1)` に修正（overflow 安全な saturating 演算を維持）
- 係数の根拠を実装コメント（transition.rs）+ doc コメント（refresh_policy.rs）で明示
- ユニットテストを新旧で値が異なる入力に更新し、旧係数では fail するよう変更。係数の意図を直接固定するテスト `total_refresh_cost_two_calls_per_pr_plus_one` を追加

## 受け入れ条件

- [x] `total_refresh_cost` が実 API コール数 `2N + 1` に整合
- [x] 係数の根拠がコメント/テストで説明されている
- [x] レート制限スケーリングのユニットテストが更新後の係数で green
- [x] `cargo nextest run --workspace` green（343 passed）
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` green

## 関連

親トラッキング: #362 / Closes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)