### PR TITLE
fix(daemon): gh spawn 失敗時の panic を回避しエラーとして扱う

### DIFF
--- a/src/contexts/daemon/infrastructure/rate_limit_client.rs
+++ b/src/contexts/daemon/infrastructure/rate_limit_client.rs
@@ -93,6 +93,10 @@ async fn raw_fetch() -> Option<RateLimitSnapshot> {
             log::warn!("rate_limit fetch failed: timeout");
             None
         }
+        Err(GhProcessError::Io(e)) => {
+            log::warn!("rate_limit fetch failed: io error: {e}");
+            None
+        }
     }
 }
 

--- a/src/contexts/evaluation/infrastructure/gh.rs
+++ b/src/contexts/evaluation/infrastructure/gh.rs
@@ -50,6 +50,10 @@ async fn run_gh(cwd: &Path, args: &[&str]) -> Result<Vec<u8>, GhError> {
         Err(crate::shared::process_gh::GhProcessError::Failed { exit_code, stderr }) => {
             Err(classify_gh_error(exit_code, &stderr))
         }
+        // spawn / wait の I/O 失敗は不明なインフラ起因エラーとして扱う。
+        Err(crate::shared::process_gh::GhProcessError::Io(e)) => {
+            Err(GhError::ApiError(e.to_string()))
+        }
     }
 }
 

--- a/src/shared/process_gh.rs
+++ b/src/shared/process_gh.rs
@@ -4,7 +4,8 @@
 //! で呼び出す。タイムアウトは `MERGE_READY_GH_TIMEOUT_SECS`（既定 30 秒）。
 //!
 //! エラー分類は呼び出し側の関心事として保持し、ここでは
-//! `NotInstalled` / `Timeout` / `Failed { exit_code, stderr }` の 3 種類だけを返す。
+//! `NotInstalled` / `Timeout` / `Failed { exit_code, stderr }` / `Io` の
+//! 4 種類だけを返す。
 
 use std::io::ErrorKind;
 use std::path::Path;
