### PR TITLE
fix(daemon): 非 Linux でも temp ディレクトリを uid で名前空間分離する

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,6 +642,7 @@ dependencies = [
  "nu-ansi-term",
  "predicates",
  "rstest",
+ "rustix",
  "serde",
  "serde_json",
  "simplelog",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,11 @@ bitflags = "2.11.1"
 tokio = { version = "1.52.3", features = ["full"] }
 tokio-util = { version = "0.7.18", default-features = false }
 
+[target.'cfg(unix)'.dependencies]
+# 全 unix で起動ユーザの uid を取得し、temp ディレクトリを名前空間分離する。
+# `unsafe_code = "forbid"` のため libc の生 FFI ではなく safe な rustix を使う。
+rustix = { version = "1.1.4", features = ["process"] }
+
 [lib]
 name = "merge_ready"
 path = "src/lib.rs"

--- a/src/contexts/daemon/infrastructure/paths.rs
+++ b/src/contexts/daemon/infrastructure/paths.rs
@@ -65,23 +65,44 @@ pub fn base_dir() -> PathBuf {
     std::env::temp_dir().join(dir_name())
 }
 
+/// 起動ユーザの uid で temp 配下のディレクトリ名を名前空間分離する。
+///
+/// uid 別ディレクトリにすることで、`TMPDIR` が共有書き込み可能な環境
+/// （例: `TMPDIR=/tmp`）でも、他ユーザが lock/pid/socket を置くディレクトリを
+/// 先回り作成する攻撃を防ぐ（defense-in-depth）。unix では実 uid を使い、
+/// 非 unix（uid の概念がない）では固定名にフォールバックする。
 fn dir_name() -> String {
     std::cfg_select! {
-        target_os = "linux" => {
-            use std::os::unix::fs::MetadataExt;
-            if let Ok(meta) = std::fs::metadata("/proc/self") {
-                format!("merge-ready-{}", meta.uid())
-            } else {
-                "merge-ready".to_owned()
-            }
-        },
-        _ => "merge-ready".to_owned(),
+        unix => dir_name_for(Some(rustix::process::getuid().as_raw())),
+        _ => dir_name_for(None),
+    }
+}
+
+/// uid から temp 配下のディレクトリ名を決める純粋関数。
+///
+/// uid がある場合は `merge-ready-{uid}` で名前空間を分離し、無い場合
+/// （非 unix）は固定の `merge-ready` を使う。
+fn dir_name_for(uid: Option<u32>) -> String {
+    match uid {
+        Some(uid) => format!("merge-ready-{uid}"),
+        None => "merge-ready".to_owned(),
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::Paths;
+    use super::{Paths, dir_name_for};
+
+    #[test]
+    fn dir_name_includes_uid_when_available() {
+        assert_eq!(dir_name_for(Some(1000)), "merge-ready-1000");
+        assert_eq!(dir_name_for(Some(0)), "merge-ready-0");
+    }
+
+    #[test]
+    fn dir_name_falls_back_to_plain_when_uid_unavailable() {
+        assert_eq!(dir_name_for(None), "merge-ready");
+    }
 
     #[test]
     fn paths_from_custom_dir() {

--- a/tests/e2e/daemon/lifecycle.rs
+++ b/tests/e2e/daemon/lifecycle.rs
@@ -674,7 +674,8 @@ fn test_daemon_and_prompt_use_default_base_dir_when_unset() {
     assert!(status.success(), "daemon start should succeed");
 
     // BASE_DIR 未設定なので TMPDIR/<dir_name>/ 配下に socket が作られる。
-    // dir_name() は OS 依存（macOS: "merge-ready"、Linux: "merge-ready-{uid}"）。
+    // dir_name() は unix では uid で名前空間分離（"merge-ready-{uid}"）、
+    // 非 unix では固定の "merge-ready"。
     let socket_name = format!("daemon-{}.sock", env!("CARGO_PKG_VERSION"));
     let socket_path = std::fs::read_dir(env.home())
         .expect("read home dir")


### PR DESCRIPTION
## 概要

`paths.rs` の `dir_name()` は uid による temp ディレクトリの名前空間分離を **Linux のみ** で行い、他プラットフォームは固定の `merge-ready` を使っていた。`TMPDIR` が共有書き込み可能な環境（例: `TMPDIR=/tmp`）では、他ユーザが `/tmp/merge-ready` を先回り作成することで lock/pid/socket が攻撃者所有のディレクトリに置かれ得る（セキュリティ調査で確認した defense-in-depth 観点、Low）。

uid 名前空間分離を **全 unix プラットフォーム** へ拡張する。

## 変更内容

- **uid 取得を全 unix へ統一**: Linux 固有の `/proc/self` メタデータ参照をやめ、全 unix で動作する `rustix::process::getuid()` に統一。
- **safe な依存の選択**: 本クレートは `unsafe_code = "forbid"` のため、`libc` の生 FFI ではなく safe API を提供する `rustix` を `[target.'cfg(unix)'.dependencies]` として追加（`features = ["process"]`）。rustix は既に推移依存としてビルドツリーに存在しており、追加コストは小さい。
- **非 unix は挙動不変**: Windows 等の非 unix は従来どおり固定名 `merge-ready` にフォールバック。
- **純粋関数への分離**: `dir_name` を「uid → 名前」の純粋関数 `dir_name_for(Option<u32>)` に分離し、全プラットフォームで両分岐を unit テストで検証可能にした。

## テスト

TDD（Red → Green → Refactor）で実装。`dir_name_for` の uid 反映はプラットフォーム依存の純粋ロジックのため unit テストが妥当（本プロジェクトの「E2E で到達不能なロジックのみ unit」方針に合致）。

- `dir_name_includes_uid_when_available`: uid がある場合 `merge-ready-{uid}` になる（`Some(1000)`、`Some(0)`）。
- `dir_name_falls_back_to_plain_when_uid_unavailable`: uid が無い場合（非 unix）`merge-ready` になる。

既存 E2E (`test_daemon_and_prompt_use_default_base_dir_when_unset`) は `merge-ready*` 前方一致で socket を探すため互換。コメントを新挙動（unix は uid 付き）に合わせて更新。

## チェック結果（全て通過）

- `cargo fmt --check --all` ✅
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✅
- `cargo nextest run --workspace` ✅ 375 passed
- `cargo deny check` ✅ advisories/bans/licenses/sources ok
- `scripts/check-layer-deps.sh` / `check-no-mod-rs.sh` / `check-no-clippy-allow.sh` ✅

Closes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)