### PR TITLE
perf(evaluation): refresh を単一 GraphQL クエリへ集約し gh subprocess を 2N+1 → N+1 にする

### DIFF
--- a/src/contexts/daemon/domain/cache/transition.rs
+++ b/src/contexts/daemon/domain/cache/transition.rs
@@ -241,10 +241,11 @@ fn total_refresh_cost<'a, I: IntoIterator<Item = &'a CacheEntryState>>(entries: 
             continue;
         }
         let pr_count = u64::try_from(e.pr_outputs().len()).unwrap_or(u64::MAX);
-        // 1 リフレッシュあたりの実 gh API コール数:
-        //   `gh pr list` 1 + PR ごとに `gh api compare` + `gh pr checks` の 2 = 2N + 1。
-        // 取得方法（#360 GraphQL 集約など）の変更時はこの係数を追従させる。
-        total = total.saturating_add(pr_count.saturating_mul(2).saturating_add(1));
+        // 1 リフレッシュあたりの実 gh API コール数（#360 GraphQL 集約後）:
+        //   PR メタ + CI を単一 `gh api graphql` で 1 回 + PR ごとに branch sync の
+        //   `gh api compare`（REST 併用）N 回 = N + 1。
+        // 取得方法を変更する際はこの係数を追従させる。
+        total = total.saturating_add(pr_count.saturating_add(1));
     }
     total
 }
@@ -828,22 +829,22 @@ mod tests {
     }
 
     #[test]