@@ -22,6 +23,9 @@ pub enum GhProcessError {
     Timeout,
     /// 非ゼロ終了。`exit_code` と `stderr` を呼び出し側の分類器に渡せる
     Failed { exit_code: i32, stderr: String },
+    /// spawn / wait の I/O 失敗（`NotFound` 以外の spawn 失敗や `wait_with_output` 失敗）。
+    /// ワーカータスクを panic させず通常のエラー経路に乗せるためのバリアント。
+    Io(std::io::Error),
 }
 
 fn gh_timeout() -> Duration {
@@ -33,7 +37,17 @@ fn gh_timeout() -> Duration {
 }
 
 pub async fn run_gh(args: &[&str], cwd: Option<&Path>) -> Result<Vec<u8>, GhProcessError> {
-    let mut cmd = Command::new("gh");
+    run_program("gh", args, cwd).await
+}
+
+/// `run_gh` の本体。実行するプログラム名を引数化し、spawn 失敗の注入を
+/// テストから行えるようにしている（本番では常に `"gh"`）。
+async fn run_program(
+    program: &str,
+    args: &[&str],
+    cwd: Option<&Path>,
+) -> Result<Vec<u8>, GhProcessError> {
+    let mut cmd = Command::new(program);
     cmd.args(args);
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
@@ -47,11 +61,14 @@ pub async fn run_gh(args: &[&str], cwd: Option<&Path>) -> Result<Vec<u8>, GhProc
     let child = match cmd.spawn() {
         Ok(c) => c,
         Err(e) if e.kind() == ErrorKind::NotFound => return Err(GhProcessError::NotInstalled),
-        Err(e) => panic!("spawn gh: {e}"),
+        // `NotFound` 以外の spawn 失敗（権限不足など）は panic させず Io として返す。
+        Err(e) => return Err(GhProcessError::Io(e)),
     };
 
     let output = match timeout(gh_timeout(), child.wait_with_output()).await {
-        Ok(out) => out.expect("wait_with_output on gh child"),
+        Ok(Ok(out)) => out,
+        // `wait_with_output` の I/O 失敗も panic させず Io として返す。
+        Ok(Err(e)) => return Err(GhProcessError::Io(e)),
         Err(_) => return Err(GhProcessError::Timeout),
     };
 
@@ -64,5 +81,45 @@ pub async fn run_gh(args: &[&str], cwd: Option<&Path>) -> Result<Vec<u8>, GhProc
             exit_code,
             stderr: stderr_str,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `NotFound` 以外の spawn 失敗（ディレクトリを実行 → `PermissionDenied`）は
+    /// panic せず `GhProcessError::Io` として返ること（Issue #377）。
+    #[tokio::test]
+    async fn spawn_failure_other_than_not_found_returns_io_error() {
+        // 一時ディレクトリ自体を program に渡すと spawn が `PermissionDenied`
+        // （`NotFound` ではない）で失敗する。これで panic 経路を踏まずに済むことを検証する。
+        let dir = std::env::temp_dir();
+        let program = dir.to_str().expect("temp_dir path is valid utf-8");
+
+        let result = run_program(program, &[], None).await;
+
+        match result {
+            Err(GhProcessError::Io(e)) => {
+                assert_ne!(
+                    e.kind(),
+                    ErrorKind::NotFound,
+                    "NotFound は NotInstalled として扱われるべき"
+                );
+            }
+            other => panic!("expected GhProcessError::Io, got {other:?}"),
+        }
+    }
+
+    /// 存在しないバイナリ（`NotFound`）は従来どおり `NotInstalled` を返すこと。
+    #[tokio::test]
+    async fn spawn_not_found_returns_not_installed() {
+        let result = run_program(
+            "/no/such/binary/merge-ready-xyzzy",
+            &["api", "rate_limit"],
+            None,
+        )
+        .await;
+        assert!(matches!(result, Err(GhProcessError::NotInstalled)));
     }
 }


### PR DESCRIPTION
## 概要

`src/shared/process_gh.rs` では `NotFound` 以外の `gh` spawn 失敗と `wait_with_output` 失敗を `panic!` / `expect` で処理しており、ワーカータスクが panic していた（Issue #377、堅牢性 / Low）。

これらの失敗を panic させず、通常のエラー経路に乗せるよう修正する。

## 変更内容

- `GhProcessError` に `Io(std::io::Error)` バリアントを追加。
- `run_gh` の本体を program 名を引数化した内部関数 `run_program` に切り出し、spawn 失敗をテストから注入可能にした（本番では常に `"gh"`）。
- `NotFound` 以外の spawn 失敗（権限不足など）と `wait_with_output` の I/O 失敗を、`panic!` / `expect` ではなく `GhProcessError::Io` として返す。`NotFound` は従来どおり `NotInstalled`。
- 呼び出し側を既存のフォールバック経路に接続:
  - `evaluation/infrastructure/gh.rs`: `Io` → `GhError::ApiError`（最終的に `✗ unexpected error` + error.log）。
  - `daemon/infrastructure/rate_limit_client.rs`: `Io` → `log::warn!` + `None`（既存バリアントと同じ流儀）。
  - `evaluation/infrastructure/gh/fetch.rs`: 既存の `Err(_) => None` で網羅済み（変更不要）。

## テスト

`process_gh.rs` に unit テストを追加（OS レベルのエラー注入は CONTRIBUTING.md でも unit テストが妥当とされるケース）:

- `spawn_failure_other_than_not_found_returns_io_error`: ディレクトリを program に渡して `PermissionDenied`（`NotFound` 以外）を再現し、panic せず `GhProcessError::Io` を返すことを検証。
- `spawn_not_found_returns_not_installed`: 存在しないバイナリは従来どおり `NotInstalled` を返すことを検証。

`gh` バイナリ不在（`NotFound`）の E2E は既存の `tests/e2e/prompt/errors.rs::test_gh_not_installed` で引き続きカバーされる。

## チェック結果（ローカル全通過）

- `cargo fmt --check --all` OK
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` OK
- `cargo nextest run --workspace` 375 passed
- `cargo deny check` OK
- `check-layer-deps.sh` / `check-no-mod-rs.sh` / `check-no-clippy-allow.sh` OK

Closes #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)