### PR TITLE
fix: uptime/CACHED AT の表示を humantime で人間に読みやすい形式に変更

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,6 +533,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,6 +644,7 @@ dependencies = [
  "clap_complete",
  "criterion",
  "crossterm",
+ "humantime",
  "log",
  "nu-ansi-term",
  "predicates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ unsafe_code = "forbid"
 pedantic = "warn"
 
 [dependencies]
+humantime = "2.3.0"
 nu-ansi-term = "0.50"
 clap = { version = "4.6.1", features = ["derive", "cargo"] }
 clap_complete = "4.6.5"

--- a/src/contexts/daemon/interface/cli/daemon.rs
+++ b/src/contexts/daemon/interface/cli/daemon.rs
@@ -221,9 +221,10 @@ pub(crate) async fn status(port: &impl DaemonLifecyclePort) -> ExitCode {
 /// 起動中デーモンのステータス行を組み立てる。PID 取得不能時は `-` を表示する。
 fn format_status(s: &DaemonStatus, pid: Option<u32>) -> String {
     let pid = pid.map_or_else(|| "-".to_owned(), |p| p.to_string());
+    let uptime = humantime::format_duration(Duration::from_secs(s.uptime_secs));
     format!(
-        "running  pid={}  entries={}  uptime={}s  version={}",
-        pid, s.entries, s.uptime_secs, s.version
+        "running  pid={}  entries={}  uptime={}  version={}",
+        pid, s.entries, uptime, s.version
     )
 }
 
@@ -405,7 +406,7 @@ mod tests {
         let line = format_status(&sample_status(), None);
         assert!(line.contains("pid=-"), "got: {line}");
         assert!(line.contains("entries=3"));
-        assert!(line.contains("uptime=12s"));
+        assert!(line.contains("uptime=12s"), "got: {line}");
         assert!(line.contains("version=1.2.3"));
     }
 
@@ -413,5 +414,21 @@ mod tests {
     fn format_status_shows_pid_when_available() {
         let line = format_status(&sample_status(), Some(4242));
         assert!(line.contains("pid=4242"), "got: {line}");
+    }
+
+    // ── format_status: uptime の humantime フォーマット ────────────────────────
+
+    fn long_running_status() -> DaemonStatus {
+        DaemonStatus {
+            entries: 1,
+            uptime_secs: 93784, // 1day 2h 3m 4s
+            version: "1.2.3".to_owned(),
+        }
+    }
+
+    #[test]
+    fn format_status_shows_human_readable_uptime() {
+        let line = format_status(&long_running_status(), Some(1));
+        assert!(line.contains("uptime=1day 2h 3m 4s"), "got: {line}");
     }
 }

--- a/src/contexts/daemon/interface/cli/watch.rs
+++ b/src/contexts/daemon/interface/cli/watch.rs
@@ -202,13 +202,8 @@ fn format_cached_at(cached_at_secs: u64) -> String {
 }
 
 fn format_elapsed(elapsed_secs: u64) -> String {
-    if elapsed_secs < 60 {
-        format!("{elapsed_secs}s ago")
-    } else if elapsed_secs < 3600 {
-        format!("{}m ago", elapsed_secs / 60)
-    } else {
-        format!("{}h ago", elapsed_secs / 3600)
-    }
+    let d = Duration::from_secs(elapsed_secs);
+    format!("{} ago", humantime::format_duration(d))
 }
 
 #[cfg(test)]
@@ -337,7 +332,7 @@ mod tests {
     #[case(5, "5s ago")]
     #[case(59, "59s ago")]
     #[case(60, "1m ago")]
-    #[case(90, "1m ago")]
+    #[case(90, "1m 30s ago")]
     #[case(3600, "1h ago")]
     #[case(7200, "2h ago")]
     fn format_elapsed_various_durations(#[case] elapsed_secs: u64, #[case] expected: &str) {

--- a/tests/e2e/daemon/lifecycle.rs
+++ b/tests/e2e/daemon/lifecycle.rs
@@ -530,7 +530,7 @@ fn test_daemon_start_stops_live_old_version_in_legacy_dir() {
 
 // ── #17: daemon status の出力フォーマット ────────────────────────────────────
 
-/// #17: `daemon status`（起動中）→ "running pid=<数字> entries=<数字> uptime=<数字>s version=<文字列>"
+/// #17: `daemon status`（起動中）→ "running pid=<数字> entries=<数字> uptime=<humantime形式> version=<文字列>"
 #[test]
 fn test_daemon_status_format() {
     let env = TestEnv::new(OPEN_PR_VIEW_JSON, Some(CI_PASS_JSON));
@@ -540,8 +540,10 @@ fn test_daemon_status_format() {
     env.apply(&mut cmd);
     cmd.args(["daemon", "status"]);
     cmd.assert().success().stdout(
-        predicate::str::is_match(r"^running  pid=\d+  entries=\d+  uptime=\d+s  version=.+\n$")
-            .unwrap(),
+        predicate::str::is_match(
+            r"^running  pid=\d+  entries=\d+  uptime=\d+\w+(?:\s\d+\w+)*  version=.+\n$",
+        )
+        .unwrap(),
     );
 }
 


### PR DESCRIPTION
## Summary

- `daemon status` の uptime 表示を `6108s` → `1h41m48s` 形式（`humantime` 使用）
- `watch` の CACHED AT を `1m ago` → `1m 30s ago` 形式（端数切り捨てを廃止）
- `humantime = "2.3.0"` を依存に追加

## Test plan

- [x] ユニットテスト: `format_status`・`format_elapsed` の期待値を humantime 出力に合わせて更新
- [x] E2E テスト: `daemon status` の正規表現をスペース区切り形式に対応
- [x] `cargo nextest run --workspace` 全 405 件通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)