### PR TITLE
perf(daemon): process_update で output/pr_outputs の不要コピーを削減 (#386)

### DIFF
--- a/src/contexts/daemon/infrastructure/daemon_state_actor.rs
+++ b/src/contexts/daemon/infrastructure/daemon_state_actor.rs
@@ -103,7 +103,7 @@ fn handle_command(state: &mut DaemonState, cmd: DaemonCommand) {
         DaemonCommand::Process { request, reply } => {
             let config = state.config;
             let result = request_handler::process(
-                &request,
+                request,
                 &mut state.cache_store,
                 &config.policy,
                 state.started_at,

--- a/src/contexts/daemon/infrastructure/request_handler.rs
+++ b/src/contexts/daemon/infrastructure/request_handler.rs
@@ -21,7 +21,7 @@ pub(super) struct ActionResult {
 }
 
 pub(super) fn process(
-    request: &Request,
+    request: Request,
     store: &mut CacheStore,
     policy: &RefreshPolicy,
     started_at: Instant,
@@ -29,7 +29,7 @@ pub(super) fn process(
 ) -> ActionResult {
     match request {
         Request::Query { cwd } => {
-            let Some((repo_id_str, branch)) = repo_id::repo_info_from_cwd(cwd) else {
+            let Some((repo_id_str, branch)) = repo_id::repo_info_from_cwd(&cwd) else {
                 return ActionResult {
                     response: Response::Output {
                         output: String::new(),
@@ -50,9 +50,9 @@ pub(super) fn process(
             refresh_mode,
             pr_outputs,
         } => process_update(
-            &RepoId::new(repo_id.clone()),
+            &RepoId::new(repo_id),
             output,
-            *refresh_mode,
+            refresh_mode,
             pr_outputs,
             store,
         ),
@@ -114,14 +114,14 @@ fn process_query(
 /// 未知の `repo_id` への Update（ブランチ切替直後の再導出 ID など）は無視する。
 fn process_update(
     repo_id: &RepoId,
-    output: &str,
+    output: String,
     refresh_mode: RefreshMode,
-    pr_outputs: &[PrOutput],
+    pr_outputs: Vec<PrOutput>,
     store: &mut CacheStore,
 ) -> ActionResult {
     let event = RefreshCompletedEvent {
-        output: output.to_owned(),
-        pr_outputs: pr_outputs.to_vec(),
+        output,
+        pr_outputs,
         refresh_mode,
         now: Instant::now(),
         now_wall: SystemTime::now(),


### PR DESCRIPTION
## 背景

`request_handler::process` が `request` を**参照**で受けていたため、`process_update` では
`output.to_owned()` / `pr_outputs.to_vec()` により、リフレッシュ完了の `Update` リクエストごとに
不要な `String` / `Vec<PrOutput>` の複製が発生していた。

呼び出し元 `handle_command` は `request` を既に所有しており、消費側の `on_refresh_completed` は
`RefreshCompletedEvent` を**値**で受けてムーブ済み。所有権を末端まで運ぶ経路は揃っており、
`process` が参照で受けていた1点だけが複製を強制していた。

## 変更内容

- `request_handler::process` を `request: &Request` → `request: Request`（値受け）に変更
- `Request::Update` のフィールドをムーブで取り出し、`repo_id.clone()` を `RepoId::new(repo_id)` のムーブに置換
- `process_update` を `output: String` / `pr_outputs: Vec<PrOutput>` 受けに変更し、`.to_owned()` / `.to_vec()` を廃止して `RefreshCompletedEvent` へそのままムーブ
- 呼び出し元 `daemon_state_actor.rs` の `process(&request, …)` → `process(request, …)`

観測可能な振る舞いは不変。関連 Issue #384（entries 二重 deep clone）は #387 で解消済みのため本件は単独対応。

## 受け入れ条件

- [x] `process_update` で output / pr_outputs の不要コピーを削減する
- [x] 既存テストがすべて通る

## 検証

- `cargo nextest run --workspace` — 404 passed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — No issues
- `cargo fmt --check --all` — OK

Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)