### PR TITLE
perf(evaluation): 設定をハッシュキャッシュ + 非同期ロードし render を前計算する

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -657,6 +657,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml",
+ "twox-hash",
 ]
 
 [[package]]
@@ -1317,6 +1318,12 @@ name = "toml_writer"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ crossterm = "0.29.0"
 bitflags = "2.11.1"
 tokio = { version = "1.52.3", features = ["full"] }
 tokio-util = { version = "0.7.18", default-features = false }
+# 設定ファイルの変更検知（非暗号学的な内容ハッシュ）に使う。独自実装を避け xxHash を利用。
+twox-hash = { version = "=2.1.2", default-features = false, features = ["xxhash3_64"] }
 
 [target.'cfg(unix)'.dependencies]
 # 全 unix で起動ユーザの uid を取得し、temp ディレクトリを名前空間分離する。

--- a/src/contexts/evaluation/domain/display_config.rs
+++ b/src/contexts/evaluation/domain/display_config.rs
@@ -1,5 +1,7 @@
 use serde::Serialize;
 
+use crate::contexts::evaluation::domain::format_parser::{CompiledSegment, compile_segments};
+
 mod defaults;
 mod render;
 
@@ -34,4 +36,81 @@ pub struct TokenConfig {
 pub struct ErrorConfig {
     pub symbol: String,
     pub format: String,
+}
+
+/// [`DisplayConfig`] をロード時に前計算した render 用の値オブジェクト。
+///
+/// 各トークンの `format` は [`CompiledSegment`] 列へ、`style` は解決済みとして
+/// 保持される。render はこのツリーを評価するだけで、`format` の再パースや
+/// `StyleSpec::parse` を行わない。
+pub struct CompiledDisplayConfig {
+    pub merge_ready: CompiledTokenConfig,
+    pub no_pull_request: CompiledTokenConfig,
+    pub conflict: CompiledTokenConfig,
+    pub update_branch: CompiledTokenConfig,
+    pub sync_unknown: CompiledTokenConfig,
+    pub ci_fail: CompiledTokenConfig,
+    pub ci_action: CompiledTokenConfig,
+    pub ci_pending: CompiledTokenConfig,
+    pub changes_requested: CompiledTokenConfig,
+    pub review_required: CompiledTokenConfig,
+    pub draft: CompiledTokenConfig,
+    pub status_calculating: CompiledTokenConfig,
+    pub blocked_unknown: CompiledTokenConfig,
+    pub error: CompiledErrorConfig,
+}
+
+pub struct CompiledTokenConfig {
+    pub symbol: String,
+    pub label: String,
+    pub segments: Vec<CompiledSegment>,
+}
+
+pub struct CompiledErrorConfig {
+    pub symbol: String,
+    pub segments: Vec<CompiledSegment>,
+}
+
+impl DisplayConfig {
+    /// 設定ロード時に一度だけ呼び、全トークンの `format` を前計算する。
+    #[must_use]
+    pub fn compile(&self) -> CompiledDisplayConfig {
+        CompiledDisplayConfig {
+            merge_ready: self.merge_ready.compile(),
+            no_pull_request: self.no_pull_request.compile(),
+            conflict: self.conflict.compile(),
+            update_branch: self.update_branch.compile(),
+            sync_unknown: self.sync_unknown.compile(),
+            ci_fail: self.ci_fail.compile(),
+            ci_action: self.ci_action.compile(),
+            ci_pending: self.ci_pending.compile(),
+            changes_requested: self.changes_requested.compile(),
+            review_required: self.review_required.compile(),
+            draft: self.draft.compile(),
+            status_calculating: self.status_calculating.compile(),
+            blocked_unknown: self.blocked_unknown.compile(),
+            error: self.error.compile(),
+        }
+    }
+}
+
+impl TokenConfig {
+    #[must_use]
+    pub fn compile(&self) -> CompiledTokenConfig {
+        CompiledTokenConfig {
+            symbol: self.symbol.clone(),
+            label: self.label.clone(),
+            segments: compile_segments(&self.format),
+        }
+    }
+}
+
+impl ErrorConfig {
+    #[must_use]
+    pub fn compile(&self) -> CompiledErrorConfig {
+        CompiledErrorConfig {
+            symbol: self.symbol.clone(),
+            segments: compile_segments(&self.format),
+        }
+    }
 }

--- a/src/contexts/evaluation/domain/display_config/render.rs
+++ b/src/contexts/evaluation/domain/display_config/render.rs
@@ -1,46 +1,44 @@
-use super::{ErrorConfig, TokenConfig};
-use crate::contexts::evaluation::domain::format_parser::{Segment, parse_segments};
-use crate::contexts::evaluation::domain::style_spec::StyleSpec;
+use super::{CompiledErrorConfig, CompiledTokenConfig};
+use crate::contexts::evaluation::domain::format_parser::CompiledSegment;
 
 /// `pr_ids` が `Some` の場合は `$pr_ids` を置換する。`None` の場合は `$pr_ids` を literal のまま残す。
 /// 値は `#1734 #2669` のように `#` 付き・スペース区切り（複数 PR 時）か、空文字（単一 PR 時）。
 /// `(...)` ブロック内の変数がすべて空の場合、そのブロックは出力されない。
+///
+/// `token` は前計算済みの [`CompiledTokenConfig`]。`format` パースと `StyleSpec::parse`
+/// はロード時に済んでいるので、ここでは変数置換とツリー評価だけを行う。
 #[must_use]
-pub fn render_token(token: &TokenConfig, pr_ids: Option<&str>) -> String {
+pub fn render_token(token: &CompiledTokenConfig, pr_ids: Option<&str>) -> String {
     let mut vars: Vec<(&str, &str)> = vec![("symbol", &token.symbol), ("label", &token.label)];
     if let Some(ids) = pr_ids {
         vars.push(("pr_ids", ids));
     }
-    render_with_vars(&token.format, &vars)
+    eval_segments(&token.segments, &vars)
 }
 
 #[must_use]
-pub fn render_error_token(config: &ErrorConfig, message: &str) -> String {
+pub fn render_error_token(config: &CompiledErrorConfig, message: &str) -> String {
     let vars: Vec<(&str, &str)> = vec![("symbol", &config.symbol), ("message", message)];
-    render_with_vars(&config.format, &vars)
+    eval_segments(&config.segments, &vars)
 }
 
-fn render_with_vars(format: &str, vars: &[(&str, &str)]) -> String {
-    eval_segments(&parse_segments(format), vars)
-}
-
-fn eval_segments(segs: &[Segment], vars: &[(&str, &str)]) -> String {
+fn eval_segments(segs: &[CompiledSegment], vars: &[(&str, &str)]) -> String {
     segs.iter().map(|s| eval_segment(s, vars)).collect()
 }
 
-fn eval_segment(seg: &Segment, vars: &[(&str, &str)]) -> String {
+fn eval_segment(seg: &CompiledSegment, vars: &[(&str, &str)]) -> String {
     match seg {
-        Segment::Text(t) => substitute_vars(t, vars),
-        Segment::Styled { content, style_str } => StyleSpec::parse(style_str)
+        CompiledSegment::Text(t) => substitute_vars(t, vars),
+        CompiledSegment::Styled { content, style } => style
             .to_ansi_style()
-            .paint(eval_segments(&parse_segments(content), vars))
+            .paint(eval_segments(content, vars))
             .to_string(),
-        Segment::Conditional(inner) => eval_conditional(inner, vars),
+        CompiledSegment::Conditional(inner) => eval_conditional(inner, vars),
     }
 }
 
 /// `(...)` ブロックの評価: 内包する変数がすべて空（またはマップにない）場合は非表示。
-fn eval_conditional(inner: &[Segment], vars: &[(&str, &str)]) -> String {
+fn eval_conditional(inner: &[CompiledSegment], vars: &[(&str, &str)]) -> String {
     let refs = collect_var_refs(inner);
     if refs.is_empty() {
         return String::new();
@@ -57,19 +55,15 @@ fn eval_conditional(inner: &[Segment], vars: &[(&str, &str)]) -> String {
     }
 }
 
-/// Segment ツリーから `$varname` 参照を収集する。
-fn collect_var_refs(segs: &[Segment]) -> Vec<&str> {
+/// `CompiledSegment` ツリーから `$varname` 参照を収集する。
+fn collect_var_refs(segs: &[CompiledSegment]) -> Vec<&str> {
     let mut refs = Vec::new();
     for seg in segs {
-        let text = match seg {
-            Segment::Text(t) => t.as_str(),
-            Segment::Styled { content, .. } => content.as_str(),
-            Segment::Conditional(inner) => {
-                refs.extend(collect_var_refs(inner));
-                continue;
-            }
-        };
-        extract_var_names(text, &mut refs);
+        match seg {
+            CompiledSegment::Text(t) => extract_var_names(t, &mut refs),
+            CompiledSegment::Styled { content, .. } => refs.extend(collect_var_refs(content)),
+            CompiledSegment::Conditional(inner) => refs.extend(collect_var_refs(inner)),
+        }
     }
     refs
 }
@@ -135,7 +129,17 @@ fn substitute_vars(s: &str, vars: &[(&str, &str)]) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::contexts::evaluation::domain::display_config::{ErrorConfig, TokenConfig};
+
+    // テストは `TokenConfig`/`ErrorConfig` を一度 compile してから render する。
+    // 期待する出力契約は前計算化の前後で不変。
+    fn render_token(token: &TokenConfig, pr_ids: Option<&str>) -> String {
+        super::render_token(&token.compile(), pr_ids)
+    }
+
+    fn render_error_token(config: &ErrorConfig, message: &str) -> String {
+        super::render_error_token(&config.compile(), message)
+    }
 
     #[test]
     fn render_error_token_substitutes_symbol_and_message() {

--- a/src/contexts/evaluation/domain/format_parser.rs
+++ b/src/contexts/evaluation/domain/format_parser.rs
@@ -1,3 +1,5 @@
+use crate::contexts::evaluation::domain::style_spec::StyleSpec;
+
 enum Either<L, R> {
     Left(L),
     Right(R),
@@ -8,6 +10,43 @@ pub(crate) enum Segment {
     Text(String),
     Styled { content: String, style_str: String },
     Conditional(Vec<Segment>),
+}
+
+/// `Segment` をロード時に前計算した render 用の値オブジェクト。
+///
+/// `Styled` は `style_str` を解決済み [`StyleSpec`] として、`content` を再帰
+/// compile 済みの `Vec<CompiledSegment>` として保持する。これにより render 時は
+/// `parse_segments` も `StyleSpec::parse` も呼ばずツリーを評価するだけで済む。
+#[derive(Debug, PartialEq)]
+pub(crate) enum CompiledSegment {
+    Text(String),
+    Styled {
+        content: Vec<CompiledSegment>,
+        style: StyleSpec,
+    },
+    Conditional(Vec<CompiledSegment>),
+}
+
+/// `format` 文字列を一度だけパースし、各 `Segment` を前計算済みの
+/// [`CompiledSegment`] へ変換する。設定ロード時に一度だけ呼ぶ。
+pub(crate) fn compile_segments(format: &str) -> Vec<CompiledSegment> {
+    parse_segments(format)
+        .into_iter()
+        .map(compile_segment)
+        .collect()
+}
+
+fn compile_segment(segment: Segment) -> CompiledSegment {
+    match segment {
+        Segment::Text(t) => CompiledSegment::Text(t),
+        Segment::Styled { content, style_str } => CompiledSegment::Styled {
+            content: compile_segments(&content),
+            style: StyleSpec::parse(&style_str),
+        },
+        Segment::Conditional(inner) => {
+            CompiledSegment::Conditional(inner.into_iter().map(compile_segment).collect())
+        }
+    }
 }
 
 /// `[text](style)` および `(content)` 構文を `Segment` 列に分解する。
@@ -183,5 +222,34 @@ mod tests {
     )]
     fn styled_segment_cases(#[case] input: &str, #[case] expected: Vec<Segment>) {
         assert_eq!(parse_segments(input), expected);
+    }
+
+    // ── compile_segments: parse_segments + StyleSpec::parse の前計算 ─────────────
+
+    #[test]
+    fn compile_resolves_style_and_nests_content() {
+        use crate::contexts::evaluation::domain::style_spec::StyleSpec;
+
+        assert_eq!(
+            compile_segments("[$symbol](bold green) $label"),
+            vec![
+                CompiledSegment::Styled {
+                    content: vec![CompiledSegment::Text("$symbol".to_owned())],
+                    style: StyleSpec::parse("bold green"),
+                },
+                CompiledSegment::Text(" $label".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn compile_preserves_conditional_and_plain_text() {
+        assert_eq!(
+            compile_segments("$symbol $label( $pr_ids)"),
+            vec![
+                CompiledSegment::Text("$symbol $label".to_owned()),
+                CompiledSegment::Conditional(vec![CompiledSegment::Text(" $pr_ids".to_owned())]),
+            ]
+        );
     }
 }

--- a/src/contexts/evaluation/infrastructure/toml_loader.rs
+++ b/src/contexts/evaluation/infrastructure/toml_loader.rs
@@ -1,21 +1,70 @@
 use serde::Deserialize;
 use std::path::PathBuf;
+use std::sync::{Arc, Mutex, OnceLock};
 
 use crate::contexts::evaluation::domain::display_config::{
-    DisplayConfig, ErrorConfig, TokenConfig,
+    CompiledDisplayConfig, DisplayConfig, ErrorConfig, TokenConfig,
 };
 
-/// 設定ファイルから `DisplayConfig` を読み込む。
-/// 環境変数で決まるパスを参照し、ファイルが無い／壊れている場合は default で埋める。
-#[must_use]
-pub fn load_display_config() -> DisplayConfig {
-    let Some(path) = config_path() else {
-        return DisplayConfig::default();
-    };
-    let Ok(content) = std::fs::read_to_string(&path) else {
-        return DisplayConfig::default();
-    };
-    let raw: RawDisplayConfig = toml::from_str(&content).unwrap_or_default();
+struct CachedConfig {
+    fingerprint: Option<u64>,
+    config: Arc<CompiledDisplayConfig>,
+}
+
+/// プロセス内に保持する前計算済み設定キャッシュ。daemon は単一プロセスで設定ファイルも
+/// 1 つなので、プロセスグローバルなキャッシュで足りる。
+static CONFIG_CACHE: OnceLock<Mutex<Option<CachedConfig>>> = OnceLock::new();
+
+/// 設定ファイルを非同期で読み込み、前計算済みの [`CompiledDisplayConfig`] を返す。
+///
+/// ファイル内容の xxHash 指紋をメモリに保持し、指紋が前回と一致する場合は前計算済みの
+/// 結果（`Arc`）をそのまま返す。ファイルが変更されたとき（または初回）だけ TOML パース・
+/// デフォルトマージ・format/style の前計算をやり直す。これにより daemon リフレッシュ経路で
+/// 不変な設定を毎回再パースする無駄をなくす。
+pub async fn load_compiled_display_config() -> Arc<CompiledDisplayConfig> {
+    let content = read_config_bytes().await;
+    let fp = fingerprint(content.as_deref());
+
+    let cache = CONFIG_CACHE.get_or_init(|| Mutex::new(None));
+    // ファイル読み込み（await）はロック取得前に完了している。ロック保持中は await しない
+    // ので、std の Mutex で安全に扱える。
+    if let Some(hit) = {
+        let guard = cache.lock().expect("config cache mutex poisoned");
+        guard
+            .as_ref()
+            .filter(|cached| cached.fingerprint == fp)
+            .map(|cached| Arc::clone(&cached.config))
+    } {
+        return hit;
+    }
+
+    let display = content
+        .as_deref()
+        .and_then(|bytes| std::str::from_utf8(bytes).ok())
+        .map_or_else(DisplayConfig::default, parse_display_config);
+    let compiled = Arc::new(display.compile());
+
+    *cache.lock().expect("config cache mutex poisoned") = Some(CachedConfig {
+        fingerprint: fp,
+        config: Arc::clone(&compiled),
+    });
+    compiled
+}
+
+/// 設定ファイルの内容を非同期で読み込む。ファイル不在・読取不可なら `None`。
+async fn read_config_bytes() -> Option<Vec<u8>> {
+    tokio::fs::read(config_path()?).await.ok()
+}
+
+/// 設定ファイル内容の xxHash 指紋。内容が無い（ファイル不在等）場合は `None`。
+/// 変更検知が目的でセキュリティ用途ではないため、高速な非暗号学的ハッシュを使う。
+fn fingerprint(content: Option<&[u8]>) -> Option<u64> {
+    content.map(twox_hash::XxHash3_64::oneshot)
+}
+
+/// TOML 文字列を `DisplayConfig` にパースする。壊れた TOML は default で埋める。
+fn parse_display_config(content: &str) -> DisplayConfig {
+    let raw: RawDisplayConfig = toml::from_str(content).unwrap_or_default();
     merge_with_defaults(raw)
 }
 
@@ -99,4 +148,45 @@ struct RawTokenConfig {
 struct RawErrorConfig {
     symbol: Option<String>,
     format: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fingerprint_is_none_for_absent_content() {
+        assert_eq!(fingerprint(None), None);
+    }
+
+    #[test]
+    fn fingerprint_is_stable_for_same_content() {
+        assert_eq!(fingerprint(Some(b"abc")), fingerprint(Some(b"abc")));
+    }
+
+    #[test]
+    fn fingerprint_differs_for_changed_content() {
+        assert_ne!(fingerprint(Some(b"abc")), fingerprint(Some(b"abd")));
+    }
+
+    #[test]
+    fn fingerprint_distinguishes_empty_file_from_absent() {
+        // 空ファイル（存在する）と不在（None）は別物として扱われる。
+        assert!(fingerprint(Some(b"")).is_some());
+    }
+
+    #[test]
+    fn parse_display_config_applies_overrides() {
+        let parsed = parse_display_config("[merge_ready]\nsymbol = \"★\"");
+        assert_eq!(parsed.merge_ready.symbol, "★");
+    }
+
+    #[test]
+    fn parse_display_config_invalid_toml_uses_defaults() {
+        let parsed = parse_display_config("][[[ not valid toml");
+        assert_eq!(
+            parsed.merge_ready.symbol,
+            DisplayConfig::default().merge_ready.symbol
+        );
+    }
 }

--- a/src/contexts/evaluation/interface/prompt.rs
+++ b/src/contexts/evaluation/interface/prompt.rs
@@ -2,7 +2,7 @@ use crate::contexts::evaluation::application::errors::ErrorToken;
 use crate::contexts::evaluation::application::prompt::display_item::DisplayItem;
 use crate::contexts::evaluation::application::prompt::to_display_items;
 use crate::contexts::evaluation::domain::display_config::{
-    DisplayConfig, TokenConfig, render_error_token, render_token,
+    CompiledDisplayConfig, CompiledTokenConfig, render_error_token, render_token,
 };
 use crate::contexts::evaluation::domain::prompt::{PrId, Prompt};
 use crate::shared::refresh_mode::RefreshMode;
@@ -18,7 +18,10 @@ pub struct RenderResult {
 /// 取得済みの `Prompt`／`ErrorToken` と表示設定だけからレンダリング結果を組み立てる
 /// **純関数**。I/O を持たないので、テストはこの関数を直接呼べばよい。
 #[must_use]
-pub fn render(prompt_result: Result<Prompt, ErrorToken>, config: &DisplayConfig) -> RenderResult {
+pub fn render(
+    prompt_result: Result<Prompt, ErrorToken>,
+    config: &CompiledDisplayConfig,
+) -> RenderResult {
     match prompt_result {
         Ok(Prompt::NoRepository | Prompt::UnsupportedRepository | Prompt::DefaultBranch) => {
             RenderResult {
@@ -88,7 +91,7 @@ pub fn render(prompt_result: Result<Prompt, ErrorToken>, config: &DisplayConfig)
 }
 
 /// watch 表示用に PR の各ステータストークンを ID なしでレンダリングし、スペース区切りで連結する。
-fn render_watch_items(display_items: &[DisplayItem], config: &DisplayConfig) -> String {
+fn render_watch_items(display_items: &[DisplayItem], config: &CompiledDisplayConfig) -> String {
     display_items
         .iter()
         .map(|item| render_token(item_to_token(*item, config), Some("")))
@@ -123,7 +126,7 @@ fn join_pr_ids(ids: &[PrId]) -> String {
         .join(" ")
 }
 
-fn item_to_token(item: DisplayItem, config: &DisplayConfig) -> &TokenConfig {
+fn item_to_token(item: DisplayItem, config: &CompiledDisplayConfig) -> &CompiledTokenConfig {
     match item {
         DisplayItem::MergeReady => &config.merge_ready,
         DisplayItem::Conflict => &config.conflict,
@@ -140,7 +143,7 @@ fn item_to_token(item: DisplayItem, config: &DisplayConfig) -> &TokenConfig {
     }
 }
 
-fn render_error(token: &ErrorToken, config: &DisplayConfig) -> String {
+fn render_error(token: &ErrorToken, config: &CompiledDisplayConfig) -> String {
     render_error_token(&config.error, &token.message)
 }
 
@@ -155,7 +158,7 @@ mod tests {
     };
 
     fn render_ok(p: Prompt) -> RenderResult {
-        render(Ok(p), &DisplayConfig::default())
+        render(Ok(p), &DisplayConfig::default().compile())
     }
 
     // ── RefreshMode 導出 ────────────────────────────────────────────────────
@@ -224,7 +227,7 @@ mod tests {
             Err(ErrorToken {
                 message: "unexpected error".to_owned(),
             }),
-            &DisplayConfig::default(),
+            &DisplayConfig::default().compile(),
         );
         assert_eq!(result.refresh_mode, RefreshMode::Warm);
     }
@@ -337,7 +340,7 @@ mod tests {
 
     #[test]
     fn error_renders_with_message() {
-        let config = DisplayConfig::default();
+        let config = DisplayConfig::default().compile();
         let token = ErrorToken {
             message: "authentication required".to_owned(),
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ use crate::contexts::daemon::infrastructure::paths::Paths;
 use crate::contexts::evaluation::application::errors::into_token;
 use crate::contexts::evaluation::infrastructure::gh::fetch_prompt;
 use crate::contexts::evaluation::infrastructure::logger::log_repository_error;
-use crate::contexts::evaluation::infrastructure::toml_loader::load_display_config;
+use crate::contexts::evaluation::infrastructure::toml_loader::load_compiled_display_config;
 use crate::contexts::evaluation::interface::prompt::render;
 use crate::shared::protocol::PrOutput;
 
@@ -41,7 +41,7 @@ fn refresh_callback(
             log_repository_error(e);
             into_token(e)
         });
-        let config = load_display_config();
+        let config = load_compiled_display_config().await;
         let result = render(prompt_result, &config);
 
         let pr_outputs = result


### PR DESCRIPTION
## 背景

daemon のリフレッシュ経路（`src/lib.rs` の `refresh_callback`）は、毎 tick（hot 2〜10s / warm 180s）ごとに次を繰り返していた:

1. `load_display_config()` で設定ファイルを **同期** 読込 + TOML パース + デフォルトマージ
2. `render` 内で `parse_segments(format)` と `StyleSpec::parse(style_str)` を **毎回** 実行

設定ファイルは実行中ほぼ不変なのに変更検知の仕組みがなく、不要な再読込・再パースが発生していた。

## 変更内容

設定ファイルを **非同期で読み込み + 内容ハッシュ（xxHash）でキャッシュゲート** し、ファイルが変更されたときだけ「TOML パース + デフォルトマージ + format/style の前計算」をやり直すようにした。render は前計算済みツリーを評価するだけになる。

### Domain（前計算）
- `format_parser.rs`: `CompiledSegment` / `compile_segments()` を追加。`parse_segments` を一度だけ実行し `StyleSpec::parse` を解決済みで保持。
- `display_config.rs`: `CompiledDisplayConfig` / `CompiledTokenConfig` / `CompiledErrorConfig` と `DisplayConfig::compile()` を追加。`DisplayConfig` は `Serialize` のまま据え置き（デフォルト設定書き出しに必要）。
- `render.rs`: `render_token` / `render_error_token` / eval を `CompiledSegment` ベースに変更。render 経路から `parse_segments` / `StyleSpec::parse` を削除。

### Infrastructure（非同期 + ハッシュ + キャッシュ）
- `toml_loader.rs`: `load_compiled_display_config()` を追加。`tokio::fs` で非同期読込 → `twox_hash::XxHash3_64::oneshot` で指紋計算 → `OnceLock<Mutex<..>>` キャッシュと照合し、一致なら `Arc<CompiledDisplayConfig>` を再利用、不一致/初回のみパース + compile。ロックは `await` をまたがない。

### Shell / 依存
- `lib.rs`: `refresh_callback` を `load_compiled_display_config().await` 経由に。
- `Cargo.toml`: `twox-hash`（MIT, `default-features = false, features = ["xxhash3_64"]`）を追加。`rand` 等は引き込まず Cargo.lock +7 行のみ。

## #385 受け入れ条件

- [x] format のパースは設定ロード時に一度だけ行う
- [x] `StyleSpec::parse` を render のたびに呼ばない
- [x] 既存の render テスト・E2E テストがすべて通る

## テスト

- 既存 E2E（`tests/e2e/prompt/style.rs`・`tests/e2e/config/token_customization.rs`）が compile/render 経路を end-to-end で網羅し回帰スイートとして機能。
- 純粋関数にユニットテスト追加: `compile_segments`・`fingerprint`・`parse_display_config`。

## 検証

- `cargo build` / `clippy --workspace --all-targets --all-features -- -D warnings`（No issues）/ `fmt --check`
- `cargo nextest run --workspace` → 413 passed
- `cargo deny check` → advisories/bans/licenses/sources ok
- `check-layer-deps` / `check-no-mod-rs` / `check-no-clippy-allow` OK

## 補足

`load_display_config` の呼び出しは daemon のバックグラウンド・リフレッシュ経路のみで、`merge-ready-prompt` は socket 経由でレンダリング済みキャッシュ文字列を受け取るだけ。本変更の効果は prompt 応答の直接短縮ではなく、リフレッシュ処理の軽量化（毎 tick の再読込・再パース除去）。

Closes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)
