### PR TITLE
fix(evaluation): substitute_vars が非 ASCII を含む format を文字化けさせる問題を修正

### DIFF
--- a/src/contexts/evaluation/domain/display_config/render.rs
+++ b/src/contexts/evaluation/domain/display_config/render.rs
@@ -120,8 +120,14 @@ fn substitute_vars(s: &str, vars: &[(&str, &str)]) -> String {
                 i += 1;
             }
         } else {
-            result.push(bytes[i] as char);
-            i += 1;
+            // 次の `$` までの非変数部分をまとめてコピーする。`$` は ASCII (1 バイト) なので
+            // i は常に char 境界に揃い、マルチバイト文字も保持される。
+            let next = bytes[i..]
+                .iter()
+                .position(|&b| b == b'$')
+                .map_or(bytes.len(), |pos| i + pos);
+            result.push_str(&s[i..next]);
+            i = next;
         }
     }
     result
@@ -333,5 +339,18 @@ mod tests {
             format: "$symbol $unknown".to_owned(),
         };
         assert_eq!(render_token(&tok, None), "+ $unknown");
+    }
+
+    #[test]
+    fn render_token_non_ascii_literal_in_format_preserved() {
+        let tok = TokenConfig {
+            symbol: "✓".to_owned(),
+            label: "Ready for merge".to_owned(),
+            format: "【$symbol】準備完了: $label 🎉".to_owned(),
+        };
+        assert_eq!(
+            render_token(&tok, None),
+            "【✓】準備完了: Ready for merge 🎉"
+        );
     }
 }

--- a/tests/e2e/config/token_customization.rs
+++ b/tests/e2e/config/token_customization.rs
@@ -44,6 +44,10 @@ fn assert_prompt_with_config(env: &TestEnv, expected: &str) {
     Some("[merge_ready]\nsymbol = \"✅\"\nlabel = \"lgtm\"\nformat = \"$label $symbol\""),
     "lgtm ✅"
 )]
+#[case::non_ascii_format(
+    Some("[merge_ready]\nformat = \"【$symbol】準備完了: $label\""),
+    "【✓】準備完了: Ready for merge"
+)]
 #[case::invalid_toml(Some("this is not valid toml ][[["), "✓ Ready for merge")]
 fn test_config_prompt(#[case] config: Option<&str>, #[case] expected: &str) {
     let env = TestEnv::new(MERGE_READY_JSON, Some(CHECKS_PASS_JSON));


### PR DESCRIPTION
## 概要

Closes #383

`display_config/render.rs` の `substitute_vars` が、変数 (`$name`) 以外のバイトを `bytes[i] as char` で 1 バイトずつ char にキャストしていたため、`format` フィールドに含まれる UTF-8 マルチバイト文字 (日本語・絵文字など) が文字化け (mojibake) していた。`u8 as char` は Latin-1 (U+0000..=U+00FF) として解釈されるのが原因。

## 変更内容

- `substitute_vars` の非変数部分の処理を「次の `$` までのスライスをまとめて `push_str`」に変更し、マルチバイト文字をそのまま保持する。`$` は ASCII (1 バイト) なので `i` は常に char 境界に揃い `&s[i..next]` は安全。
- `$` 検出・変数置換・条件ブロック評価の既存ロジックはすべて維持（挙動不変）。
- `extract_var_names` / `parse_segments` は位置スライスのみで `as char` を使わず非 ASCII を保持するため変更不要（調査で確認）。

## テスト

- **E2E**: `tests/e2e/config/token_customization.rs` の `test_config_prompt` に非 ASCII format ケース (`【$symbol】準備完了: $label`) を追加。
- **unit**: `render_token_non_ascii_literal_in_format_preserved` を追加。修正前は mojibake で fail することを確認済み (Red → Green)。

## 受け入れ条件

- [x] 非 ASCII を含む format がそのまま出力される
- [x] 既存の変数置換・条件ブロックの挙動が変わらない
- [x] 非 ASCII format の回帰テストを追加する

## 検証ログ

- `cargo nextest run --workspace`: 401 passed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: クリーン
- `cargo fmt --check --all`: クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)