### PR TITLE
test(daemon): stop タイミングテストのフレークを閾値緩和とリトライで抑える

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -7,3 +7,10 @@ test-threads = "num-cpus"
 [[profile.default.overrides]]
 filter = 'test(test_cold_interval_switches_from_early_to_late) | test(test_cold_reset_on_warm_query) | test(test_terminal_pr_reopened_resets_to_warm) | test(test_refresh_timeout_clears_lock_and_allows_retry) | test(test_warm_without_recent_query_uses_warm_interval) | test(test_warm_with_recent_query_uses_hot_interval)'
 slow-timeout = { period = "10s", terminate-after = 2 }
+
+# 並列負荷下でごく稀にフレークする実時間タイミングテスト。
+# 一過性の負荷オーバーヘッドのみリトライで吸収する
+# （真の回帰は毎回〜5s で落ちるためリトライでは隠れない）。
+[[profile.default.overrides]]
+filter = 'test(test_daemon_stop_does_not_wait_for_scheduler_tick)'
+retries = 2

--- a/tests/e2e/daemon/lifecycle.rs
+++ b/tests/e2e/daemon/lifecycle.rs
@@ -284,7 +284,7 @@ fn test_daemon_stop_does_not_wait_for_scheduler_tick() {
     assert!(String::from_utf8_lossy(&output.stdout).contains("stopped"));
 
     assert!(
-        started.elapsed() < std::time::Duration::from_secs(2),
+        started.elapsed() < std::time::Duration::from_secs(4),
         "daemon stop should not wait for the scheduler tick"
     );
     drop(daemon);


### PR DESCRIPTION
## 概要

Closes #370

E2E テスト `test_daemon_stop_does_not_wait_for_scheduler_tick`（`tests/e2e/daemon/lifecycle.rs`）が、並列実行による高負荷時にごく稀に失敗するフレークを解消する。

## 原因

サブプロセス起動 + IPC ラウンドトリップの**実時間**を絶対しきい値 `2s` で測っているため、負荷オーバーヘッドで tick を待っていなくても超過しうる（実測 `2.051s`）。`daemon stop` 自体は `CancellationToken` で scheduler を即中断する設計で、tick を待つ作りにはなっていない（回帰ではない既存の脆さ）。

## 対応（Issue 対応案の併用）

- **閾値緩和**: elapsed しきい値を `2s` → `4s`。検出したい回帰（stop が ~5s の tick を待つ）は毎回ほぼ同じ時間かかる*決定的*な失敗で、`4s` 閾値か既存の `COMMAND_TIMEOUT_MS = 5000` で引き続き捕捉される。
- **nextest リトライ**: `.config/nextest.toml` にこのテスト限定の `retries = 2` を追加。*一過性*の負荷フレークのみ吸収し、決定的な回帰は全試行で落ちるため隠れない。

## 検証

- 対象テスト単体: `1 passed`
- `daemon::lifecycle` スイート: `18 passed`
- `cargo fmt --check --all`: OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)