### PR TITLE
chore(cliff): rename changelog group "Bug Fixes" to "Fixes"

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -28,7 +28,7 @@ split_commits = false
 commit_preprocessors = []
 commit_parsers = [
   { message = "^feat",  group = "Features" },
-  { message = "^fix",   group = "Bug Fixes" },
+  { message = "^fix",   group = "Fixes" },
   { message = "^perf",  group = "Performance" },
   { message = ".*",     skip = true },
 ]


### PR DESCRIPTION
## Summary

- `cliff.toml` の changelog グループ名 `"Bug Fixes"` を `"Fixes"` に変更

## Test plan

- [x] `CHANGELOG.md` 生成時に `fix:` コミットが `Fixes` セクションに表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)