-    fn total_refresh_cost_two_calls_per_pr_plus_one() {
-        // 1 リフレッシュあたり `gh pr list` 1 + PR ごとに 2 コール = 2N + 1。
-        // 単独 active エントリ（3 PR）→ 2*3 + 1 = 7。
+    fn total_refresh_cost_one_graphql_plus_compare_per_pr() {
+        // 1 リフレッシュあたり GraphQL 1 + PR ごとに compare 1 コール = N + 1。
+        // 単独 active エントリ（3 PR）→ 3 + 1 = 4。
         let entries = vec![entry_with_pr_count(3, RefreshMode::Warm)];
-        assert_eq!(super::total_refresh_cost(&entries), 7);
+        assert_eq!(super::total_refresh_cost(&entries), 4);
     }
 
     #[test]
     fn total_refresh_cost_excludes_terminal() {
-        // active: (2*3+1) + (2*1+1) = 7 + 3 = 10、Terminal は除外。
+        // active: (3+1) + (1+1) = 4 + 2 = 6、Terminal は除外。
         let entries = vec![
             entry_with_pr_count(3, RefreshMode::Warm),
             entry_with_pr_count(1, RefreshMode::Warm),
             entry_with_pr_count(3, RefreshMode::Terminal),
         ];
-        assert_eq!(super::total_refresh_cost(&entries), 10);
+        assert_eq!(super::total_refresh_cost(&entries), 6);
     }
 
     #[test]

--- a/src/contexts/daemon/domain/refresh_policy.rs
+++ b/src/contexts/daemon/domain/refresh_policy.rs
@@ -126,7 +126,7 @@ impl RefreshPolicy {
     /// - **予算項**: `total_cost_per_cycle * secs_until_reset / safety_budget * weight`
     ///
     /// `total_cost_per_cycle` は全 active エントリの「1 リフレッシュあたりの API
-    /// コール数」総和（呼び出し側が `2 * pr_count + 1` の総和を渡す）。
+    /// コール数」総和（呼び出し側が `pr_count + 1` の総和を渡す）。
     ///
     /// `is_exhausted()` のとき、結果は最低でも `cold_late_secs` 以上に保証する。
     ///

--- a/src/contexts/evaluation/infrastructure/gh.rs
+++ b/src/contexts/evaluation/infrastructure/gh.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 use error::{GhError, classify_gh_error};
 use fetch::fetch_behind_by;
 use mapper::{aggregate_ci, translate_review, translate_sync, translate_unblocked};
-use schema::{CheckBucket, GhCheckItem, GhPrListItem, GhRepoViewFull, translate_bucket};
+use schema::{CheckBucket, GhPrNode, GraphQlResponse, Repository, context_to_bucket};
 use tokio::task::JoinSet;
 
 use crate::contexts::evaluation::domain::error::RepositoryError;
@@ -17,6 +17,29 @@ use crate::contexts::evaluation::domain::prompt::pull_request::state::evaluate;
 use crate::contexts::evaluation::domain::prompt::{PrId, Prompt, PullRequest, State};
 use crate::contexts::evaluation::infrastructure::git::{current_branch, is_git_repo};
 use crate::contexts::evaluation::infrastructure::logger::{ErrorCategory, LogRecord, log_record};
+
+/// PR メタ + CI（statusCheckRollup）+ defaultBranchRef を単一リクエストで取得する
+/// GraphQL クエリ。`{owner}` / `{repo}` placeholder は `-F` 経由で gh が現在の
+/// リポジトリから補完する。
+const REPO_QUERY: &str = "\
+query($owner:String!, $repo:String!, $head:String!) {
+  repository(owner:$owner, name:$repo) {
+    defaultBranchRef { name }
+    pullRequests(headRefName:$head, first:100, states:[OPEN,CLOSED,MERGED]) {
+      nodes {
+        number state isDraft mergeable mergeStateStatus reviewDecision
+        baseRefName headRefName
+        commits(last:1) { nodes { commit { statusCheckRollup {
+          contexts(first:100) { nodes {
+            __typename
+            ... on CheckRun { status conclusion }
+            ... on StatusContext { state }
+          } }
+        } } } }
+      }
+    }
+  }
+}";
 
 async fn run_gh(cwd: &Path, args: &[&str]) -> Result<Vec<u8>, GhError> {
     match crate::shared::process_gh::run_gh(args, Some(cwd)).await {
@@ -54,100 +77,66 @@ fn log_and_convert(e: GhError) -> RepositoryError {
     RepositoryError::from(e)
 }
 
-async fn default_branch(cwd: &Path) -> String {
-    match run_gh(cwd, &["repo", "view", "--json", "defaultBranchRef"]).await {
-        Ok(bytes) => match serde_json::from_slice::<GhRepoViewFull>(&bytes) {
-            Ok(v) => v.default_branch_ref.name,
-            Err(_) => String::new(),
-        },
-        Err(_) => String::new(),
-    }
-}
-
-async fn is_default_branch(cwd: &Path, branch: &str) -> bool {
-    if branch.is_empty() {
-        return false;
-    }
-    branch == default_branch(cwd).await
-}
-
-async fn fetch_pr_list(cwd: &Path, branch: &str) -> Result<Vec<GhPrListItem>, GhError> {
+/// 単一 GraphQL クエリで repository（PR メタ + CI rollup + defaultBranchRef）を取得する。
+///
+/// `repository` が `null`（解決不能）の場合は `None` を返す。gh が非ゼロ終了した場合は
+/// `classify_gh_error`（`run_gh` 内）で分類済みの `GhError` を返す。
+async fn fetch_repository(cwd: &Path, branch: &str) -> Result<Option<Repository>, GhError> {
+    let head_arg = format!("head={branch}");
+    let query_arg = format!("query={REPO_QUERY}");
     let bytes = run_gh(
         cwd,
         &[
-            "pr",
-            "list",
-            "--head",
-            branch,
-            "--state",
-            "all",
-            "--json",
-            "number,state,isDraft,mergeable,mergeStateStatus,reviewDecision,baseRefName,headRefName",
+            "api",
+            "graphql",
+            "-F",
+            "owner={owner}",
+            "-F",
+            "repo={repo}",
+            "-f",
+            head_arg.as_str(),
+            "-f",
+            query_arg.as_str(),
         ],
     )
     .await?;
-    let mut items: Vec<GhPrListItem> = serde_json::from_slice(&bytes).map_err(|e| {
+    let resp: GraphQlResponse = serde_json::from_slice(&bytes).map_err(|e| {
         log_record(&LogRecord {
             category: ErrorCategory::Unknown,
             detail: Some(e.to_string()),
         });
         GhError::ApiError(e.to_string())
     })?;
-    items.sort_by_key(|i| i.number);
-    Ok(items)
+    Ok(resp.data.and_then(|d| d.repository))
 }
 
-async fn fetch_ci_state_for(
-    cwd: &Path,
-    pr_number: u64,
-) -> Result<Option<CiState>, RepositoryError> {
-    let pr_num_str = pr_number.to_string();
-    let bytes = match run_gh(
-        cwd,
-        &["pr", "checks", &pr_num_str, "--json", "bucket,state"],
-    )
-    .await
-    {
-        Ok(b) => b,
-        Err(GhError::ApiError(msg)) if msg.contains("no checks reported") => {
-            return Ok(None);
-        }
-        Err(e) => return Err(log_and_convert(e)),
-    };
-    let items: Vec<GhCheckItem> = serde_json::from_slice(&bytes).map_err(|e| {
-        log_record(&LogRecord {
-            category: ErrorCategory::Unknown,
-            detail: Some(e.to_string()),
-        });
-        RepositoryError::Unexpected
-    })?;
-    let buckets: Vec<CheckBucket> = items.iter().map(|c| translate_bucket(&c.bucket)).collect();
-    Ok(aggregate_ci(&buckets))
+/// PR ノードの `statusCheckRollup` から CI 状態を集約する（追加の gh 起動なし）。
+/// チェック未設定（rollup が `null`）の場合は `None`。
+fn ci_from_node(node: &GhPrNode) -> Option<CiState> {
+    let contexts = node
+        .commits
+        .nodes
+        .first()
+        .and_then(|c| c.commit.status_check_rollup.as_ref())
+        .map_or(&[][..], |r| r.contexts.nodes.as_slice());
+    let buckets: Vec<CheckBucket> = contexts.iter().map(context_to_bucket).collect();
+    aggregate_ci(&buckets)
 }
 
 async fn evaluate_single_pr(
     cwd: PathBuf,
-    pr_view: GhPrListItem,
+    pr_view: GhPrNode,
 ) -> Result<PullRequest, RepositoryError> {
     let id = PrId::new(pr_view.number);
 
-    // branch_sync と ci を並列取得
-    let base = pr_view.base_ref_name.clone();
-    let head = pr_view.head_ref_name.clone();
-    let mergeable = pr_view.mergeable.clone();
-    let pr_number = pr_view.number;
-    let cwd_for_sync = cwd.clone();
-    let cwd_for_ci = cwd.clone();
+    // CI は GraphQL レスポンス（rollup）から同期的に算出する。
+    let ci = ci_from_node(&pr_view);
 
-    let (branch_sync, ci_result) = tokio::join!(
-        async move {
-            let behind_by = fetch_behind_by(&base, &head, Some(&cwd_for_sync)).await;
-            translate_sync(&mergeable, behind_by)
-        },
-        async move { fetch_ci_state_for(&cwd_for_ci, pr_number).await },
-    );
-
-    let ci = ci_result?;
+    // branch sync の behind_by だけは GraphQL に対応フィールドが無いため
+    // PR ごとに REST compare を併用する（refresh あたり 1 GraphQL + N compare）。
+    let behind_by =
+        fetch_behind_by(&pr_view.base_ref_name, &pr_view.head_ref_name, Some(&cwd)).await;
+    let branch_sync = translate_sync(&pr_view.mergeable, behind_by);
 
     // GitHub がまだマージ可能性を計算中（他のシグナルより優先）
     if matches!(
@@ -180,25 +169,39 @@ pub async fn fetch_prompt(cwd: &Path) -> Result<Prompt, RepositoryError> {
         return Ok(Prompt::NoRepository);
     }
 
-    // `git branch --show-current` は 1 回だけ起動し、結果を両ヘルパーで使い回す。
+    // `git branch --show-current` は 1 回だけ起動し、結果を使い回す。
     let branch = current_branch(cwd).await.unwrap_or_default();
 
-    let all_prs = match fetch_pr_list(cwd, &branch).await {
-        Ok(list) => list,
+    // PR メタ + CI + defaultBranchRef を単一 GraphQL で取得する。
+    let repository = match fetch_repository(cwd, &branch).await {
+        Ok(Some(repo)) => repo,
+        // repository が null（解決不能）/ 非 GitHub リモート → 未対応リポジトリ扱い。
+        Ok(None) | Err(GhError::NotGithubRepository) => {
+            return Ok(Prompt::UnsupportedRepository);
+        }
+        // GraphQL では通常発生しない（空 nodes で成功する）が、gh が
+        // "no pull requests found" 系の stderr を返した場合の保険。
         Err(GhError::NoPr) => return Ok(Prompt::NoPullRequest),
-        Err(GhError::NotGithubRepository) => return Ok(Prompt::UnsupportedRepository),
         Err(e) => return Err(log_and_convert(e)),
     };
 
-    // PR が一度も作られていない場合
+    let all_prs = repository.pull_requests.nodes;
+
+    // PR が一度も作られていない場合: defaultBranchRef で判定（追加の gh 起動なし）。
     if all_prs.is_empty() {
-        if is_default_branch(cwd, &branch).await {
+        let default_branch = repository
+            .default_branch_ref
+            .map(|d| d.name)
+            .unwrap_or_default();
+        if !branch.is_empty() && branch == default_branch {
             return Ok(Prompt::DefaultBranch);
         }
         return Ok(Prompt::NoPullRequest);
     }
 
-    let open_prs: Vec<GhPrListItem> = all_prs.into_iter().filter(|p| p.state == "OPEN").collect();
+    let mut open_prs: Vec<GhPrNode> = all_prs.into_iter().filter(|p| p.state == "OPEN").collect();
+    // 表示順を安定させるため PR 番号昇順にそろえる。
+    open_prs.sort_by_key(|i| i.number);
 
     // オープン PR がなく全て MERGED/CLOSED → ターミナル状態（空 Vec で表現）
     if open_prs.is_empty() {

--- a/src/contexts/evaluation/infrastructure/gh.rs
+++ b/src/contexts/evaluation/infrastructure/gh.rs
@@ -3,12 +3,13 @@ mod fetch;
 mod mapper;
 mod schema;
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use error::{GhError, classify_gh_error};
 use fetch::fetch_behind_by;
 use mapper::{aggregate_ci, translate_review, translate_sync, translate_unblocked};
-use schema::{CheckBucket, GhPrNode, GraphQlResponse, Repository, context_to_bucket};
+use schema::{CheckBucket, CheckContext, GhPrNode, GraphQlResponse, Repository, context_to_bucket};
 use tokio::task::JoinSet;
 
 use crate::contexts::evaluation::domain::error::RepositoryError;
@@ -32,8 +33,8 @@ query($owner:String!, $repo:String!, $head:String!) {
         commits(last:1) { nodes { commit { statusCheckRollup {
           contexts(first:100) { nodes {
             __typename
-            ... on CheckRun { status conclusion }
-            ... on StatusContext { state }
+            ... on CheckRun { name status conclusion startedAt }
+            ... on StatusContext { context state createdAt }
           } }
         } } } }
       }
@@ -112,6 +113,10 @@ async fn fetch_repository(cwd: &Path, branch: &str) -> Result<Option<Repository>
 
 /// PR ノードの `statusCheckRollup` から CI 状態を集約する（追加の gh 起動なし）。
 /// チェック未設定（rollup が `null`）の場合は `None`。
+///
+/// CI を再実行すると rollup には古い run も残るため、`gh pr checks` と同様に
+/// 同名 check は最新 run（`startedAt` / `createdAt` 最大）のみを採用する。
+/// これを怠ると古い失敗/キャンセル run を拾って誤って CI ブロック扱いになる。
 fn ci_from_node(node: &GhPrNode) -> Option<CiState> {
     let contexts = node
         .commits
@@ -119,7 +124,20 @@ fn ci_from_node(node: &GhPrNode) -> Option<CiState> {
         .first()
         .and_then(|c| c.commit.status_check_rollup.as_ref())
         .map_or(&[][..], |r| r.contexts.nodes.as_slice());
-    let buckets: Vec<CheckBucket> = contexts.iter().map(context_to_bucket).collect();
+
+    // 名前ごとに最新 run のみ残す。名前を持たない Unknown は無視（常に非ブロッカー）。
+    let mut latest: HashMap<&str, &CheckContext> = HashMap::new();
+    for ctx in contexts {
+        let Some(name) = ctx.name() else { continue };
+        match latest.get(name) {
+            Some(prev) if prev.recency() >= ctx.recency() => {}
+            _ => {
+                latest.insert(name, ctx);
+            }
+        }
+    }
+
+    let buckets: Vec<CheckBucket> = latest.values().map(|c| context_to_bucket(c)).collect();
     aggregate_ci(&buckets)
 }
 

--- a/src/contexts/evaluation/infrastructure/gh/schema.rs
+++ b/src/contexts/evaluation/infrastructure/gh/schema.rs
@@ -1,7 +1,41 @@
 use serde::Deserialize;
 
+/// `gh api graphql` のレスポンス封筒（`{"data":{"repository":...}}`）。
+///
+/// GraphQL エラー時は gh が非ゼロ終了し stderr 経由で分類されるため、
+/// ここでは正常応答（`data.repository`）のみを表現する。`repository` は
+/// `NOT_FOUND` 等で `null` になり得るため `Option`。
 #[derive(Deserialize)]
-pub(super) struct GhPrListItem {
+pub(super) struct GraphQlResponse {
+    pub(super) data: Option<GraphQlData>,
+}
+
+#[derive(Deserialize)]
+pub(super) struct GraphQlData {
+    pub(super) repository: Option<Repository>,
+}
+
+#[derive(Deserialize)]
+pub(super) struct Repository {
+    #[serde(rename = "defaultBranchRef")]
+    pub(super) default_branch_ref: Option<DefaultBranchRef>,
+    #[serde(rename = "pullRequests")]
+    pub(super) pull_requests: PullRequests,
+}
+
+#[derive(Deserialize)]
+pub(super) struct DefaultBranchRef {
+    pub(super) name: String,
+}
+
+#[derive(Deserialize)]
+pub(super) struct PullRequests {
+    pub(super) nodes: Vec<GhPrNode>,
+}
+
+/// `pullRequests.nodes[*]`。`gh pr list --json ...` の各項目に CI rollup を加えた形。
+#[derive(Deserialize)]
+pub(super) struct GhPrNode {
     pub(super) number: u64,
     #[serde(default)]
     pub(super) state: String,
@@ -16,29 +50,60 @@ pub(super) struct GhPrListItem {
     pub(super) base_ref_name: String,
     #[serde(rename = "headRefName", default)]
     pub(super) head_ref_name: String,
+    pub(super) commits: Commits,
 }
 
 #[derive(Deserialize)]
-pub(super) struct GhRepoViewFull {
-    #[serde(rename = "defaultBranchRef")]
-    pub(super) default_branch_ref: GhDefaultBranchRef,
+pub(super) struct Commits {
+    pub(super) nodes: Vec<CommitNode>,
 }
 
 #[derive(Deserialize)]
-pub(super) struct GhDefaultBranchRef {
-    pub(super) name: String,
+pub(super) struct CommitNode {
+    pub(super) commit: Commit,
 }
 
 #[derive(Deserialize)]
-pub(super) struct GhCheckItem {
-    pub(super) bucket: String,
+pub(super) struct Commit {
+    /// チェック未設定の PR では `null`。
+    #[serde(rename = "statusCheckRollup")]
+    pub(super) status_check_rollup: Option<StatusCheckRollup>,
 }
 
+#[derive(Deserialize)]
+pub(super) struct StatusCheckRollup {
+    pub(super) contexts: Contexts,
+}
+
+#[derive(Deserialize)]
+pub(super) struct Contexts {
+    pub(super) nodes: Vec<CheckContext>,
+}
+
+/// `statusCheckRollup.contexts.nodes[*]`。`__typename` で `CheckRun` /
+/// `StatusContext` を判別する。未知の型は `Unknown` に倒して無視する。
+#[derive(Deserialize)]
+#[serde(tag = "__typename")]
+pub(super) enum CheckContext {
+    CheckRun {
+        status: String,
+        conclusion: Option<String>,
+    },
+    StatusContext {
+        state: String,
+    },
+    #[serde(other)]
+    Unknown,
+}
+
+/// Compare API（`gh api repos/{owner}/{repo}/compare/...`）のレスポンス。
+/// branch sync の `behind_by` 取得のため GraphQL 化後も REST で併用する。
 #[derive(Deserialize)]
 pub(super) struct GhCompare {
     pub(super) behind_by: u64,
 }
 
+/// CI チェックの集計用カテゴリ。`aggregate_ci` が消費する。
 pub(super) enum CheckBucket {
     Fail,
     Cancel,
@@ -47,13 +112,32 @@ pub(super) enum CheckBucket {
     Other,
 }
 
-pub(super) fn translate_bucket(bucket: &str) -> CheckBucket {
-    match bucket {
-        "fail" => CheckBucket::Fail,
-        "cancel" => CheckBucket::Cancel,
-        "action_required" => CheckBucket::ActionRequired,
-        "pending" => CheckBucket::Pending,
-        _ => CheckBucket::Other,
+/// `statusCheckRollup` の 1 コンテキストを `CheckBucket` に写像する。
+///
+/// gh CLI（`gh pr checks --json bucket`）の bucket 判定を再現する。
+/// `CheckRun` は `status != COMPLETED` を pending、完了時は `conclusion` で分類。
+/// `StatusContext` は `state` で分類する。`Fail` / `Cancel` は `aggregate_ci`
+/// で同じ `CiState::Fail` に畳まれるため、両者の弁別は最終結果に影響しない。
+pub(super) fn context_to_bucket(ctx: &CheckContext) -> CheckBucket {
+    match ctx {
+        CheckContext::CheckRun { status, conclusion } => {
+            if status != "COMPLETED" {
+                return CheckBucket::Pending;
+            }
+            match conclusion.as_deref() {
+                Some("ACTION_REQUIRED") => CheckBucket::ActionRequired,
+                Some("CANCELLED") => CheckBucket::Cancel,
+                Some("FAILURE" | "TIMED_OUT" | "STARTUP_FAILURE") => CheckBucket::Fail,
+                // SUCCESS / NEUTRAL / SKIPPED と未知の conclusion は非ブロッカー扱い。
+                _ => CheckBucket::Other,
+            }
+        }
+        CheckContext::StatusContext { state } => match state.as_str() {
+            "PENDING" | "EXPECTED" => CheckBucket::Pending,
+            "ERROR" | "FAILURE" => CheckBucket::Fail,
+            _ => CheckBucket::Other,
+        },
+        CheckContext::Unknown => CheckBucket::Other,
     }
 }
 
@@ -61,8 +145,112 @@ pub(super) fn translate_bucket(bucket: &str) -> CheckBucket {
 mod tests {
     use super::*;
 
+    fn check_run(status: &str, conclusion: Option<&str>) -> CheckContext {
+        CheckContext::CheckRun {
+            status: status.to_owned(),
+            conclusion: conclusion.map(str::to_owned),
+        }
+    }
+
+    fn status_context(state: &str) -> CheckContext {
+        CheckContext::StatusContext {
+            state: state.to_owned(),
+        }
+    }
+
     #[test]
-    fn translate_bucket_pending() {
-        assert!(matches!(translate_bucket("pending"), CheckBucket::Pending));
+    fn check_run_in_progress_is_pending() {
+        assert!(matches!(
+            context_to_bucket(&check_run("IN_PROGRESS", None)),
+            CheckBucket::Pending
+        ));
+    }
+
+    #[test]
+    fn check_run_queued_is_pending() {
+        assert!(matches!(
+            context_to_bucket(&check_run("QUEUED", None)),
+            CheckBucket::Pending
+        ));
+    }
+
+    #[test]
+    fn check_run_success_is_other() {
+        assert!(matches!(
+            context_to_bucket(&check_run("COMPLETED", Some("SUCCESS"))),
+            CheckBucket::Other
+        ));
+    }
+
+    #[test]
+    fn check_run_skipped_is_other() {
+        assert!(matches!(
+            context_to_bucket(&check_run("COMPLETED", Some("SKIPPED"))),
+            CheckBucket::Other
+        ));
+    }
+
+    #[test]
+    fn check_run_failure_is_fail() {
+        assert!(matches!(
+            context_to_bucket(&check_run("COMPLETED", Some("FAILURE"))),
+            CheckBucket::Fail
+        ));
+    }
+
+    #[test]
+    fn check_run_timed_out_is_fail() {
+        assert!(matches!(
+            context_to_bucket(&check_run("COMPLETED", Some("TIMED_OUT"))),
+            CheckBucket::Fail
+        ));
+    }
+
+    #[test]
+    fn check_run_cancelled_is_cancel() {
+        assert!(matches!(
+            context_to_bucket(&check_run("COMPLETED", Some("CANCELLED"))),
+            CheckBucket::Cancel
+        ));
+    }
+
+    #[test]
+    fn check_run_action_required_is_action_required() {
+        assert!(matches!(
+            context_to_bucket(&check_run("COMPLETED", Some("ACTION_REQUIRED"))),
+            CheckBucket::ActionRequired
+        ));
+    }
+
+    #[test]
+    fn status_context_success_is_other() {
+        assert!(matches!(
+            context_to_bucket(&status_context("SUCCESS")),
+            CheckBucket::Other
+        ));
+    }
+
+    #[test]
+    fn status_context_pending_is_pending() {
+        assert!(matches!(
+            context_to_bucket(&status_context("PENDING")),
+            CheckBucket::Pending
+        ));
+    }
+
+    #[test]
+    fn status_context_error_is_fail() {
+        assert!(matches!(
+            context_to_bucket(&status_context("ERROR")),
+            CheckBucket::Fail
+        ));
+    }
+
+    #[test]
+    fn unknown_typename_is_other() {
+        assert!(matches!(
+            context_to_bucket(&CheckContext::Unknown),
+            CheckBucket::Other
+        ));
     }
 }

--- a/src/contexts/evaluation/infrastructure/gh/schema.rs
+++ b/src/contexts/evaluation/infrastructure/gh/schema.rs
@@ -82,18 +82,52 @@ pub(super) struct Contexts {
 
 /// `statusCheckRollup.contexts.nodes[*]`。`__typename` で `CheckRun` /
 /// `StatusContext` を判別する。未知の型は `Unknown` に倒して無視する。
+///
+/// `name` / `started_at`（`StatusContext` は `context` / `created_at`）は
+/// 同名 check の重複排除に使う。CI を再実行すると rollup には古い run も残るため、
+/// gh `pr checks` と同様に名前ごとに最新 run のみを採用する必要がある。
 #[derive(Deserialize)]
 #[serde(tag = "__typename")]
 pub(super) enum CheckContext {
     CheckRun {
+        #[serde(default)]
+        name: String,
         status: String,
         conclusion: Option<String>,
+        #[serde(rename = "startedAt")]
+        started_at: Option<String>,
     },
     StatusContext {
+        #[serde(default)]
+        context: String,
         state: String,
+        #[serde(rename = "createdAt")]
+        created_at: Option<String>,
     },
     #[serde(other)]
     Unknown,
+}
+
+impl CheckContext {
+    /// 重複排除のグルーピングキー（CheckRun.name / StatusContext.context）。
+    /// 名前を持たない `Unknown` は `None`。
+    pub(super) fn name(&self) -> Option<&str> {
+        match self {
+            CheckContext::CheckRun { name, .. } => Some(name),
+            CheckContext::StatusContext { context, .. } => Some(context),
+            CheckContext::Unknown => None,
+        }
+    }
+
+    /// 同名 run の新しさ比較用タイムスタンプ。ISO8601 文字列は辞書順 = 時系列順。
+    /// 欠損時は空文字（= 最古扱い）。
+    pub(super) fn recency(&self) -> &str {
+        match self {
+            CheckContext::CheckRun { started_at, .. } => started_at.as_deref().unwrap_or(""),
+            CheckContext::StatusContext { created_at, .. } => created_at.as_deref().unwrap_or(""),
+            CheckContext::Unknown => "",
+        }
+    }
 }
 
 /// Compare API（`gh api repos/{owner}/{repo}/compare/...`）のレスポンス。
@@ -120,7 +154,9 @@ pub(super) enum CheckBucket {
 /// で同じ `CiState::Fail` に畳まれるため、両者の弁別は最終結果に影響しない。
 pub(super) fn context_to_bucket(ctx: &CheckContext) -> CheckBucket {
     match ctx {
-        CheckContext::CheckRun { status, conclusion } => {
+        CheckContext::CheckRun {
+            status, conclusion, ..
+        } => {
             if status != "COMPLETED" {
                 return CheckBucket::Pending;
             }
@@ -132,7 +168,7 @@ pub(super) fn context_to_bucket(ctx: &CheckContext) -> CheckBucket {
                 _ => CheckBucket::Other,
             }
         }
-        CheckContext::StatusContext { state } => match state.as_str() {
+        CheckContext::StatusContext { state, .. } => match state.as_str() {
             "PENDING" | "EXPECTED" => CheckBucket::Pending,
             "ERROR" | "FAILURE" => CheckBucket::Fail,
             _ => CheckBucket::Other,
@@ -147,14 +183,18 @@ mod tests {
 
     fn check_run(status: &str, conclusion: Option<&str>) -> CheckContext {
         CheckContext::CheckRun {
+            name: "ci".to_owned(),
             status: status.to_owned(),
             conclusion: conclusion.map(str::to_owned),
+            started_at: None,
         }
     }
 
     fn status_context(state: &str) -> CheckContext {
         CheckContext::StatusContext {
+            context: "ci".to_owned(),
             state: state.to_owned(),
+            created_at: None,
         }
     }
 

--- a/tests/e2e/cli/completions.rs
+++ b/tests/e2e/cli/completions.rs
@@ -3,7 +3,8 @@ use assert_cmd::Command;
 use super::super::helpers::TestEnv;
 
 const MERGE_READY_PR_VIEW_JSON: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED"}"#;
-const MERGE_READY_PR_CHECKS_JSON: &str = r#"[{"bucket":"pass","state":"SUCCESS"}]"#;
+const MERGE_READY_PR_CHECKS_JSON: &str =
+    r#"[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]"#;
 
 const BIN: &str = "merge-ready";
 

--- a/tests/e2e/cli/flags.rs
+++ b/tests/e2e/cli/flags.rs
@@ -8,7 +8,8 @@ use predicates::prelude::PredicateBooleanExt;
 use super::super::helpers::TestEnv;
 
 const MERGE_READY_PR_VIEW_JSON: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED"}"#;
-const MERGE_READY_PR_CHECKS_JSON: &str = r#"[{"bucket":"pass","state":"SUCCESS"}]"#;
+const MERGE_READY_PR_CHECKS_JSON: &str =
+    r#"[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]"#;
 
 const BIN: &str = "merge-ready";
 

--- a/tests/e2e/config/config_path.rs
+++ b/tests/e2e/config/config_path.rs
@@ -8,7 +8,8 @@ use assert_cmd::Command;
 use super::super::helpers::{DaemonHandle, TestEnv};
 
 const MERGE_READY_JSON: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED"}"#;
-const CHECKS_PASS_JSON: &str = r#"[{"bucket":"pass","state":"SUCCESS"}]"#;
+const CHECKS_PASS_JSON: &str =
+    r#"[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]"#;
 
 const PROMPT_BIN: &str = "merge-ready-prompt";
 

--- a/tests/e2e/config/token_customization.rs
+++ b/tests/e2e/config/token_customization.rs
@@ -11,7 +11,8 @@ use rstest::rstest;
 use super::super::helpers::{DaemonHandle, TestEnv};
 
 const MERGE_READY_JSON: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED"}"#;
-const CHECKS_PASS_JSON: &str = r#"[{"bucket":"pass","state":"SUCCESS"}]"#;
+const CHECKS_PASS_JSON: &str =
+    r#"[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]"#;
 const CONFLICT_JSON: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"CONFLICTING","mergeStateStatus":"DIRTY","reviewDecision":"APPROVED"}"#;
 
 const PROMPT_BIN: &str = "merge-ready-prompt";

--- a/tests/e2e/daemon/lifecycle.rs
+++ b/tests/e2e/daemon/lifecycle.rs
@@ -11,7 +11,8 @@ const BIN: &str = "merge-ready";
 const PROMPT_BIN: &str = "merge-ready-prompt";
 
 const OPEN_PR_VIEW_JSON: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}"#;
-const CI_PASS_JSON: &str = r#"[{"bucket":"pass","state":"SUCCESS","name":"ci","link":""}]"#;
+const CI_PASS_JSON: &str =
+    r#"[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]"#;
 const COMMAND_TIMEOUT_MS: u64 = 5000;
 const CONCURRENT_PROMPTS: usize = 8;
 

--- a/tests/e2e/daemon/watch.rs
+++ b/tests/e2e/daemon/watch.rs
@@ -12,7 +12,8 @@ use super::super::helpers::{DaemonHandle, MultiRepoEnv, TestEnv, apply_coverage_
 
 const BIN: &str = "merge-ready";
 const OPEN_PR_VIEW_JSON: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}"#;
-const CI_PASS_JSON: &str = r#"[{"bucket":"pass","state":"SUCCESS","name":"ci","link":""}]"#;
+const CI_PASS_JSON: &str =
+    r#"[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]"#;
 
 /// `merge-ready watch` を起動し、`n` 行分の stdout を最大 `timeout` で読んで返す。
 /// 読み取り後に SIGINT を送りプロセスを終了させる。

--- a/tests/e2e/helpers/env.rs
+++ b/tests/e2e/helpers/env.rs
@@ -47,26 +47,21 @@ pub struct TestEnv {
 }
 
 impl TestEnv {
-    /// 正常系: `pr list` / `pr checks` それぞれの JSON を返す `fake gh` を配置する。
+    /// 正常系: 単一 PR の `gh api graphql` 応答を返す `fake gh` を配置する。
+    ///
+    /// `pr_view_json` は `{...}` の PR フラグメント（`number` を含まない）。
+    /// `pr_checks_json` は `statusCheckRollup.contexts.nodes`（`None` で CI 未設定）。
+    /// branch sync 用の `gh api ...compare...` は `behind_by:0` を返す。
     pub fn new(pr_view_json: &str, pr_checks_json: Option<&str>) -> Self {
         let (bin, home_tmp, repo) = setup_git_dirs("feat/my-feature");
 
-        let checks_block = match pr_checks_json {
-            Some(j) => format!("printf '%s' '{j}'\n"),
-            None => "printf 'unexpected pr checks call' >&2\nexit 1\n".to_string(),
-        };
-
-        let inner = pr_view_json.strip_prefix('{').unwrap_or(pr_view_json);
-        let pr_list_json = format!(r#"[{{"number":1,{inner}]"#);
+        let graphql_json = super::graphql_single(pr_view_json, pr_checks_json);
 
         let script = format!(
             "#!/bin/sh\n\
              case \"$*\" in\n\
-               *'pr list'*)\n\
-                 printf '%s' '{pr_list_json}'\n\
-                 ;;\n\
-               *'pr checks'*)\n\
-                 {checks_block}\
+               *graphql*)\n\
+                 printf '%s' '{graphql_json}'\n\
                  ;;\n\
                *'api'*'compare'*)\n\
                  printf '{{\"behind_by\":0}}'\n\
@@ -89,24 +84,25 @@ impl TestEnv {
     /// PR なしシナリオ: フィーチャーブランチに PR が存在しない場合を模倣する。
     ///
     /// 現在ブランチ: `feat/my-feature`（デフォルトブランチではない）
-    /// `gh pr list` → 空配列 `[]` を返す
-    /// `gh repo view --json defaultBranchRef` → main をデフォルトブランチとして返す
+    /// graphql 応答 → 空 `nodes` + `defaultBranchRef.name = "main"` を返す
     pub fn with_no_pr() -> Self {
         let (bin, home_tmp, repo) = setup_git_dirs("feat/my-feature");
-        let script = "#!/bin/sh\n\
-                      case \"$*\" in\n\
-                        *'pr list'*)\n\
-                          printf '[]'\n\
-                          ;;\n\
-                        *'repo view'*'defaultBranchRef'*)\n\
-                          printf '{\"defaultBranchRef\":{\"name\":\"main\"}}'\n\
-                          ;;\n\
-                        *)\n\
-                          printf 'unknown gh command: %s' \"$*\" >&2\n\
-                          exit 127\n\
-                          ;;\n\
-                      esac\n";
-        write_executable(bin.path().join("gh"), script);
+        // 空 nodes + defaultBranchRef=main。現在ブランチ feat/my-feature はデフォルト
+        // ブランチではないため NoPullRequest（= `+ Create PR`）になる。
+        let graphql_json = super::graphql_response(&[], "main");
+        let script = format!(
+            "#!/bin/sh\n\
+             case \"$*\" in\n\
+               *graphql*)\n\
+                 printf '%s' '{graphql_json}'\n\
+                 ;;\n\
+               *)\n\
+                 printf 'unknown gh command: %s' \"$*\" >&2\n\
+                 exit 127\n\
+                 ;;\n\
+             esac\n"
+        );
+        write_executable(bin.path().join("gh"), &script);
         Self {
             bin,
             home_tmp,
@@ -138,24 +134,26 @@ impl TestEnv {
 
     /// 複数 PR シナリオ: `pr_list_json` に複数エントリを含む JSON 配列を直接指定する。
     ///
-    /// `pr_list_json` は `[{...}, {...}]` 形式の完全な JSON 配列。
-    /// `gh pr checks` はすべての PR 番号に対して同じ `pr_checks_json` を返す。
+    /// `pr_list_json` は `[{...}, {...}]` 形式（各ノードは `number` を含む）。
+    /// `pr_checks_json`（`statusCheckRollup.contexts.nodes`）は全 PR に同じものを付与する。
     pub fn with_pr_list(pr_list_json: &str, pr_checks_json: Option<&str>) -> Self {
         let (bin, home_tmp, repo) = setup_git_dirs("feat/my-feature");
 
-        let checks_block = match pr_checks_json {
-            Some(j) => format!("printf '%s' '{j}'\n"),
-            None => "printf 'unexpected pr checks call' >&2\nexit 1\n".to_string(),
-        };
+        // `pr_list_json` は `number` を含む PR ノードの JSON 配列。各ノードに同じ
+        // CI rollup を付与して graphql 応答へまとめる。
+        let parsed: Vec<serde_json::Value> =
+            serde_json::from_str(pr_list_json).expect("invalid pr list json array");
+        let nodes: Vec<serde_json::Value> = parsed
+            .into_iter()
+            .map(|n| super::attach_rollup(n, pr_checks_json))
+            .collect();
+        let graphql_json = super::graphql_response(&nodes, "main");
 
         let script = format!(
             "#!/bin/sh\n\
              case \"$*\" in\n\
-               *'pr list'*)\n\
-                 printf '%s' '{pr_list_json}'\n\
-                 ;;\n\
-               *'pr checks'*)\n\
-                 {checks_block}\
+               *graphql*)\n\
+                 printf '%s' '{graphql_json}'\n\
                  ;;\n\
                *'api'*'compare'*)\n\
                  printf '{{\"behind_by\":0}}'\n\

--- a/tests/e2e/helpers/mod.rs
+++ b/tests/e2e/helpers/mod.rs
@@ -46,6 +46,62 @@ pub(crate) fn write_executable(path: impl AsRef<Path>, content: &str) {
     fs::set_permissions(path, fs::Permissions::from_mode(0o755)).expect("failed to chmod script");
 }
 
+// ── GraphQL レスポンス組み立て（#360） ────────────────────────────────────────
+//
+// `fetch_prompt` は `gh api graphql` 単一クエリで PR メタ + CI rollup +
+// defaultBranchRef を取得する。fake gh はこの封筒形状の JSON を返す。
+// branch sync の `behind_by` だけは REST `gh api ...compare...` 併用のまま。
+
+use serde_json::{Value, json};
+
+/// CLEAN + 成功 CI を表す `statusCheckRollup.contexts.nodes`。多くの fixture が利用。
+pub(crate) const ROLLUP_PASS: &str =
+    r#"[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]"#;
+
+fn commits_value(rollup_contexts: Option<&str>) -> Value {
+    let rollup = match rollup_contexts {
+        Some(ctx) => {
+            let nodes: Value = serde_json::from_str(ctx).expect("invalid rollup contexts json");
+            json!({ "contexts": { "nodes": nodes } })
+        }
+        None => Value::Null,
+    };
+    json!({ "nodes": [ { "commit": { "statusCheckRollup": rollup } } ] })
+}
+
+/// PR フラグメント（`{...}` オブジェクト）に `number` と CI `statusCheckRollup` を付与した
+/// PR ノード `Value` を作る。`rollup_contexts` が `None` のとき rollup は `null`（CI 未設定）。
+pub(crate) fn pr_node(number: u64, fragment: &str, rollup_contexts: Option<&str>) -> Value {
+    let mut obj: Value = serde_json::from_str(fragment).expect("invalid pr fragment json");
+    let map = obj.as_object_mut().expect("pr fragment must be an object");
+    map.insert("number".to_owned(), json!(number));
+    map.insert("commits".to_owned(), commits_value(rollup_contexts));
+    obj
+}
+
+/// すでに `number` を含む PR ノードに CI `statusCheckRollup` を付与する（複数 PR 用）。
+pub(crate) fn attach_rollup(mut node: Value, rollup_contexts: Option<&str>) -> Value {
+    let map = node.as_object_mut().expect("pr node must be an object");
+    map.insert("commits".to_owned(), commits_value(rollup_contexts));
+    node
+}
+
+/// `gh api graphql` の repository レスポンス JSON 文字列。
+pub(crate) fn graphql_response(nodes: &[Value], default_branch: &str) -> String {
+    json!({
+        "data": { "repository": {
+            "defaultBranchRef": { "name": default_branch },
+            "pullRequests": { "nodes": nodes }
+        }}
+    })
+    .to_string()
+}
+
+/// 単一 PR の graphql 応答文字列（defaultBranch="main"）。
+pub(crate) fn graphql_single(fragment: &str, rollup_contexts: Option<&str>) -> String {
+    graphql_response(&[pr_node(1, fragment, rollup_contexts)], "main")
+}
+
 /// fake `gh` バイナリ用に `api rate_limit` を「クォータ十分」の静的 JSON で返す
 /// シェルスクリプト断片。各 fixture の `case "$*"` よりも前に挿入することで、
 /// daemon の `rate_limit` fetcher による予期しないコール記録を防ぐ。

--- a/tests/e2e/helpers/multi_repo.rs
+++ b/tests/e2e/helpers/multi_repo.rs
@@ -4,7 +4,10 @@ use std::fs;
 use std::path::Path;
 use tempfile::{TempDir, tempdir};
 
-use super::{DaemonHandle, apply_coverage_env, run_prompt_with_timeout, write_executable};
+use super::{
+    DaemonHandle, ROLLUP_PASS, apply_coverage_env, graphql_single, run_prompt_with_timeout,
+    write_executable,
+};
 
 pub struct MultiRepoEnv {
     pub bin: TempDir,
@@ -24,11 +27,8 @@ impl MultiRepoEnv {
 
         let gh_script = "#!/bin/sh\n\
             case \"$*\" in\n\
-              *'pr list'*)\n\
-                cat \"$PWD/.gh_pr_list.json\"\n\
-                ;;\n\
-              *'pr checks'*)\n\
-                printf '[{\"bucket\":\"pass\",\"state\":\"SUCCESS\"}]'\n\
+              *graphql*)\n\
+                cat \"$PWD/.gh_graphql.json\"\n\
                 ;;\n\
               *'api'*'compare'*)\n\
                 printf '{\"behind_by\":0}'\n\
@@ -40,14 +40,13 @@ impl MultiRepoEnv {
             esac\n";
         write_executable(bin.path().join("gh"), gh_script);
 
-        for (repo, json) in [(&repo_a, pr_view_a), (&repo_b, pr_view_b)] {
+        for (repo, fragment) in [(&repo_a, pr_view_a), (&repo_b, pr_view_b)] {
             let git_dir = repo.path().join(".git");
             fs::create_dir_all(&git_dir).expect("create .git");
             fs::write(git_dir.join("HEAD"), "ref: refs/heads/feat/my-feature\n")
                 .expect("write HEAD");
-            let inner = json.strip_prefix('{').unwrap_or(json);
-            let list_json = format!(r#"[{{"number":1,{inner}]"#);
-            fs::write(repo.path().join(".gh_pr_list.json"), &list_json)
+            let graphql_json = graphql_single(fragment, Some(ROLLUP_PASS));
+            fs::write(repo.path().join(".gh_graphql.json"), &graphql_json)
                 .expect("write response json");
         }
 

--- a/tests/e2e/prompt/branch_sync.rs
+++ b/tests/e2e/prompt/branch_sync.rs
@@ -15,8 +15,11 @@ const CONFLICTING_BEHIND: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":
 const CONFLICTING_DIRTY_CHANGES: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"CONFLICTING","mergeStateStatus":"DIRTY","reviewDecision":"CHANGES_REQUESTED"}"#;
 const MERGEABLE_BLOCKED: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"BLOCKED","reviewDecision":null,"baseRefName":"main","headRefName":"feat/test"}"#;
 
-const PASS_JSON: &str = r#"[{"bucket":"pass","state":"SUCCESS"}]"#;
-const FAIL_JSON: &str = r#"[{"bucket":"fail","state":"FAILURE"}]"#;
+// `statusCheckRollup.contexts.nodes` 形式
+const PASS_JSON: &str =
+    r#"[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]"#;
+const FAIL_JSON: &str =
+    r#"[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"FAILURE"}]"#;
 
 fn assert_prompt(env: &TestEnv, expected: &str) {
     let _daemon = DaemonHandle::start(env);

--- a/tests/e2e/prompt/branch_sync_fixtures.rs
+++ b/tests/e2e/prompt/branch_sync_fixtures.rs
@@ -1,25 +1,18 @@
-use super::super::helpers::{TestEnv, setup_git_dirs, write_executable};
+use super::super::helpers::{TestEnv, graphql_single, setup_git_dirs, write_executable};
 
 /// compare API が `behind_by` を返すシナリオ用の `fake gh` を配置する。
+///
+/// PR メタ + CI は単一 graphql 応答、branch sync の `behind_by` は REST compare 併用。
 pub fn with_behind_by(pr_view_json: &str, pr_checks_json: Option<&str>, behind_by: u64) -> TestEnv {
     let (bin, home_tmp, repo) = setup_git_dirs("feat/my-feature");
 
-    let checks_block = match pr_checks_json {
-        Some(j) => format!("printf '%s' '{j}'\n"),
-        None => "printf 'unexpected pr checks call' >&2\nexit 1\n".to_string(),
-    };
-
-    let inner = pr_view_json.strip_prefix('{').unwrap_or(pr_view_json);
-    let pr_list_json = format!(r#"[{{"number":1,{inner}]"#);
+    let graphql_json = graphql_single(pr_view_json, pr_checks_json);
 
     let script = format!(
         "#!/bin/sh\n\
          case \"$*\" in\n\
-           *'pr list'*)\n\
-             printf '%s' '{pr_list_json}'\n\
-             ;;\n\
-           *'pr checks'*)\n\
-             {checks_block}\
+           *graphql*)\n\
+             printf '%s' '{graphql_json}'\n\
              ;;\n\
            *'api'*'compare'*)\n\
              printf '{{\"behind_by\":{behind_by}}}'\n\
@@ -43,22 +36,13 @@ pub fn with_behind_by(pr_view_json: &str, pr_checks_json: Option<&str>, behind_b
 pub fn with_compare_error(pr_view_json: &str, pr_checks_json: Option<&str>) -> TestEnv {
     let (bin, home_tmp, repo) = setup_git_dirs("feat/my-feature");
 
-    let checks_block = match pr_checks_json {
-        Some(j) => format!("printf '%s' '{j}'\n"),
-        None => "printf 'unexpected pr checks call' >&2\nexit 1\n".to_string(),
-    };
-
-    let inner = pr_view_json.strip_prefix('{').unwrap_or(pr_view_json);
-    let pr_list_json = format!(r#"[{{"number":1,{inner}]"#);
+    let graphql_json = graphql_single(pr_view_json, pr_checks_json);
 
     let script = format!(
         "#!/bin/sh\n\
          case \"$*\" in\n\
-           *'pr list'*)\n\
-             printf '%s' '{pr_list_json}'\n\
-             ;;\n\
-           *'pr checks'*)\n\
-             {checks_block}\
+           *graphql*)\n\
+             printf '%s' '{graphql_json}'\n\
              ;;\n\
            *'api'*'compare'*)\n\
              printf 'API error' >&2\n\
@@ -79,21 +63,18 @@ pub fn with_compare_error(pr_view_json: &str, pr_checks_json: Option<&str>) -> T
     }
 }
 
-/// `gh pr list` / `gh pr checks` が成功するが compare API が
-/// exit 0 で不正な JSON を返すシナリオ（`GhCompare` パース失敗で `None`）
+/// graphql は成功するが compare API が exit 0 で不正な JSON を返すシナリオ
+/// （`GhCompare` パース失敗で `behind_by` は `None` → `SyncUnknown`）。
 pub fn with_invalid_compare_json(pr_view_json: &str, pr_checks_json: &str) -> TestEnv {
     let (bin, home_tmp, repo) = setup_git_dirs("feat/my-feature");
-    let inner = pr_view_json.strip_prefix('{').unwrap_or(pr_view_json);
-    let pr_list_json = format!(r#"[{{"number":1,{inner}]"#);
-    let checks_json = pr_checks_json.to_owned();
+
+    let graphql_json = graphql_single(pr_view_json, Some(pr_checks_json));
+
     let script = format!(
         "#!/bin/sh\n\
          case \"$*\" in\n\
-           *'pr list'*)\n\
-             printf '%s' '{pr_list_json}'\n\
-             ;;\n\
-           *'pr checks'*)\n\
-             printf '%s' '{checks_json}'\n\
+           *graphql*)\n\
+             printf '%s' '{graphql_json}'\n\
              ;;\n\
            *'api'*'compare'*)\n\
              printf 'not-valid-json'\n\

--- a/tests/e2e/prompt/ci_checks.rs
+++ b/tests/e2e/prompt/ci_checks.rs
@@ -21,7 +21,12 @@ const CANCEL_JSON: &str =
     r#"[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"CANCELLED"}]"#;
 const ACTION_REQUIRED_JSON: &str =
     r#"[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"ACTION_REQUIRED"}]"#;
-const FAIL_AND_ACTION_JSON: &str = r#"[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"FAILURE"},{"__typename":"CheckRun","status":"COMPLETED","conclusion":"ACTION_REQUIRED"}]"#;
+// 別 check（名前が異なる）。同名だと重複排除で 1 件に潰れるため name を分ける。
+const FAIL_AND_ACTION_JSON: &str = r#"[{"__typename":"CheckRun","name":"build","status":"COMPLETED","conclusion":"FAILURE"},{"__typename":"CheckRun","name":"lint","status":"COMPLETED","conclusion":"ACTION_REQUIRED"}]"#;
+
+// 同名 check の再実行: 古い FAILURE(早い startedAt) と新しい SUCCESS(遅い startedAt)。
+// gh `pr checks` 同様に最新 run のみ採用 → CI ブロックなしになるべき。
+const RERUN_RECOVERED_JSON: &str = r#"[{"__typename":"CheckRun","name":"build","status":"COMPLETED","conclusion":"FAILURE","startedAt":"2026-01-01T00:00:00Z"},{"__typename":"CheckRun","name":"build","status":"COMPLETED","conclusion":"SUCCESS","startedAt":"2026-01-01T01:00:00Z"}]"#;
 
 fn assert_prompt(env: &TestEnv, expected: &str) {
     let _daemon = DaemonHandle::start(env);
@@ -66,4 +71,14 @@ fn test_ci_check_prompt(#[case] pr_json: &str, #[case] checks_json: &str, #[case
 fn test_no_ci_checks_prompt(#[case] pr_json: &str, #[case] expected: &str) {
     let env = ci_checks_fixtures::with_no_ci_checks(pr_json);
     assert_prompt(&env, expected);
+}
+
+// ── 再実行 check の重複排除 ───────────────────────────────────────────────────
+
+/// 同名 check が失敗 → 再実行で成功した場合、`statusCheckRollup` には古い FAILURE も
+/// 残るが、最新 run（SUCCESS）のみを採用して CI ブロックしないこと（`gh pr checks` 相当）。
+#[test]
+fn test_rerun_recovered_check_is_not_blocked() {
+    let env = TestEnv::new(APPROVED_CLEAN, Some(RERUN_RECOVERED_JSON));
+    assert_prompt(&env, "✓ Ready for merge");
 }

--- a/tests/e2e/prompt/ci_checks.rs
+++ b/tests/e2e/prompt/ci_checks.rs
@@ -1,6 +1,6 @@
 //! CI チェックの E2E テスト（シナリオ #23–29）
 //!
-//! 対象条件: `ci_fail` / `ci_action`（`gh pr checks --json bucket,state` の結果）
+//! 対象条件: `ci_fail` / `ci_action`（graphql `statusCheckRollup.contexts` の集約結果）
 //! 実行フローは daemon 経由（`merge-ready prompt`）に統一する。
 
 use assert_cmd::Command;
@@ -14,10 +14,14 @@ const BLOCKED_NO_REVIEW: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"
 const BLOCKED_CHANGES_REQUESTED: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"BLOCKED","reviewDecision":"CHANGES_REQUESTED"}"#;
 const APPROVED_CLEAN: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED"}"#;
 
-const FAIL_JSON: &str = r#"[{"bucket":"fail","state":"FAILURE"}]"#;
-const CANCEL_JSON: &str = r#"[{"bucket":"cancel","state":"CANCELLED"}]"#;
-const ACTION_REQUIRED_JSON: &str = r#"[{"bucket":"action_required","state":"ACTION_REQUIRED"}]"#;
-const FAIL_AND_ACTION_JSON: &str = r#"[{"bucket":"fail","state":"FAILURE"},{"bucket":"action_required","state":"ACTION_REQUIRED"}]"#;
+// `statusCheckRollup.contexts.nodes`（gh の bucket は GraphQL では生の CheckRun へ移行）
+const FAIL_JSON: &str =
+    r#"[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"FAILURE"}]"#;
+const CANCEL_JSON: &str =
+    r#"[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"CANCELLED"}]"#;
+const ACTION_REQUIRED_JSON: &str =
+    r#"[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"ACTION_REQUIRED"}]"#;
+const FAIL_AND_ACTION_JSON: &str = r#"[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"FAILURE"},{"__typename":"CheckRun","status":"COMPLETED","conclusion":"ACTION_REQUIRED"}]"#;
 
 fn assert_prompt(env: &TestEnv, expected: &str) {
     let _daemon = DaemonHandle::start(env);

--- a/tests/e2e/prompt/ci_checks_fixtures.rs
+++ b/tests/e2e/prompt/ci_checks_fixtures.rs
@@ -1,21 +1,19 @@
-use super::super::helpers::{TestEnv, setup_git_dirs, write_executable};
+use super::super::helpers::{TestEnv, graphql_single, setup_git_dirs, write_executable};
 
-/// CI 未設定シナリオ: `gh pr checks` が `"no checks reported"` で `exit 1` を返す。
+/// CI 未設定シナリオ: `statusCheckRollup` が `null`（チェック未設定）の graphql 応答。
 pub fn with_no_ci_checks(pr_view_json: &str) -> TestEnv {
     let (bin, home_tmp, repo) = setup_git_dirs("feat/my-feature");
 
-    let inner = pr_view_json.strip_prefix('{').unwrap_or(pr_view_json);
-    let pr_list_json = format!(r#"[{{"number":1,{inner}]"#);
+    let graphql_json = graphql_single(pr_view_json, None);
 
     let script = format!(
         "#!/bin/sh\n\
          case \"$*\" in\n\
-           *'pr list'*)\n\
-             printf '%s' '{pr_list_json}'\n\
+           *graphql*)\n\
+             printf '%s' '{graphql_json}'\n\
              ;;\n\
-           *'pr checks'*)\n\
-             printf \"%s\" \"no checks reported on the 'test-branch' branch\" >&2\n\
-             exit 1\n\
+           *'api'*'compare'*)\n\
+             printf '{{\"behind_by\":0}}'\n\
              ;;\n\
            *)\n\
              printf 'unknown gh command: %s' \"$*\" >&2\n\

--- a/tests/e2e/prompt/errors.rs
+++ b/tests/e2e/prompt/errors.rs
@@ -105,10 +105,10 @@ fn test_error_log_written() {
 
 // ── JSON 解析失敗 ─────────────────────────────────────────────────────────────
 
-/// `gh pr list` が exit 0 で不正な JSON を返した場合 → `✗ unexpected error`
+/// `gh api graphql` が exit 0 で不正な JSON を返した場合 → `✗ unexpected error`
 #[test]
-fn test_pr_list_invalid_json_shows_unexpected_error() {
-    let env = errors_fixtures::with_invalid_pr_list_json();
+fn test_invalid_graphql_json_shows_unexpected_error() {
+    let env = errors_fixtures::with_invalid_graphql_json();
     let _daemon = DaemonHandle::start(&env);
     DaemonHandle::wait_for_cache(&env, 5000);
 
@@ -119,11 +119,11 @@ fn test_pr_list_invalid_json_shows_unexpected_error() {
         .stderr("");
 }
 
-/// `gh pr checks` が exit 0 で不正な JSON を返した場合 → `✗ unexpected error`
+/// graphql 応答の `statusCheckRollup` の型が壊れている場合 → `✗ unexpected error`
 #[test]
-fn test_pr_checks_invalid_json_shows_unexpected_error() {
+fn test_invalid_rollup_json_shows_unexpected_error() {
     const OPEN_PR: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"BLOCKED","reviewDecision":null,"baseRefName":"","headRefName":""}"#;
-    let env = errors_fixtures::with_invalid_pr_checks_json(OPEN_PR);
+    let env = errors_fixtures::with_invalid_rollup_json(OPEN_PR);
     let _daemon = DaemonHandle::start(&env);
     DaemonHandle::wait_for_cache(&env, 5000);
 

--- a/tests/e2e/prompt/errors_fixtures.rs
+++ b/tests/e2e/prompt/errors_fixtures.rs
@@ -1,4 +1,4 @@
-use super::super::helpers::{TestEnv, setup_git_dirs, write_executable};
+use super::super::helpers::{TestEnv, graphql_response, pr_node, setup_git_dirs, write_executable};
 
 /// `gh` バイナリが無期限にハングするシナリオ（タイムアウト検証用）
 pub fn with_hanging_gh() -> TestEnv {
@@ -11,12 +11,12 @@ pub fn with_hanging_gh() -> TestEnv {
     }
 }
 
-/// `gh pr list` が exit 0 で不正な JSON を返すシナリオ
-pub fn with_invalid_pr_list_json() -> TestEnv {
+/// `gh api graphql` が exit 0 で不正な JSON を返すシナリオ
+pub fn with_invalid_graphql_json() -> TestEnv {
     let (bin, home_tmp, repo) = setup_git_dirs("feat/my-feature");
     let script = "#!/bin/sh\n\
                   case \"$*\" in\n\
-                    *'pr list'*)\n\
+                    *graphql*)\n\
                       printf 'not-valid-json'\n\
                       ;;\n\
                     *)\n\
@@ -32,19 +32,21 @@ pub fn with_invalid_pr_list_json() -> TestEnv {
     }
 }
 
-/// `gh pr list` が成功するが `gh pr checks` が exit 0 で不正な JSON を返すシナリオ
-pub fn with_invalid_pr_checks_json(pr_view_json: &str) -> TestEnv {
+/// graphql 応答の封筒形状は正しいが `statusCheckRollup` の型が壊れているシナリオ。
+/// `GhPrNode` のデシリアライズが失敗し、`✗ unexpected error` になることを検証する。
+pub fn with_invalid_rollup_json(pr_view_json: &str) -> TestEnv {
     let (bin, home_tmp, repo) = setup_git_dirs("feat/my-feature");
-    let inner = pr_view_json.strip_prefix('{').unwrap_or(pr_view_json);
-    let pr_list_json = format!(r#"[{{"number":1,{inner}]"#);
+
+    // 妥当な PR ノードを作り、rollup をオブジェクト以外（文字列）に差し替えて壊す。
+    let mut node = pr_node(1, pr_view_json, None);
+    node["commits"]["nodes"][0]["commit"]["statusCheckRollup"] = serde_json::json!("not-an-object");
+    let graphql_json = graphql_response(&[node], "main");
+
     let script = format!(
         "#!/bin/sh\n\
          case \"$*\" in\n\
-           *'pr list'*)\n\
-             printf '%s' '{pr_list_json}'\n\
-             ;;\n\
-           *'pr checks'*)\n\
-             printf 'not-valid-json'\n\
+           *graphql*)\n\
+             printf '%s' '{graphql_json}'\n\
              ;;\n\
            *'api'*'compare'*)\n\
              printf '{{\"behind_by\":0}}'\n\

--- a/tests/e2e/prompt/merge_ready.rs
+++ b/tests/e2e/prompt/merge_ready.rs
@@ -31,7 +31,7 @@ fn assert_prompt(env: &TestEnv, expected: &str) {
 fn test_merge_ready() {
     let env = TestEnv::new(
         r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED"}"#,
-        Some(r#"[{"bucket":"pass","state":"SUCCESS"}]"#),
+        Some(r#"[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]"#),
     );
     assert_prompt(&env, "✓ Ready for merge");
 }
@@ -43,7 +43,7 @@ fn test_merge_ready() {
 fn test_all_conditions_block_merge_ready() {
     let env = TestEnv::new(
         r#"{"state":"OPEN","isDraft":false,"mergeable":"CONFLICTING","mergeStateStatus":"DIRTY","reviewDecision":"CHANGES_REQUESTED"}"#,
-        Some(r#"[{"bucket":"fail","state":"FAILURE"}]"#),
+        Some(r#"[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"FAILURE"}]"#),
     );
     assert_prompt(&env, "✗ Resolve conflict ✗ Fix CI failure ⚠ Resolve review");
 }

--- a/tests/e2e/prompt/review.rs
+++ b/tests/e2e/prompt/review.rs
@@ -16,7 +16,7 @@ use super::super::helpers::{DaemonHandle, TestEnv};
 fn test_review_changes_requested() {
     let env = TestEnv::new(
         r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"BLOCKED","reviewDecision":"CHANGES_REQUESTED"}"#,
-        Some(r#"[{"bucket":"pass","state":"SUCCESS"}]"#),
+        Some(r#"[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]"#),
     );
     let _daemon = DaemonHandle::start(&env);
     DaemonHandle::wait_for_cache(&env, 5000);
@@ -31,7 +31,7 @@ fn test_review_changes_requested() {
 fn test_review_required() {
     let env = TestEnv::new(
         r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"BLOCKED","reviewDecision":"REVIEW_REQUIRED"}"#,
-        Some(r#"[{"bucket":"pass","state":"SUCCESS"}]"#),
+        Some(r#"[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]"#),
     );
     let _daemon = DaemonHandle::start(&env);
     DaemonHandle::wait_for_cache(&env, 5000);

--- a/tests/e2e/prompt/style.rs
+++ b/tests/e2e/prompt/style.rs
@@ -2,7 +2,8 @@
 
 const PROMPT_BIN: &str = "merge-ready-prompt";
 const MERGE_READY_JSON: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED"}"#;
-const CHECKS_PASS_JSON: &str = r#"[{"bucket":"pass","state":"SUCCESS"}]"#;
+const CHECKS_PASS_JSON: &str =
+    r#"[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]"#;
 
 use assert_cmd::Command;
 use predicates::prelude::*;

--- a/tests/e2e/scenarios/cache_hit.rs
+++ b/tests/e2e/scenarios/cache_hit.rs
@@ -9,7 +9,8 @@ use super::super::helpers::{DaemonHandle, TestEnv};
 
 const PROMPT_BIN: &str = "merge-ready-prompt";
 const OPEN_PR_VIEW_JSON: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}"#;
-const CI_PASS_JSON: &str = r#"[{"bucket":"pass","state":"SUCCESS","name":"ci","link":""}]"#;
+const CI_PASS_JSON: &str =
+    r#"[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]"#;
 
 /// daemon 起動 → キャッシュ温まる → 壊れた gh でも daemon キャッシュからヒット
 #[test]

--- a/tests/e2e/scenarios/cold_mode.rs
+++ b/tests/e2e/scenarios/cold_mode.rs
@@ -61,9 +61,11 @@ fn test_cold_interval_switches_from_early_to_late() {
     // hot_recent_query_secs=0 なので wait_for_cache 直後も has_recent_query=false
     std::thread::sleep(std::time::Duration::from_secs(2));
 
+    // refresh あたり graphql 1 回（CLEAN PR は compare スキップ）。
+    // 初回フェッチ(1) + cold-early refresh(1) = 2 で「cold-early が 1 回以上」を満たす。
     let calls_after_early = std::fs::read_to_string(&log_path).unwrap_or_default().len();
     assert!(
-        calls_after_early >= 3,
+        calls_after_early >= 2,
         "should have at least 1 cold-early refresh after initial fetch (calls: {calls_after_early})"
     );
 

--- a/tests/e2e/scenarios/cold_mode_fixtures.rs
+++ b/tests/e2e/scenarios/cold_mode_fixtures.rs
@@ -1,7 +1,8 @@
 use std::path::PathBuf;
 
 use super::super::helpers::{
-    FAKE_GH_RATE_LIMIT_OK_SNIPPET, TestEnv, setup_git_dirs, write_executable,
+    FAKE_GH_RATE_LIMIT_OK_SNIPPET, ROLLUP_PASS, TestEnv, graphql_single, setup_git_dirs,
+    write_executable,
 };
 
 /// Warm (CLEAN) PR + gh 呼び出しカウントログ付き fixture。
@@ -11,18 +12,17 @@ pub fn with_warm_pr_call_log() -> (TestEnv, PathBuf) {
     let (bin, home_tmp, repo) = setup_git_dirs("feat/my-feature");
     let log_path = home_tmp.path().join("gh_calls.log");
     let log = log_path.display().to_string();
-    let pr_list_json = r#"[{"number":1,"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}]"#;
-    let checks_json = r#"[{"bucket":"pass","state":"SUCCESS","name":"ci","link":""}]"#;
+    let graphql_json = graphql_single(
+        r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}"#,
+        Some(ROLLUP_PASS),
+    );
     let script = format!(
         "#!/bin/sh\n\
          {FAKE_GH_RATE_LIMIT_OK_SNIPPET}\
          printf '1' >> \"{log}\"\n\
          case \"$*\" in\n\
-           *'pr list'*)\n\
-             printf '%s' '{pr_list_json}'\n\
-             ;;\n\
-           *'pr checks'*)\n\
-             printf '%s' '{checks_json}'\n\
+           *graphql*)\n\
+             printf '%s' '{graphql_json}'\n\
              ;;\n\
            *'api'*'compare'*)\n\
              printf '{{\"behind_by\":0}}'\n\

--- a/tests/e2e/scenarios/default_branch_fixtures.rs
+++ b/tests/e2e/scenarios/default_branch_fixtures.rs
@@ -1,23 +1,20 @@
 use super::super::helpers::{
-    FAKE_GH_RATE_LIMIT_OK_SNIPPET, TestEnv, setup_git_dirs, write_executable,
+    FAKE_GH_RATE_LIMIT_OK_SNIPPET, TestEnv, graphql_response, setup_git_dirs, write_executable,
 };
 
 /// デフォルトブランチ上シナリオ: 現在ブランチ == デフォルトブランチ、PR なし。
 ///
 /// `branch` に "main" または "master" などを指定する。
-/// `gh pr list` → 空配列 `[]` を返す
-/// `gh repo view --json defaultBranchRef` → `branch` をデフォルトブランチとして返す
+/// graphql 応答は空 `nodes` + `defaultBranchRef.name = branch` を返す。
 pub fn with_default_branch_no_pr(branch: &str) -> TestEnv {
     let (bin, home_tmp, repo) = setup_git_dirs(branch);
+    let graphql_json = graphql_response(&[], branch);
     let script = format!(
         "#!/bin/sh\n\
          {FAKE_GH_RATE_LIMIT_OK_SNIPPET}\
          case \"$*\" in\n\
-           *'pr list'*)\n\
-             printf '[]'\n\
-             ;;\n\
-           *'repo view'*'defaultBranchRef'*)\n\
-             printf '{{\"defaultBranchRef\":{{\"name\":\"{branch}\"}}}}'\n\
+           *graphql*)\n\
+             printf '%s' '{graphql_json}'\n\
              ;;\n\
            *)\n\
              printf 'unknown gh command: %s' \"$*\" >&2\n\

--- a/tests/e2e/scenarios/entry_expiry.rs
+++ b/tests/e2e/scenarios/entry_expiry.rs
@@ -11,7 +11,8 @@ use predicates::prelude::*;
 use super::super::helpers::{DaemonHandle, TestEnv};
 
 const OPEN_PR_VIEW_JSON: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}"#;
-const CI_PASS_JSON: &str = r#"[{"bucket":"pass","state":"SUCCESS","name":"ci","link":""}]"#;
+const CI_PASS_JSON: &str =
+    r#"[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]"#;
 
 /// #C: クエリが途絶えた後に `entry_max_age_secs` が経過するとエントリが削除される
 #[test]

--- a/tests/e2e/scenarios/initial_load.rs
+++ b/tests/e2e/scenarios/initial_load.rs
@@ -9,7 +9,8 @@ use super::super::helpers::{DaemonHandle, TestEnv};
 
 const PROMPT_BIN: &str = "merge-ready-prompt";
 const OPEN_PR_VIEW_JSON: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}"#;
-const CI_PASS_JSON: &str = r#"[{"bucket":"pass","state":"SUCCESS","name":"ci","link":""}]"#;
+const CI_PASS_JSON: &str =
+    r#"[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]"#;
 
 /// daemon 未起動 → `? loading`（daemon を自動起動）→ キャッシュ温まる → 結果表示
 #[test]

--- a/tests/e2e/scenarios/no_pr_fixtures.rs
+++ b/tests/e2e/scenarios/no_pr_fixtures.rs
@@ -1,5 +1,5 @@
 use super::super::helpers::{
-    FAKE_GH_RATE_LIMIT_OK_SNIPPET, TestEnv, setup_git_dirs, write_executable,
+    FAKE_GH_RATE_LIMIT_OK_SNIPPET, TestEnv, graphql_response, setup_git_dirs, write_executable,
 };
 
 /// PR なしシナリオ（遅延付き）: stale refresh 中の挙動を再現するため、初回呼び出しは即座に返し、
@@ -10,21 +10,20 @@ pub fn with_no_pr_stale_delay_ms(delay_ms: u64) -> TestEnv {
     let millis = delay_ms % 1000;
     let sleep_arg = format!("{secs}.{millis:03}");
     let count_path = home_tmp.path().join(".gh_call_count").display().to_string();
+    // 空 nodes + defaultBranchRef=main（現在ブランチは feat/my-feature → NoPullRequest）。
+    let graphql_json = graphql_response(&[], "main");
     let script = format!(
         "#!/bin/sh\n\
          {FAKE_GH_RATE_LIMIT_OK_SNIPPET}\
          case \"$*\" in\n\
-           *'pr list'*)\n\
+           *graphql*)\n\
              count=$(cat \"{count_path}\" 2>/dev/null || printf '0')\n\
              count=$((count + 1))\n\
              printf '%d' \"$count\" > \"{count_path}\"\n\
              if [ \"$count\" -gt 1 ]; then\n\
                  sleep {sleep_arg}\n\
              fi\n\
-             printf '[]'\n\
-             ;;\n\
-           *'repo view'*'defaultBranchRef'*)\n\
-             printf '{{\"defaultBranchRef\":{{\"name\":\"main\"}}}}'\n\
+             printf '%s' '{graphql_json}'\n\
              ;;\n\
            *)\n\
              printf 'unknown gh command: %s' \"$*\" >&2\n\

--- a/tests/e2e/scenarios/rate_limit_aware_fixtures.rs
+++ b/tests/e2e/scenarios/rate_limit_aware_fixtures.rs
@@ -1,12 +1,14 @@
 //! `rate_limit` aware シナリオ用 `fixture`。
 //!
-//! fake `gh` は `pr list` / `pr checks` / `api compare` / `api rate_limit` を
-//! それぞれ別の counter ファイルにカウントする。`api rate_limit` のレスポンスは
-//! `remaining_bp`（0..=10000）に応じた残量を返す。
+//! fake `gh` は `graphql`（refresh 本体）/ `api compare` / `api rate_limit` を扱う。
+//! `pr_list_log` は refresh あたり 1 回の `graphql` 呼び出しをカウントする。
+//! `api rate_limit` のレスポンスは `remaining_bp`（0..=10000）に応じた残量を返す。
 
 use std::path::PathBuf;
 
-use super::super::helpers::{TestEnv, setup_git_dirs, write_executable};
+use super::super::helpers::{
+    ROLLUP_PASS, TestEnv, graphql_single, setup_git_dirs, write_executable,
+};
 
 pub struct RateLimitFixture {
     pub env: TestEnv,
@@ -31,8 +33,10 @@ pub fn with_rate_limit_response(remaining_bp: u32, reset_offset_secs: u64) -> Ra
         .try_into()
         .unwrap_or(0);
 
-    let pr_list_json = r#"[{"number":1,"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}]"#;
-    let checks_json = r#"[{"bucket":"pass","state":"SUCCESS","name":"ci","link":""}]"#;
+    let graphql_json = graphql_single(
+        r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}"#,
+        Some(ROLLUP_PASS),
+    );
 
     // reset は absolute unix epoch を渡したいので、シェルスクリプト内で date を呼ぶ
     let script = format!(
@@ -45,12 +49,9 @@ pub fn with_rate_limit_response(remaining_bp: u32, reset_offset_secs: u64) -> Ra
              printf '{{\"resources\":{{\"core\":{{\"limit\":{limit},\"remaining\":{remaining},\"reset\":%d}},\"graphql\":{{\"limit\":{limit},\"remaining\":{remaining},\"reset\":%d}}}}}}' \"$reset\" \"$reset\"\n\
              exit 0\n\
              ;;\n\
-           *'pr list'*)\n\
+           *graphql*)\n\
              printf '1' >> \"{pr_list_log_s}\"\n\
-             printf '%s' '{pr_list_json}'\n\
-             ;;\n\
-           *'pr checks'*)\n\
-             printf '%s' '{checks_json}'\n\
+             printf '%s' '{graphql_json}'\n\
              ;;\n\
            *'api'*'compare'*)\n\
              printf '{{\"behind_by\":0}}'\n\
@@ -88,8 +89,10 @@ pub fn with_rate_limit_exhaust_then_recover(reset_offset_secs_first: u64) -> Rat
     let rate_limit_counter_s = rate_limit_counter.display().to_string();
 
     let limit: u32 = 5_000;
-    let pr_list_json = r#"[{"number":1,"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}]"#;
-    let checks_json = r#"[{"bucket":"pass","state":"SUCCESS","name":"ci","link":""}]"#;
+    let graphql_json = graphql_single(
+        r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}"#,
+        Some(ROLLUP_PASS),
+    );
 
     let script = format!(
         "#!/bin/sh\n\
@@ -110,12 +113,9 @@ pub fn with_rate_limit_exhaust_then_recover(reset_offset_secs_first: u64) -> Rat
              printf '{{\"resources\":{{\"core\":{{\"limit\":{limit},\"remaining\":%d,\"reset\":%d}},\"graphql\":{{\"limit\":{limit},\"remaining\":%d,\"reset\":%d}}}}}}' \"$remaining\" \"$reset\" \"$remaining\" \"$reset\"\n\
              exit 0\n\
              ;;\n\
-           *'pr list'*)\n\
+           *graphql*)\n\
              printf '1' >> \"{pr_list_log_s}\"\n\
-             printf '%s' '{pr_list_json}'\n\
-             ;;\n\
-           *'pr checks'*)\n\
-             printf '%s' '{checks_json}'\n\
+             printf '%s' '{graphql_json}'\n\
              ;;\n\
            *'api'*'compare'*)\n\
              printf '{{\"behind_by\":0}}'\n\

--- a/tests/e2e/scenarios/refresh_interval_fixtures.rs
+++ b/tests/e2e/scenarios/refresh_interval_fixtures.rs
@@ -1,7 +1,8 @@
 use std::path::PathBuf;
 
 use super::super::helpers::{
-    FAKE_GH_RATE_LIMIT_OK_SNIPPET, TestEnv, setup_git_dirs, write_executable,
+    FAKE_GH_RATE_LIMIT_OK_SNIPPET, ROLLUP_PASS, TestEnv, graphql_single, setup_git_dirs,
+    write_executable,
 };
 
 /// `mergeStateStatus="UNKNOWN"` → `State::Calculating` → `CacheHint::Hot` の PR。
@@ -10,14 +11,20 @@ pub fn with_calculating_pr_call_log() -> (TestEnv, PathBuf) {
     let (bin, home_tmp, repo) = setup_git_dirs("feat/my-feature");
     let log_path = home_tmp.path().join("gh_calls.log");
     let log = log_path.display().to_string();
-    let pr_list_json = r#"[{"number":1,"state":"OPEN","isDraft":false,"mergeable":"UNKNOWN","mergeStateStatus":"UNKNOWN","reviewDecision":null}]"#;
+    let graphql_json = graphql_single(
+        r#"{"state":"OPEN","isDraft":false,"mergeable":"UNKNOWN","mergeStateStatus":"UNKNOWN","reviewDecision":null}"#,
+        None,
+    );
     let script = format!(
         "#!/bin/sh\n\
          {FAKE_GH_RATE_LIMIT_OK_SNIPPET}\
          printf '1' >> \"{log}\"\n\
          case \"$*\" in\n\
-           *'pr list'*)\n\
-             printf '%s' '{pr_list_json}'\n\
+           *graphql*)\n\
+             printf '%s' '{graphql_json}'\n\
+             ;;\n\
+           *'api'*'compare'*)\n\
+             printf '{{\"behind_by\":0}}'\n\
              ;;\n\
            *)\n\
              printf 'unexpected gh call: %s' \"$*\" >&2\n\
@@ -42,18 +49,17 @@ pub fn with_warm_pr_call_log() -> (TestEnv, PathBuf) {
     let (bin, home_tmp, repo) = setup_git_dirs("feat/my-feature");
     let log_path = home_tmp.path().join("gh_calls.log");
     let log = log_path.display().to_string();
-    let pr_list_json = r#"[{"number":1,"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}]"#;
-    let checks_json = r#"[{"bucket":"pass","state":"SUCCESS","name":"ci","link":""}]"#;
+    let graphql_json = graphql_single(
+        r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}"#,
+        Some(ROLLUP_PASS),
+    );
     let script = format!(
         "#!/bin/sh\n\
          {FAKE_GH_RATE_LIMIT_OK_SNIPPET}\
          printf '1' >> \"{log}\"\n\
          case \"$*\" in\n\
-           *'pr list'*)\n\
-             printf '%s' '{pr_list_json}'\n\
-             ;;\n\
-           *'pr checks'*)\n\
-             printf '%s' '{checks_json}'\n\
+           *graphql*)\n\
+             printf '%s' '{graphql_json}'\n\
              ;;\n\
            *'api'*'compare'*)\n\
              printf '{{\"behind_by\":0}}'\n\

--- a/tests/e2e/scenarios/refresh_timeout.rs
+++ b/tests/e2e/scenarios/refresh_timeout.rs
@@ -6,10 +6,10 @@
 use super::super::helpers::DaemonHandle;
 use super::refresh_timeout_fixtures;
 
-/// #I: 遅い gh (2 回目 pr list) → ロック期限切れ → `clear_refresh_lock` → リトライ → データ取得成功
+/// #I: 遅い gh (2 回目 graphql) → ロック期限切れ → `clear_refresh_lock` → リトライ → データ取得成功
 #[test]
 fn test_refresh_timeout_clears_lock_and_allows_retry() {
-    let (env, log_path) = refresh_timeout_fixtures::with_slow_second_pr_list();
+    let (env, log_path) = refresh_timeout_fixtures::with_slow_second_graphql();
     let _daemon = DaemonHandle::start_with_env(
         &env,
         &[
@@ -23,19 +23,19 @@ fn test_refresh_timeout_clears_lock_and_allows_retry() {
         ],
     );
 
-    // 初回 pr list は即時応答 → CacheEntry に output が入り is_active()=true になる。
+    // 初回 graphql は即時応答 → CacheEntry に output が入り is_active()=true になる。
     DaemonHandle::wait_for_cache(&env, 15000);
 
-    // 初回フェッチ完了後:
-    //   T+~1s: スケジューラが 2 回目リフレッシュをスケジュール → pr list #2 が 2s sleep 開始
+    // 初回フェッチ完了後（CLEAN PR のため refresh あたり graphql 1 回・compare はスキップ）:
+    //   T+~1s: スケジューラが 2 回目リフレッシュをスケジュール → graphql #2 が 2s sleep 開始
     //   T+~2s: refresh_lock_timeout=1s を超えると clear_refresh_lock 呼び出し
-    //   T+~3s: スケジューラがリトライ → pr list #3 が即時応答
+    //   T+~3s: スケジューラがリトライ → graphql #3 が即時応答
     std::thread::sleep(std::time::Duration::from_secs(3));
 
     let calls = std::fs::read_to_string(&log_path).unwrap_or_default().len();
     assert!(
-        calls >= 4,
-        "should have at least 4 gh calls: initial 3 (pr list + checks + compare) \
-         + slow pr list #2 logged before sleep (calls: {calls})"
+        calls >= 3,
+        "should have at least 3 gh calls: initial graphql #1 \
+         + slow graphql #2 (logged before sleep) + retry graphql #3 (calls: {calls})"
     );
 }

--- a/tests/e2e/scenarios/refresh_timeout_fixtures.rs
+++ b/tests/e2e/scenarios/refresh_timeout_fixtures.rs
@@ -1,44 +1,44 @@
 use std::path::PathBuf;
 
 use super::super::helpers::{
-    FAKE_GH_RATE_LIMIT_OK_SNIPPET, TestEnv, setup_git_dirs, write_executable,
+    FAKE_GH_RATE_LIMIT_OK_SNIPPET, ROLLUP_PASS, TestEnv, graphql_single, setup_git_dirs,
+    write_executable,
 };
 
-/// 初回 pr list は即時応答し、2 回目の pr list は 2 秒 sleep してから応答する fixture。
+/// 初回 graphql は即時応答し、2 回目の graphql は 2 秒 sleep してから応答する fixture。
 ///
 /// `clear_refresh_lock` のシナリオ用。
-/// - 初回フェッチ (pr list #1) が素早く完了 → `CacheEntry` に output が入り `is_active()=true` になる。
-/// - スケジューラが次のリフレッシュをスケジュール → pr list #2 がスロー (2s sleep)。
+/// - 初回フェッチ (graphql #1) が素早く完了 → `CacheEntry` に output が入り `is_active()=true` になる。
+/// - スケジューラが次のリフレッシュをスケジュール → graphql #2 がスロー (2s sleep)。
 /// - `refresh_lock_timeout=1s` を超えると `clear_refresh_lock` が呼ばれ、スケジューラがリトライ。
-/// - pr list #3 以降は即時応答 → リトライ成功。
+/// - graphql #3 以降は即時応答 → リトライ成功。
 ///
-/// カウンタファイルは `pr list` 呼び出し専用。`home_tmp` 配下に置く。
-pub fn with_slow_second_pr_list() -> (TestEnv, PathBuf) {
+/// カウンタファイルは graphql 呼び出し専用。`home_tmp` 配下に置く。
+pub fn with_slow_second_graphql() -> (TestEnv, PathBuf) {
     let (bin, home_tmp, repo) = setup_git_dirs("feat/my-feature");
     let log_path = home_tmp.path().join("gh_calls.log");
     let log = log_path.display().to_string();
-    let pr_list_counter_path = home_tmp.path().join("pr_list_counter");
-    let pr_list_counter = pr_list_counter_path.display().to_string();
+    let graphql_counter_path = home_tmp.path().join("graphql_counter");
+    let graphql_counter = graphql_counter_path.display().to_string();
 
-    let pr_list_json = r#"[{"number":1,"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}]"#;
-    let checks_json = r#"[{"bucket":"pass","state":"SUCCESS","name":"ci","link":""}]"#;
+    let graphql_json = graphql_single(
+        r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}"#,
+        Some(ROLLUP_PASS),
+    );
 
     let script = format!(
         "#!/bin/sh\n\
          {FAKE_GH_RATE_LIMIT_OK_SNIPPET}\
          printf '1' >> \"{log}\"\n\
          case \"$*\" in\n\
-           *'pr list'*)\n\
-             pl=$(cat \"{pr_list_counter}\" 2>/dev/null || printf '0')\n\
-             pl=$((pl + 1))\n\
-             printf '%d' \"$pl\" > \"{pr_list_counter}\"\n\
-             if [ \"$pl\" -eq 2 ]; then\n\
+           *graphql*)\n\
+             gq=$(cat \"{graphql_counter}\" 2>/dev/null || printf '0')\n\
+             gq=$((gq + 1))\n\
+             printf '%d' \"$gq\" > \"{graphql_counter}\"\n\
+             if [ \"$gq\" -eq 2 ]; then\n\
                sleep 2\n\
              fi\n\
-             printf '%s' '{pr_list_json}'\n\
-             ;;\n\
-           *'pr checks'*)\n\
-             printf '%s' '{checks_json}'\n\
+             printf '%s' '{graphql_json}'\n\
              ;;\n\
            *'api'*'compare'*)\n\
              printf '{{\"behind_by\":0}}'\n\

--- a/tests/e2e/scenarios/stale.rs
+++ b/tests/e2e/scenarios/stale.rs
@@ -10,7 +10,8 @@ use predicates::prelude::*;
 use super::super::helpers::{DaemonHandle, TestEnv};
 
 const OPEN_PR_VIEW_JSON: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}"#;
-const CI_PASS_JSON: &str = r#"[{"bucket":"pass","state":"SUCCESS","name":"ci","link":""}]"#;
+const CI_PASS_JSON: &str =
+    r#"[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]"#;
 
 /// TTL=0 で起動した daemon → stale でも値を返す（`? loading` に戻らない）
 #[test]

--- a/tests/e2e/scenarios/sub_repo.rs
+++ b/tests/e2e/scenarios/sub_repo.rs
@@ -12,7 +12,8 @@ use super::super::helpers::{DaemonHandle, TestEnv};
 
 const PROMPT_BIN: &str = "merge-ready-prompt";
 const OPEN_PR_VIEW_JSON: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}"#;
-const CI_PASS_JSON: &str = r#"[{"bucket":"pass","state":"SUCCESS","name":"ci","link":""}]"#;
+const CI_PASS_JSON: &str =
+    r#"[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]"#;
 
 /// サブディレクトリから実行したとき walk-up で `.git` を検出して通常動作する
 #[test]

--- a/tests/e2e/scenarios/terminal_pr_fixtures.rs
+++ b/tests/e2e/scenarios/terminal_pr_fixtures.rs
@@ -1,24 +1,26 @@
 use super::super::helpers::{
-    FAKE_GH_RATE_LIMIT_OK_SNIPPET, TestEnv, setup_git_dirs, write_executable,
+    FAKE_GH_RATE_LIMIT_OK_SNIPPET, TestEnv, graphql_single, setup_git_dirs, write_executable,
 };
 
 /// terminal PR シナリオ（呼び出しカウンタ付き）
 ///
-/// `gh pr list` が closed / merged JSON を返す。カウンタログファイルのパスを返す。
+/// graphql 応答が closed / merged PR を返す。カウンタログファイルのパスを返す。
 pub fn with_terminal_pr_call_log(state: &str) -> (TestEnv, std::path::PathBuf) {
     let (bin, home_tmp, repo) = setup_git_dirs("feat/my-feature");
     let log_path = home_tmp.path().join("gh_calls.log");
     let log = log_path.display().to_string();
-    let pr_list_json = format!(
-        r#"[{{"number":1,"state":"{state}","isDraft":false,"mergeable":"UNKNOWN","mergeStateStatus":"UNKNOWN","reviewDecision":null}}]"#
+    let fragment = format!(
+        r#"{{"state":"{state}","isDraft":false,"mergeable":"UNKNOWN","mergeStateStatus":"UNKNOWN","reviewDecision":null}}"#
     );
+    // closed / merged は OPEN フィルタで除外され CI 評価されないため rollup は null。
+    let graphql_json = graphql_single(&fragment, None);
     let script = format!(
         "#!/bin/sh\n\
          {FAKE_GH_RATE_LIMIT_OK_SNIPPET}\
          printf '1' >> \"{log}\"\n\
          case \"$*\" in\n\
-           *'pr list'*)\n\
-             printf '%s' '{pr_list_json}'\n\
+           *graphql*)\n\
+             printf '%s' '{graphql_json}'\n\
              ;;\n\
            *)\n\
              printf 'unexpected gh call: %s' \"$*\" >&2\n\

--- a/tests/e2e/scenarios/terminal_reopen_fixtures.rs
+++ b/tests/e2e/scenarios/terminal_reopen_fixtures.rs
@@ -1,26 +1,32 @@
 use super::super::helpers::{
-    FAKE_GH_RATE_LIMIT_OK_SNIPPET, TestEnv, setup_git_dirs, write_executable,
+    FAKE_GH_RATE_LIMIT_OK_SNIPPET, ROLLUP_PASS, TestEnv, graphql_single, setup_git_dirs,
+    write_executable,
 };
 
-/// 1 回目の `pr list` 呼び出しは MERGED、2 回目以降は OPEN+CLEAN を返す stateful fixture。
+/// 1 回目の graphql 呼び出しは MERGED、2 回目以降は OPEN+CLEAN を返す stateful fixture。
 ///
 /// カウンタファイルを `home_tmp` 配下に置き並列実行に対応する。
 /// `api rate_limit` 呼び出しはカウンタを進めず静的に応答する（daemon の定期取得が
-/// pr list カウンタを汚染しないようにするため）。
+/// graphql カウンタを汚染しないようにするため）。
 pub fn with_reopened_pr() -> TestEnv {
     let (bin, home_tmp, repo) = setup_git_dirs("feat/my-feature");
     let counter_path = home_tmp.path().join("pr_list_counter");
     let counter = counter_path.display().to_string();
 
-    let merged_json = r#"[{"number":1,"state":"MERGED","isDraft":false,"mergeable":"UNKNOWN","mergeStateStatus":"UNKNOWN","reviewDecision":null}]"#;
-    let open_json = r#"[{"number":1,"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}]"#;
-    let checks_json = r#"[{"bucket":"pass","state":"SUCCESS","name":"ci","link":""}]"#;
+    let merged_json = graphql_single(
+        r#"{"state":"MERGED","isDraft":false,"mergeable":"UNKNOWN","mergeStateStatus":"UNKNOWN","reviewDecision":null}"#,
+        None,
+    );
+    let open_json = graphql_single(
+        r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}"#,
+        Some(ROLLUP_PASS),
+    );
 
     let script = format!(
         "#!/bin/sh\n\
          {FAKE_GH_RATE_LIMIT_OK_SNIPPET}\
          case \"$*\" in\n\
-           *'pr list'*)\n\
+           *graphql*)\n\
              count=$(cat \"{counter}\" 2>/dev/null || printf '0')\n\
              count=$((count + 1))\n\
              printf '%d' \"$count\" > \"{counter}\"\n\
@@ -29,9 +35,6 @@ pub fn with_reopened_pr() -> TestEnv {
              else\n\
                printf '%s' '{open_json}'\n\
              fi\n\
-             ;;\n\
-           *'pr checks'*)\n\
-             printf '%s' '{checks_json}'\n\
              ;;\n\
            *'api'*'compare'*)\n\
              printf '{{\"behind_by\":0}}'\n\

--- a/tests/e2e/scenarios/warm_interval_fixtures.rs
+++ b/tests/e2e/scenarios/warm_interval_fixtures.rs
@@ -1,7 +1,8 @@
 use std::path::PathBuf;
 
 use super::super::helpers::{
-    FAKE_GH_RATE_LIMIT_OK_SNIPPET, TestEnv, setup_git_dirs, write_executable,
+    FAKE_GH_RATE_LIMIT_OK_SNIPPET, ROLLUP_PASS, TestEnv, graphql_single, setup_git_dirs,
+    write_executable,
 };
 
 /// Warm (CLEAN) PR + gh 呼び出しカウントログ付き fixture。
@@ -11,18 +12,17 @@ pub fn with_warm_pr_call_log() -> (TestEnv, PathBuf) {
     let (bin, home_tmp, repo) = setup_git_dirs("feat/my-feature");
     let log_path = home_tmp.path().join("gh_calls.log");
     let log = log_path.display().to_string();
-    let pr_list_json = r#"[{"number":1,"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}]"#;
-    let checks_json = r#"[{"bucket":"pass","state":"SUCCESS","name":"ci","link":""}]"#;
+    let graphql_json = graphql_single(
+        r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}"#,
+        Some(ROLLUP_PASS),
+    );
     let script = format!(
         "#!/bin/sh\n\
          {FAKE_GH_RATE_LIMIT_OK_SNIPPET}\
          printf '1' >> \"{log}\"\n\
          case \"$*\" in\n\
-           *'pr list'*)\n\
-             printf '%s' '{pr_list_json}'\n\
-             ;;\n\
-           *'pr checks'*)\n\
-             printf '%s' '{checks_json}'\n\
+           *graphql*)\n\
+             printf '%s' '{graphql_json}'\n\
              ;;\n\
            *'api'*'compare'*)\n\
              printf '{{\"behind_by\":0}}'\n\


### PR DESCRIPTION
## 概要

`fetch_prompt`（`src/contexts/evaluation/infrastructure/gh.rs`）の PR メタ取得・CI チェック・デフォルトブランチ判定を **`gh api graphql` 単一クエリ**へ集約し、`gh pr list` / `gh pr checks` / `gh repo view` を撤廃する。refresh あたりの `gh` サブプロセス起動数を `2N+1` → **`N+1`**（GraphQL 1 + branch sync の compare N）に削減する。

> **到達点について**: Issue タイトルは `3N+1 → 1` だが、branch sync の `behind_by` は GitHub GraphQL に対応フィールドが無いため、現行どおり PR ごとに REST `gh api .../compare/...` を併用する方針を選択した（ステータス判定を維持するため）。結果は `N+1`。

Closes #360

## 変更内容

- **取得**: `fetch_repository` が単一 graphql で PR メタ + CI(`statusCheckRollup`) + `defaultBranchRef` を取得。`{owner}`/`{repo}` は gh の `-F` placeholder、branch 名は `-f head=` で渡す。
- **CI 写像**: `statusCheckRollup.contexts` を gh の bucket 判定へ写像する `context_to_bucket` を新設し、`aggregate_ci` をそのまま消費（写像の unit テスト付き）。
- **CI 重複排除**: 再実行された check は rollup に古い run も残るため、`gh pr checks` 同様に名前ごとに最新 run（`startedAt`/`createdAt` 最大）のみを採用（後述の検証で判明・修正）。
- **ドメイン温存**: `evaluate` / `translate_sync` / `translate_review` / `translate_unblocked` は無変更。
- **branch sync**: REST compare 併用を維持（`translate_sync` で `behind_by>0→UpdateBranch` / 失敗→`SyncUnknown`）。
- **コストモデル**: `total_refresh_cost`（`transition.rs`）の係数を `2*pr_count+1` → `pr_count+1` に追従（#367 の継続）。
- **E2E**: fake gh を `graphql + compare` 応答へ全面移行。CI テストデータを rollup contexts 形式へ更新（**ステータス出力は不変**）。

## データ取得元の変更（出力トークン別・フィールドパス詳細）

凡例: `node` = `data.repository.pullRequests.nodes[]`（PR 1 件）、`rollup` = `node.commits.nodes[0].commit.statusCheckRollup.contexts.nodes[]`（各 check）。旧 `gh pr list` の `[]` は PR 配列の各要素、`gh pr checks` の `[]` は check 配列の各要素。

| 出力トークン | 修正前の取得元（コマンド → フィールドパス → 条件） | 修正後の取得元（GraphQL パス → 条件） |
|---|---|---|
| `✓ Ready for merge` | `gh pr list` → `[].isDraft`(=false) + `[].mergeStateStatus`(∈CLEAN/HAS_HOOKS) | `node.isDraft` + `node.mergeStateStatus` |
| `✎ Ready for review` | `gh pr list` → `[].isDraft`(=true) | `node.isDraft` |
| `✗ Resolve conflict` | `gh pr list` → `[].mergeable`(=CONFLICTING) | `node.mergeable` |
| `⚠ Resolve review` | `gh pr list` → `[].reviewDecision`(=CHANGES_REQUESTED) | `node.reviewDecision` |
| `@ Assign reviewer` | `gh pr list` → `[].reviewDecision`(=REVIEW_REQUIRED) | `node.reviewDecision` |
| `⧖ Wait for status` | `gh pr list` → `[].mergeStateStatus`(∈UNKNOWN/MERGE_STATE_UNKNOWN) | `node.mergeStateStatus` |
| `? Check merge blocker` | `gh pr list` → `[].mergeStateStatus`(=BLOCKED 等)＋他シグナル全 None | `node.mergeStateStatus`＋他シグナル全 None |
| `✗ Fix CI failure` | `gh pr checks <num>` → `[].bucket`(∈fail/cancel) | `rollup[].status`+`rollup[].conclusion`(CheckRun) / `rollup[].state`(StatusContext) を `context_to_bucket` で fail/cancel 判定（同名は最新 run のみ） |
| `⚠ Run CI action` | `gh pr checks <num>` → `[].bucket`(=action_required) | `rollup[].conclusion`(=ACTION_REQUIRED) |
| `⧖ Wait for CI` | `gh pr checks <num>` → `[].bucket`(=pending) | `rollup[].status`(≠COMPLETED) / `rollup[].state`(∈PENDING/EXPECTED) |
| `✗ Update branch` | refs: `gh pr list` → `[].baseRefName`,`[].headRefName` → `gh api .../compare/{base}...{head}` → `.behind_by`(>0) | refs: `node.baseRefName`,`node.headRefName` → `gh api .../compare/...` → `.behind_by`（**compare は変更なし**） |
| `? Check branch sync` | 同上 compare 呼び出しが失敗/不正 JSON | 同上（refs は `node.*`、**compare は変更なし**） |
| `+ Create PR` | `gh pr list` → `[]`(空) ＋ `gh repo view` → `.defaultBranchRef.name`(≠現在ブランチ) | `data.repository.pullRequests.nodes`(空) ＋ `data.repository.defaultBranchRef.name` |

※ デフォルトブランチ上（出力トークンなし）の判定元: `gh repo view` → `.defaultBranchRef.name` から `data.repository.defaultBranchRef.name` に統合。
※ CI 列の「最新 run のみ」= `rollup` を `name`(CheckRun) / `context`(StatusContext) でグルーピングし `startedAt`/`createdAt` 最大の run のみ採用（再実行された古い run を除外）。

## GraphQL が旧コマンドと等価であることの検証

`statusCheckRollup` → bucket の写像が実 `gh pr checks --json bucket` と一致するかを、実 PR で **check 名突き合わせ**により検証（home-assistant/core・denoland/deno の計 1040+ checks、pass/fail/cancel/pending/skipping/action_required/再実行 を網羅）。検証で **2 点**が判明:

1. **再実行 check の重複排除（バグ→修正済み）**: GraphQL は再実行された check の古い run（FAILURE/CANCELLED）も返すが、`gh pr checks` は名前で重複排除し最新 run のみ残す。未対応だと回復済み CI を誤って失敗表示にしていた。→ 名前ごとに最新 run へ重複排除する修正を追加し、実データで不一致 0 を確認。
2. **ACTION_REQUIRED（意図的な差異）**: 実 gh は `ACTION_REQUIRED` を `fail` バケットにする（`✗ Fix CI failure`）。本 PR は GraphQL の生 conclusion を活かし、旧コードでは到達不能だった `⚠ Run CI action`（`CiState::ActionRequired`）を**意図的に有効化**する。これは旧の観測挙動からの軽微な仕様改善。

最終実装を実 gh と再突合した結果、**意図的な ACTION_REQUIRED 以外は完全一致**。

## パフォーマンス計測（実コマンドレベル）

実 PR（N=1）で新旧の `gh` コマンドを実測（ネットワーク依存・warm-up 除外・複数回平均）。

### 個別コマンド（平均）

| コマンド | 平均 | 備考 |
|---|---|---|
| OLD `gh pr list` | 630 ms | 新方式で廃止 |
| OLD `gh pr checks <num>` | 967 ms | 新方式で廃止（GraphQL に統合） |
| `gh api .../compare/...` | 597 ms | **新旧共通**（branch sync 用に REST 維持） |
| NEW `gh api graphql`（単一） | 692 ms | 上記 2 つを 1 つに統合 |

### refresh 1 回ぶん（コマンドを順番に実行）

| 方式 | コマンド | 平均 | 最小 |
|---|---|---|---|
| OLD | pr list + pr checks + compare（3 cmd） | **2365 ms** | 2058 ms |
| NEW | api graphql + compare（2 cmd） | **1291 ms** | 1122 ms |

**→ 約 45% 短縮（約 1.8 倍速、平均 −1074 ms）。PR 数が増えるほど差が拡大**（旧は PR ごとに `pr checks` 約 970 ms/件が増えるが、新の graphql は 1 回のまま）。compare は新旧共通のため時短には寄与しない。

## 受け入れ条件

- [x] refresh あたりの `gh` サブプロセス起動数を計測し削減を確認（N=2 で `1 GRAPHQL + 2 COMPARE = 3`、従来 5）
- [x] 既存のステータス判定（CI / review / branch sync / unblocked / calculating）が現行と一致することを E2E で固定（CI 写像は実 gh と突合・検証済み）
- [x] レート制限コストモデルと整合する実コール数（`pr_count+1`）
- [x] `cargo nextest run --workspace` green（355 passed）
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` green
- [x] `bash scripts/check-layer-deps.sh` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
