### PR TITLE
fix(daemon): クロスバージョンの旧 daemon を旧命名ディレクトリ含め停止する (#390)

### DIFF
--- a/src/contexts/daemon/infrastructure/paths.rs
+++ b/src/contexts/daemon/infrastructure/paths.rs
@@ -4,11 +4,19 @@ use std::path::PathBuf;
 ///
 /// バージョンごとに別ファイルを使うことで、複数バージョンのデーモンが共存しても
 /// 衝突せず、新デーモンが古いデーモンを安全に検知・停止できる。
+///
+/// なお #380 で temp ディレクトリ名を `merge-ready` → `merge-ready-{uid}` に変えたため、
+/// 旧バージョン検知（`old_daemon_pid_files`）は自分の `base_dir` に加えて pre-#380 の旧命名
+/// 兄弟ディレクトリ `merge-ready` も走査する。将来ディレクトリ命名を変える際は、上記の
+/// 「新デーモンが旧デーモンを検知・停止する」不変条件を保つよう走査集合と E2E を更新すること。
 const DAEMON_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 const SOCKET_PREFIX: &str = "daemon-";
 const SOCKET_EXT: &str = ".sock";
 const PID_EXT: &str = ".pid";
+
+/// #380 以前の temp ディレクトリ名（uid 名前空間分離の前）。
+const LEGACY_DIR_NAME: &str = "merge-ready";
 
 #[derive(Clone)]
 pub struct Paths {
@@ -38,19 +46,38 @@ impl Paths {
     ///
     /// 列挙対象は `daemon-{version}.pid` 形式のファイルのみ。新デーモン起動時に
     /// 旧バージョンの停止・stale ファイル削除のために使用する。
+    ///
+    /// 自分の `base_dir` に加えて、pre-#380 の旧命名兄弟ディレクトリ `merge-ready`（あれば）も
+    /// 走査する。これにより `merge-ready` → `merge-ready-{uid}` のバージョン跨ぎでも、
+    /// 旧ディレクトリに残った旧デーモンを検知・停止できる。
     pub fn old_daemon_pid_files(&self) -> Vec<PathBuf> {
         let current_pid_name = format!("{SOCKET_PREFIX}{DAEMON_VERSION}{PID_EXT}");
-        std::fs::read_dir(&self.base_dir)
-            .into_iter()
-            .flatten()
-            .filter_map(Result::ok)
-            .map(|e| e.path())
+        let mut dirs = vec![self.base_dir.clone()];
+        dirs.extend(self.legacy_sibling_dir());
+        dirs.into_iter()
+            .filter_map(|dir| std::fs::read_dir(dir).ok())
+            .flat_map(|entries| entries.filter_map(Result::ok).map(|e| e.path()))
             .filter(|p| {
                 p.file_name().and_then(|n| n.to_str()).is_some_and(|n| {
                     n.starts_with(SOCKET_PREFIX) && n.ends_with(PID_EXT) && n != current_pid_name
                 })
             })
             .collect()
+    }
+
+    /// pre-#380 の旧命名兄弟ディレクトリ `merge-ready` を返す（該当する場合のみ）。
+    ///
+    /// `base_dir` が `merge-ready-{uid}`（suffix が空でなく全て数字）のときだけ、その親の下の
+    /// `merge-ready` を返す。これにより uid 名前空間ディレクトリだけが pre-#380 の対応物を
+    /// 走査対象とし、ランダム名のテスト用ディレクトリや本物の `merge-ready` 自身は誤走査しない。
+    fn legacy_sibling_dir(&self) -> Option<PathBuf> {
+        let name = self.base_dir.file_name()?.to_str()?;
+        let suffix = name.strip_prefix(&format!("{LEGACY_DIR_NAME}-"))?;
+        if suffix.is_empty() || !suffix.bytes().all(|b| b.is_ascii_digit()) {
+            return None;
+        }
+        let legacy = self.base_dir.parent()?.join(LEGACY_DIR_NAME);
+        (legacy != self.base_dir).then_some(legacy)
     }
 }
 
@@ -92,6 +119,7 @@ fn dir_name_for(uid: Option<u32>) -> String {
 #[cfg(test)]
 mod tests {
     use super::{Paths, dir_name_for};
+    use std::path::PathBuf;
 
     #[test]
     fn dir_name_includes_uid_when_available() {
@@ -142,5 +170,46 @@ mod tests {
             .collect();
         found.sort();
         assert_eq!(found, vec!["daemon-0.0.0.pid", "daemon-0.1.0.pid"]);
+    }
+
+    #[test]
+    fn old_daemon_pid_files_scans_legacy_sibling_dir() {
+        // #390: base_dir が `merge-ready-{uid}` のとき、pre-#380 の旧命名兄弟
+        // ディレクトリ `merge-ready` も走査する。
+        let parent = tempfile::tempdir().unwrap();
+        let base = parent.path().join("merge-ready-0");
+        let legacy = parent.path().join("merge-ready");
+        std::fs::create_dir_all(&base).unwrap();
+        std::fs::create_dir_all(&legacy).unwrap();
+        std::fs::write(base.join("daemon-0.0.0.pid"), "1").unwrap();
+        std::fs::write(legacy.join("daemon-0.1.0.pid"), "2").unwrap();
+
+        let paths = Paths::new(base);
+        let mut found: Vec<PathBuf> = paths.old_daemon_pid_files();
+        found.sort();
+        assert_eq!(
+            found,
+            vec![
+                legacy.join("daemon-0.1.0.pid"),
+                parent.path().join("merge-ready-0").join("daemon-0.0.0.pid"),
+            ]
+        );
+    }
+
+    #[test]
+    fn old_daemon_pid_files_ignores_sibling_when_suffix_not_uid() {
+        // base_dir の suffix が uid（数字）でない場合は旧命名兄弟ディレクトリを走査しない。
+        // テスト用の隔離ディレクトリや本物の `$TMPDIR/merge-ready` を誤って掃除しないため。
+        let parent = tempfile::tempdir().unwrap();
+        let base = parent.path().join("merge-ready-e2e");
+        let legacy = parent.path().join("merge-ready");
+        std::fs::create_dir_all(&base).unwrap();
+        std::fs::create_dir_all(&legacy).unwrap();
+        std::fs::write(base.join("daemon-0.0.0.pid"), "1").unwrap();
+        std::fs::write(legacy.join("daemon-0.1.0.pid"), "2").unwrap();
+
+        let paths = Paths::new(base.clone());
+        let found: Vec<PathBuf> = paths.old_daemon_pid_files();
+        assert_eq!(found, vec![base.join("daemon-0.0.0.pid")]);
     }
 }

--- a/tests/e2e/daemon/lifecycle.rs
+++ b/tests/e2e/daemon/lifecycle.rs
@@ -459,6 +459,75 @@ fn test_daemon_start_sends_stop_to_live_old_version_daemon() {
     }
 }
 
+// ── #16b: 旧命名ディレクトリにいる生きた旧バージョンデーモンの停止（#390）─────
+
+/// #16b（#390 回帰）: PR #380 が temp ディレクトリ名を `merge-ready` →
+/// `merge-ready-{uid}` に変更したため、新デーモン（`merge-ready-{uid}/`）が pre-#380 の
+/// 旧命名ディレクトリ（`merge-ready/`）に居る旧デーモンを検知・停止できなくなっていた。
+///
+/// 新デーモンの起動時クリーンアップは、自分の `base_dir` だけでなく旧命名の兄弟ディレクトリ
+/// `merge-ready/` も走査し、そこで生きている旧バージョンデーモンを停止しなければならない。
+#[test]
+fn test_daemon_start_stops_live_old_version_in_legacy_dir() {
+    let env = TestEnv::new(OPEN_PR_VIEW_JSON, Some(CI_PASS_JSON));
+
+    // 隔離された親の下に pre-#380 形（merge-ready）と uid 名前空間形（merge-ready-0）を作る。
+    // 親が専用 tempdir なので、本物の $TMPDIR/merge-ready とは衝突しない。
+    let parent = tempfile::tempdir().expect("create parent tmp");
+    let legacy = parent.path().join("merge-ready");
+    let base = parent.path().join("merge-ready-0");
+    std::fs::create_dir_all(&legacy).expect("create legacy dir");
+    std::fs::create_dir_all(&base).expect("create base dir");
+
+    // 旧命名ディレクトリに「生きた旧バージョンデーモン」を用意する。
+    // 一度現バージョンで起動 → ファイルを daemon-0.0.0.* に rename して旧版を装う。
+    // Unix ソケットは rename 後も FD が有効なので socket 経由の Stop が届く。
+    let old_guard = DaemonHandle::start_in_dir(&env, &legacy);
+    let current_sock = versioned_socket(&legacy);
+    let current_pid_path = versioned_pid(&legacy);
+    let old_pid: u32 = std::fs::read_to_string(&current_pid_path)
+        .expect("read current pid")
+        .trim()
+        .parse()
+        .expect("parse pid");
+    let old_sock = legacy.join("daemon-0.0.0.sock");
+    let old_pid_path = legacy.join("daemon-0.0.0.pid");
+    std::fs::rename(&current_sock, &old_sock).expect("rename sock");
+    std::fs::rename(&current_pid_path, &old_pid_path).expect("rename pid");
+    // rename 済みファイルを参照する Drop による空振り stop を避ける。
+    std::mem::forget(old_guard);
+
+    // 新デーモンを uid 名前空間ディレクトリで起動 → 旧命名ディレクトリも走査して
+    // 旧デーモンに Stop を送るはず。
+    let _new_guard = DaemonHandle::start_in_dir(&env, &base);
+
+    // 旧 PID が終了するまで最大 5 秒待つ
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while std::time::Instant::now() < deadline {
+        if !is_pid_alive(old_pid) {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    assert!(
+        !is_pid_alive(old_pid),
+        "old daemon (pid={old_pid}) in legacy dir should be stopped by new daemon"
+    );
+
+    // 旧命名ディレクトリのファイルがクリーンアップされていること
+    let cleanup_deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        if !old_sock.exists() && !old_pid_path.exists() {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < cleanup_deadline,
+            "old daemon files in legacy dir were not cleaned up within 5s"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
 // ── #17: daemon status の出力フォーマット ────────────────────────────────────
 
 /// #17: `daemon status`（起動中）→ "running pid=<数字> entries=<数字> uptime=<数字>s version=<文字列>"

--- a/tests/e2e/helpers/daemon_handle.rs
+++ b/tests/e2e/helpers/daemon_handle.rs
@@ -36,6 +36,21 @@ impl DaemonHandle {
     /// 追加の環境変数を指定して daemon を起動する。
     #[must_use]
     pub fn start_with_env(env: &TestEnv, extra_envs: &[(&str, &str)]) -> Self {
+        Self::start_in_base_dir(env, env.home(), extra_envs)
+    }
+
+    /// `base_dir` を指定して daemon を起動する。
+    ///
+    /// `MERGE_READY_BASE_DIR` を `base_dir` に固定するため、socket/pid を任意の名前の
+    /// ディレクトリ（例: `merge-ready-{uid}` / 旧命名 `merge-ready`）に配置できる。
+    /// クロスバージョン cleanup のように、ディレクトリ名に依存する挙動の検証で使う。
+    /// Drop 時の停止も `base_dir` に対して行う。
+    #[must_use]
+    pub fn start_in_dir(env: &TestEnv, base_dir: &Path) -> Self {
+        Self::start_in_base_dir(env, base_dir, &[])
+    }
+
+    fn start_in_base_dir(env: &TestEnv, base_dir: &Path, extra_envs: &[(&str, &str)]) -> Self {
         let bin = assert_cmd::cargo::cargo_bin("merge-ready");
 
         let mut cmd = std::process::Command::new(&bin);
@@ -43,7 +58,7 @@ impl DaemonHandle {
             .env("PATH", env.path_env())
             .env("HOME", env.home())
             .env("TMPDIR", env.home())
-            .env("MERGE_READY_BASE_DIR", env.home())
+            .env("MERGE_READY_BASE_DIR", base_dir)
             .env("XDG_CONFIG_HOME", env.home().join(".config"))
             .current_dir(env.repo.path())
             .stdin(std::process::Stdio::null())
@@ -65,7 +80,7 @@ impl DaemonHandle {
             match child.try_wait() {
                 Ok(Some(status)) => {
                     if status.success() {
-                        return DaemonHandle::new(child, env.home_tmp.path().to_path_buf());
+                        return DaemonHandle::new(child, base_dir.to_path_buf());
                     }
                     let stderr = read_pipe(child.stderr.as_mut());
                     let stdout = read_pipe(child.stdout.as_mut());


### PR DESCRIPTION
## 背景

PR #380（Closes #375）が daemon の temp ディレクトリ名を `$TMPDIR/merge-ready` → `$TMPDIR/merge-ready-{uid}` に変更した（uid による名前空間分離）。一方、旧バージョンの daemon を検出・停止する処理 `old_daemon_pid_files()` は **自分の `base_dir` しか走査しない**ため、ディレクトリ名が変わるバージョン跨ぎ（v1.0.0 → v1.0.1）では旧 daemon を発見できなくなっていた。

結果として macOS でアップグレードすると:

- v1.0.0 daemon は `$TMPDIR/merge-ready/daemon-1.0.0.pid` で稼働し続ける
- v1.0.1 の新 daemon は `$TMPDIR/merge-ready-{uid}/` だけを走査 → 別ディレクトリの旧 daemon を検知も停止もできない
- → **2 つの daemon が同時常駐**（`gh` 呼び出しの二重化、リソースリーク）

`paths.rs` の `DAEMON_VERSION` コメントが謳う「バージョン別ファイル名で複数バージョン共存時も新 daemon が旧 daemon を安全に検知・停止する」不変条件が、ディレクトリ名も同時に分けたことで壊れていた。

Closes #390

## 変更内容

**案1（cleanup の走査範囲拡張）** を採用。ディレクトリ構成は `merge-ready-{uid}` のまま変えず、公開済み v1.0.1 レイアウトに新たな移行を増やさない最小・局所的な修正。

- `old_daemon_pid_files()` が `base_dir` に加えて **pre-#380 の旧命名兄弟ディレクトリ `merge-ready`** も走査するようにした。
- 新規ヘルパー `legacy_sibling_dir()` を追加。`base_dir` が `merge-ready-{uid}`（suffix が空でなく**全て ASCII 数字**）のときだけ legacy ディレクトリを対象に含める。これにより、ランダム名のテスト用ディレクトリや他者所有の本物の `merge-ready` を誤走査しない。
- `restart.rs` / `daemon_lifecycle.rs` / `daemon_server.rs` は**無変更**（返る pid 集合に依存するだけのため、走査範囲拡張だけで自動的に機能する）。
- `DAEMON_VERSION` 周辺コメントに不変条件（将来ディレクトリ命名を変える際は走査集合と E2E を更新すること）を明文化。

### 設計上の注意

- 旧命名 `merge-ready` は v1.0.0 で全ユーザー共有だったため他ユーザーの pid が残りうるが、その PID への socket Stop は失敗、ファイル削除も `/tmp` の sticky bit で他者ファイルは消せず安全側に倒れる。
- 他 uid の `merge-ready-{otheruid}` は走査しない（#375 の分離を維持）。
- 非 unix は base 名が固定 `merge-ready` で `legacy_sibling_dir()` が `None` → 挙動不変。

## テスト

TDD（Red → Green）で実装。

- **ユニットテスト2本**（`paths.rs`）: legacy 走査が効くケース／数字 suffix でないときは走査しないケース。修正前は前者が Red、修正後は Green。
- **E2E 1本**（`lifecycle.rs`）: 旧命名ディレクトリ `merge-ready/` で生きている旧バージョン daemon を、`merge-ready-0/` で起動した新 daemon が停止・除去することを検証（#390 の回帰固定）。
- E2E ヘルパー `DaemonHandle::start_in_dir` を追加（既存 `start_with_env` と内部共通化）。

## チェック結果（全て通過）

- `cargo nextest run --workspace` ✅ 404 passed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✅
- `cargo fmt --check --all` ✅
- `scripts/check-layer-deps.sh` / `check-no-mod-rs.sh` / `check-no-clippy-allow.sh` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
