### PR TITLE
chore: 依存バージョン指定を major/minor 粒度に統一する

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,15 @@ To fix a violation:
 foo/bar/mod.rs  →  rename to foo/bar.rs  (keep the content as-is)
 ```
 
+## Dependency Versioning
+
+Specify dependency versions in `Cargo.toml` at **major** or **major.minor** granularity (e.g. `"2"` / `"0.29"`).
+
+- Use `"major"` for crates with `version >= 1` (e.g. `"1"`, `"2"`).
+- Use `"0.minor"` for pre-1.0 crates, since semver treats minor bumps as breaking in that range.
+- **Exact pins (`=x.y.z`) are reserved for working around a known library bug.** When used, add a comment explaining why.
+- Reproducibility is provided by the committed `Cargo.lock` (and `--locked` when needed), not by `Cargo.toml` pins.
+
 ## Commit Convention
 
 Follow [Conventional Commits](https://www.conventionalcommits.org/). Only `feat`, `fix`, and `perf` commits appear in the changelog (`cliff.toml`).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,26 +18,26 @@ unsafe_code = "forbid"
 pedantic = "warn"
 
 [dependencies]
-humantime = "2.3.0"
+humantime = "2"
 nu-ansi-term = "0.50"
-clap = { version = "4.6.1", features = ["derive", "cargo"] }
-clap_complete = "4.6.5"
+clap = { version = "4", features = ["derive", "cargo"] }
+clap_complete = "4"
 log = "0.4"
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.150"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 simplelog = "0.12"
-toml = "1.1.2"
-crossterm = "0.29.0"
-bitflags = "2.11.1"
-tokio = { version = "1.52.3", features = ["full"] }
-tokio-util = { version = "0.7.18", default-features = false }
+toml = "1"
+crossterm = "0.29"
+bitflags = "2"
+tokio = { version = "1", features = ["full"] }
+tokio-util = { version = "0.7", default-features = false }
 # 設定ファイルの変更検知（非暗号学的な内容ハッシュ）に使う。独自実装を避け xxHash を利用。
-twox-hash = { version = "=2.1.2", default-features = false, features = ["xxhash3_64"] }
+twox-hash = { version = "2", default-features = false, features = ["xxhash3_64"] }
 
 [target.'cfg(unix)'.dependencies]
 # 全 unix で起動ユーザの uid を取得し、temp ディレクトリを名前空間分離する。
 # `unsafe_code = "forbid"` のため libc の生 FFI ではなく safe な rustix を使う。
-rustix = { version = "1.1.4", features = ["process"] }
+rustix = { version = "1", features = ["process"] }
 
 [lib]
 name = "merge_ready"
@@ -56,13 +56,13 @@ name = "e2e"
 path = "tests/e2e/mod.rs"
 
 [dev-dependencies]
-assert_cmd = "2.2.2"
-criterion = { version = "0.8.2", features = ["html_reports"] }
-predicates = "3.1.4"
-rstest = "0.26.1"
-serde_json = "1.0.150"
-tempfile = "3.27.0"
-tokio = { version = "1.52.3", features = ["test-util"] }
+assert_cmd = "2"
+criterion = { version = "0.8", features = ["html_reports"] }
+predicates = "3"
+rstest = "0.26"
+serde_json = "1"
+tempfile = "3"
+tokio = { version = "1", features = ["test-util"] }
 
 [[bench]]
 name = "hot_path"


### PR DESCRIPTION
## Summary

- `twox-hash` の厳密ピン（`=2.1.2`）を含む全依存を `major` または `0.minor` 形式に揃える
- 再現性は `Cargo.lock` で担保するため `Cargo.toml` 側のパッチ指定は不要
- CONTRIBUTING.md に依存バージョン指定方針を明文化する

Closes #398

## Test plan

- [ ] `cargo build` が通ること（ローカル確認済み）
- [ ] CI の `cargo nextest run`、`clippy`、`fmt`、`deny` が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)