### PR TITLE
fix(prompt): daemon ソケットの入力を検証し、出力の制御文字を除去する

### DIFF
--- a/src/contexts/daemon/infrastructure/connection.rs
+++ b/src/contexts/daemon/infrastructure/connection.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
 use tokio::runtime::Handle;
 use tokio::sync::mpsc::UnboundedSender;
@@ -12,6 +12,14 @@ use super::request_handler::ActionResult;
 use super::restart;
 use crate::shared::protocol::Request;
 
+/// 1 リクエスト行として受理する最大バイト数。
+///
+/// 信頼境界は同一ユーザだが defense-in-depth として、改行まで無制限に読み取る
+/// ことで悪意あるローカルプロセスがメモリを枯渇させるのを防ぐ。最大の正当な
+/// リクエストは `Update`（PR ごとのレンダリング済み出力を多数含む）なので、
+/// 通常のステータス文字列に対して十分余裕のある 1 MiB を上限とする。
+const MAX_REQUEST_BYTES: u64 = 1024 * 1024;
+
 pub(super) async fn handle(
     mut stream: UnixStream,
     state: &DaemonStateHandle,
@@ -20,13 +28,13 @@ pub(super) async fn handle(
     paths: &Paths,
     handle: &Handle,
 ) {
-    let mut buf = String::new();
-    {
+    let buf = {
         let mut reader = BufReader::new(&mut stream);
-        if reader.read_line(&mut buf).await.is_err() || buf.is_empty() {
-            return;
+        match read_request_line(&mut reader).await {
+            Some(buf) => buf,
+            None => return,
         }
-    }
+    };
 
     let request: Request = match serde_json::from_str(buf.trim()) {
         Ok(r) => r,
@@ -56,5 +64,58 @@ pub(super) async fn handle(
         restart::cleanup(paths);
         tokio::time::sleep(Duration::from_millis(50)).await;
         let _ = exit_tx.send(());
+    }
+}
+
+/// ソケットから 1 リクエスト行を読み取る。
+///
+/// `take` で [`MAX_REQUEST_BYTES`] の上限を設けるため、改行が来ない / 巨大な行
+/// でも無制限にメモリを確保しない。空入力 / 読み取りエラー時は `None` を返す。
+/// 上限に達した場合は改行なしで打ち切られた文字列を返すため、呼び出し側の
+/// JSON パースが失敗して安全に拒否される。
+async fn read_request_line<R>(reader: &mut R) -> Option<String>
+where
+    R: AsyncBufReadExt + Unpin,
+{
+    let mut buf = String::new();
+    let mut limited = reader.take(MAX_REQUEST_BYTES);
+    if limited.read_line(&mut buf).await.is_err() || buf.is_empty() {
+        return None;
+    }
+    Some(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn reads_a_full_line_within_the_limit() {
+        let input = b"hello world\n";
+        let mut reader = BufReader::new(&input[..]);
+        let line = read_request_line(&mut reader).await;
+        assert_eq!(line.as_deref(), Some("hello world\n"));
+    }
+
+    #[tokio::test]
+    async fn returns_none_for_empty_input() {
+        let input: &[u8] = b"";
+        let mut reader = BufReader::new(input);
+        assert!(read_request_line(&mut reader).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn truncates_input_exceeding_the_byte_limit() {
+        let limit = usize::try_from(MAX_REQUEST_BYTES).expect("limit fits in usize");
+        // 改行のない巨大入力。`take` がなければ read_line は EOF まで全量を確保する。
+        let oversized = vec![b'a'; limit + 1024];
+        let mut reader = BufReader::new(&oversized[..]);
+        let line = read_request_line(&mut reader)
+            .await
+            .expect("should read up to the limit");
+        // 上限ちょうどで打ち切られ、超過分は読み込まれない。
+        assert_eq!(line.len(), limit);
+        // 改行が含まれないため、呼び出し側の JSON パースは失敗する。
+        assert!(!line.contains('\n'));
     }
 }

--- a/src_prompt/main.rs
+++ b/src_prompt/main.rs
@@ -15,7 +15,68 @@ fn main() {
         spawn_daemon();
         "? loading".to_owned()
     });
-    print!("{output}");
+    // 信頼境界は同一ユーザだが defense-in-depth として、端末へ出力する前に
+    // 危険な制御文字を除去する。正当な ANSI カラー（SGR）は保持する。
+    print!("{}", sanitize_output(&output));
+}
+
+/// daemon から受け取った出力を端末へ表示する前にサニタイズする。
+///
+/// プロンプトは 1 行のステータス表示用途であり、表示に必要な ANSI カラー
+/// （SGR: `ESC [ ... m`）は保持する。それ以外の制御文字はすべて除去する:
+///
+/// - C0 制御文字（`\x00`–`\x1f`）と DEL（`\x7f`）。改行・タブも含めて除去し、
+///   悪意ある `Update` による複数行注入やプロンプト破壊を防ぐ。
+/// - C1 制御文字（`U+0080`–`U+009F`）。
+/// - SGR 以外の ANSI エスケープシーケンス（カーソル移動・画面消去・OSC など）。
+///
+/// SGR シーケンスは `ESC [` で始まり、パラメータ（`0x30`–`0x3f`）と中間
+/// バイト（`0x20`–`0x2f`）が続き、終端文字 `m`（`0x6d`）で終わる。終端が `m`
+/// 以外の CSI シーケンスや、`ESC [` 以外で始まるエスケープは丸ごと除去する。
+#[must_use]
+fn sanitize_output(input: &str) -> String {
+    const ESC: char = '\u{1b}';
+    let mut out = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        if c == ESC {
+            // `ESC [` で始まり `m` で終わる SGR（カラー）シーケンスだけを保持する。
+            if matches!(chars.peek(), Some('[')) {
+                let mut seq = String::from(ESC);
+                seq.push(chars.next().expect("peeked '['"));
+                let mut terminated_with_m = false;
+                for sc in chars.by_ref() {
+                    seq.push(sc);
+                    // CSI シーケンスの終端は 0x40–0x7e。終端まで読み切る。
+                    if ('\u{40}'..='\u{7e}').contains(&sc) {
+                        terminated_with_m = sc == 'm';
+                        break;
+                    }
+                }
+                if terminated_with_m {
+                    out.push_str(&seq);
+                }
+                // SGR 以外の CSI は破棄する（seq は out へ push しない）。
+            }
+            // `ESC [` 以外のエスケープ（OSC など）は ESC を捨てて続行する。
+            continue;
+        }
+
+        if is_disallowed_control(c) {
+            continue;
+        }
+        out.push(c);
+    }
+
+    out
+}
+
+/// 表示を許可しない制御文字かどうか。
+///
+/// C0（`\x00`–`\x1f`、改行・タブを含む）、DEL（`\x7f`）、C1（`U+0080`–`U+009F`）。
+fn is_disallowed_control(c: char) -> bool {
+    matches!(c, '\u{00}'..='\u{1f}' | '\u{7f}'..='\u{9f}')
 }
 
 fn query_daemon() -> Option<String> {
@@ -55,4 +116,75 @@ fn spawn_daemon() {
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keeps_plain_text_unchanged() {
+        assert_eq!(sanitize_output("✓ Ready for merge"), "✓ Ready for merge");
+    }
+
+    #[test]
+    fn keeps_sgr_color_sequences() {
+        // bold green + reset。E2E のスタイル機能が依存する正当な出力。
+        let styled = "\u{1b}[1;32m✓\u{1b}[0m Ready";
+        assert_eq!(sanitize_output(styled), styled);
+    }
+
+    #[test]
+    fn keeps_ansi256_and_rgb_sgr() {
+        let styled = "\u{1b}[38;5;196m✗\u{1b}[0m \u{1b}[38;2;255;0;0mfail\u{1b}[0m";
+        assert_eq!(sanitize_output(styled), styled);
+    }
+
+    #[test]
+    fn strips_c0_control_characters() {
+        // ベル・NUL・キャリッジリターン・タブ・改行を除去する。
+        assert_eq!(sanitize_output("a\u{07}b\u{00}c\rd\te\nf"), "abcdef");
+    }
+
+    #[test]
+    fn strips_del_and_c1_controls() {
+        assert_eq!(sanitize_output("a\u{7f}b\u{80}c\u{9f}d"), "abcd");
+    }
+
+    #[test]
+    fn strips_cursor_movement_csi() {
+        // CSI カーソル上移動 (`ESC [ 2 A`) は SGR ではないので除去する。
+        assert_eq!(sanitize_output("a\u{1b}[2Ab"), "ab");
+    }
+
+    #[test]
+    fn strips_screen_clear_csi() {
+        // 画面消去 (`ESC [ 2 J`) を除去する。
+        assert_eq!(sanitize_output("\u{1b}[2Jhello"), "hello");
+    }
+
+    #[test]
+    fn strips_osc_escape() {
+        // OSC（`ESC ]`）はウィンドウタイトル変更など。`ESC [` で始まらないため
+        // ESC を捨て、続くテキストはそのまま残る（制御文字は別途除去される）。
+        let injected = "\u{1b}]0;malicious\u{07}prompt";
+        // ESC と BEL が除去され、残りは表示テキストとして残る。
+        assert_eq!(sanitize_output(injected), "]0;maliciousprompt");
+    }
+
+    #[test]
+    fn strips_lone_escape_at_end() {
+        assert_eq!(sanitize_output("ok\u{1b}"), "ok");
+    }
+
+    #[test]
+    fn strips_unterminated_csi() {
+        // 終端されない CSI（EOF まで来る）は丸ごと除去する。
+        assert_eq!(sanitize_output("ok\u{1b}[38;5;"), "ok");
+    }
+
+    #[test]
+    fn keeps_loading_placeholder() {
+        assert_eq!(sanitize_output("? loading"), "? loading");
+    }
 }

--- a/tests/e2e/prompt/mod.rs
+++ b/tests/e2e/prompt/mod.rs
@@ -7,4 +7,5 @@ mod errors_fixtures;
 mod merge_ready;
 mod pr_state;
 mod review;
+mod sanitize;
 mod style;

--- a/tests/e2e/prompt/sanitize.rs
+++ b/tests/e2e/prompt/sanitize.rs
@@ -1,0 +1,58 @@
+//! 出力サニタイズの E2E テスト（Issue #374）
+//!
+//! `merge-ready-prompt` は daemon から受け取った出力を端末へ表示する前に、
+//! 危険な制御文字を除去する。正当な ANSI カラー（SGR）は保持し、改行などの
+//! 制御文字は除去してプロンプト破壊・複数行注入を防ぐ。
+
+const PROMPT_BIN: &str = "merge-ready-prompt";
+const MERGE_READY_JSON: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED"}"#;
+const CHECKS_PASS_JSON: &str =
+    r#"[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]"#;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+use super::super::helpers::{DaemonHandle, TestEnv};
+
+/// format に埋め込まれた改行（制御文字）はプロンプト出力から除去される。
+///
+/// daemon 側の render は format 文字列をそのまま展開するため、設定に改行を
+/// 含めると出力にも改行が乗る。prompt バイナリのサニタイズがこれを除去する
+/// ことで、出力が 1 行に保たれる（複数行注入・プロンプト破壊の防止）。
+#[test]
+fn newline_in_output_is_stripped() {
+    let env = TestEnv::new(MERGE_READY_JSON, Some(CHECKS_PASS_JSON));
+    // TOML basic string の `\n` は実際の改行文字に展開される。
+    env.write_config("[merge_ready]\nformat = \"$symbol\\n$label\"");
+
+    let _daemon = DaemonHandle::start(&env);
+    DaemonHandle::wait_for_cache(&env, 5000);
+
+    let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
+    env.apply_with_cache(&mut cmd);
+    // 改行が除去され、symbol と label が連結された 1 行になる。
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("\n").not())
+        .stdout(predicate::str::diff("✓Ready for merge"))
+        .stderr("");
+}
+
+/// サニタイズ後も正当な ANSI カラー（SGR）は保持される（後方互換）。
+#[test]
+fn sgr_color_is_preserved_after_sanitize() {
+    let env = TestEnv::new(MERGE_READY_JSON, Some(CHECKS_PASS_JSON));
+    env.write_config("[merge_ready]\nformat = \"[$symbol](bold green) $label\"");
+
+    let _daemon = DaemonHandle::start(&env);
+    DaemonHandle::wait_for_cache(&env, 5000);
+
+    let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
+    env.apply_with_cache(&mut cmd);
+    cmd.assert()
+        .success()
+        // SGR シーケンスは残り、末尾のプレーンテキストも保持される。
+        .stdout(predicate::str::contains("\x1b["))
+        .stdout(predicate::str::ends_with("Ready for merge"))
+        .stderr("");
+}


### PR DESCRIPTION
## 概要

セキュリティ調査で確認した defense-in-depth 観点（Low, Issue #374）。信頼境界は「同一ユーザ」だが、悪意あるローカルプロセスが daemon の `Update` リクエスト経由で ANSI/制御文字をプロンプトへ注入できる点と、ソケット読み取りが改行まで無制限である点を是正する。

## 変更内容

### 1. 出力サニタイズ（`src_prompt/main.rs`）
端末へ表示する前に純粋関数 `sanitize_output` を通す。
- **保持**: 正当な ANSI カラー（SGR: `ESC [ ... m`）。ユーザー設定の `format` でスタイルを指定したときに生成される正規出力で、既存の E2E テスト（`prompt::style`）が依存している。
- **除去**: C0 制御文字（`\x00`–`\x1f`、改行・タブ含む）、DEL（`\x7f`）、C1 制御文字（`U+0080`–`U+009F`）、および SGR 以外の ANSI エスケープ（カーソル移動・画面消去・OSC など）。プロンプトは 1 行のステータス表示用途のため、改行も除去して複数行注入・プロンプト破壊を防ぐ。

### 2. ソケット読み取り上限（`src/contexts/daemon/infrastructure/connection.rs`）
`read_line` を `take(MAX_REQUEST_BYTES)` でラップし、改行が来ない / 巨大な行による無制限なメモリ確保を防ぐ。上限（`MAX_REQUEST_BYTES = 1 MiB`）に達した場合は改行なしで打ち切られ、後続の JSON パースが失敗して安全に拒否される。読み取りロジックを `read_request_line` ヘルパーへ切り出してテスト可能にした。

## テスト

- **unit（prompt バイナリ）**: SGR カラー保持・C0/C1/DEL 除去・非 SGR CSI / OSC / 未終端 CSI の除去など 11 ケース。
- **unit（connection）**: 上限内での読み取り・空入力・上限超過時の打ち切りの 3 ケース。
- **E2E（`tests/e2e/prompt/sanitize.rs`）**: サニタイズが出力経路に組み込まれていること（format に埋め込んだ改行が除去され 1 行になる）と、正規 ANSI カラーが壊れないことを観測。`print!` をサニタイズなしに戻すと改行テストが落ちることも確認済み（真に有効なテスト）。
- 既存の `prompt::style` E2E（20 ケース）が引き続き green であることで「既存の出力仕様を壊さない」を担保。

ローカルで `cargo fmt --check`, `clippy -D warnings`, `nextest run --workspace`（389 件）, `cargo deny check`, layer-deps / no-mod-rs / no-clippy-allow を全て通過。

Closes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)