### PR TITLE
chore: テストの match 検証を assert_matches! に置換し MSRV を 1.96 に上げる

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "merge-ready"
 version = "1.0.2"
 edition = "2024"
-rust-version = "1.95"
+rust-version = "1.96"
 description = "Show pull request merge blockers as concise prompt tokens"
 license = "MIT"
 repository = "https://github.com/toshiki670/merge-ready"

--- a/src/contexts/daemon/domain/cache/transition.rs
+++ b/src/contexts/daemon/domain/cache/transition.rs
@@ -405,6 +405,7 @@ mod tests {
 
     use super::super::entry::FetchState;
     use super::*;
+    use std::assert_matches;
 
     fn test_policy() -> RefreshPolicy {
         RefreshPolicy {
@@ -454,7 +455,7 @@ mod tests {
 
         assert_eq!(effects.len(), 2);
         assert_eq!(effects[0], Effect::EmitOutput("? loading".to_owned()));
-        assert!(matches!(effects[1], Effect::SpawnRefresh { .. }));
+        assert_matches!(effects[1], Effect::SpawnRefresh { .. });
         assert_eq!(new_store.entries().len(), 1);
         let entry = new_store.entries().get(&repo_id).expect("entry present");
         assert_eq!(entry.fetch_state(), FetchState::Loading);
@@ -497,7 +498,7 @@ mod tests {
 
         assert_eq!(effects.len(), 2);
         assert_eq!(effects[0], Effect::EmitOutput("hello".to_owned()));
-        assert!(matches!(effects[1], Effect::SpawnRefresh { .. }));
+        assert_matches!(effects[1], Effect::SpawnRefresh { .. });
         let new_entry = new_store.entries().get(&repo_id).expect("entry present");
         assert_eq!(new_entry.fetch_state(), FetchState::Refreshing);
     }

--- a/src/contexts/daemon/infrastructure/socket_listener.rs
+++ b/src/contexts/daemon/infrastructure/socket_listener.rs
@@ -102,6 +102,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches;
     use std::io::{Error, ErrorKind};
     use tempfile::tempdir;
 
@@ -114,7 +115,7 @@ mod tests {
         let paths = Paths::new(bogus);
 
         let err = bind(&paths).await.unwrap_err();
-        assert!(matches!(err, DaemonError::Failure));
+        assert_matches!(err, DaemonError::Failure);
     }
 
     #[tokio::test]
@@ -128,7 +129,7 @@ mod tests {
         )
         .await
         .unwrap_err();
-        assert!(matches!(err, DaemonError::Failure));
+        assert_matches!(err, DaemonError::Failure);
     }
 
     #[tokio::test]
@@ -144,7 +145,7 @@ mod tests {
         )
         .await
         .unwrap_err();
-        assert!(matches!(err, DaemonError::AlreadyRunning));
+        assert_matches!(err, DaemonError::AlreadyRunning);
         // retry_max=2 のため、初回 + 2 リトライ = 計 3 回試行してから上限到達。
         assert_eq!(calls, 3);
     }

--- a/src/contexts/daemon/interface/cli/daemon.rs
+++ b/src/contexts/daemon/interface/cli/daemon.rs
@@ -233,6 +233,7 @@ mod tests {
     use std::os::unix::process::ExitStatusExt as _;
 
     use super::*;
+    use std::assert_matches;
 
     // ── interpret: 監視結果 → 終了コードの純粋な分岐 ───────────────────────────
 
@@ -302,26 +303,20 @@ mod tests {
     #[test]
     fn exit_info_from_wait_success() {
         let status = ExitStatus::from_raw(0);
-        assert!(matches!(
-            ExitInfo::from_wait(&Ok(status)),
-            ExitInfo::Success
-        ));
+        assert_matches!(ExitInfo::from_wait(&Ok(status)), ExitInfo::Success);
     }
 
     #[test]
     fn exit_info_from_wait_failure_captures_code() {
         // Unix の raw wait status は「終了コード << 8」。code 7 を表現する。
         let status = ExitStatus::from_raw(7 << 8);
-        assert!(matches!(
-            ExitInfo::from_wait(&Ok(status)),
-            ExitInfo::Failure(Some(7))
-        ));
+        assert_matches!(ExitInfo::from_wait(&Ok(status)), ExitInfo::Failure(Some(7)));
     }
 
     #[test]
     fn exit_info_from_wait_error() {
         let err = Err(std::io::Error::other("wait failed"));
-        assert!(matches!(ExitInfo::from_wait(&err), ExitInfo::WaitError));
+        assert_matches!(ExitInfo::from_wait(&err), ExitInfo::WaitError);
     }
 
     // ── Exit → ExitCode 変換 ───────────────────────────────────────────────────
@@ -358,7 +353,7 @@ mod tests {
             Duration::from_secs(5),
         )
         .await;
-        assert!(matches!(result, StartResult::SpawnFailed(_)));
+        assert_matches!(result, StartResult::SpawnFailed(_));
     }
 
     #[tokio::test]
@@ -370,7 +365,7 @@ mod tests {
             Duration::from_millis(100),
         )
         .await;
-        assert!(matches!(result, StartResult::Timeout(_)));
+        assert_matches!(result, StartResult::Timeout(_));
     }
 
     #[tokio::test]
@@ -384,7 +379,7 @@ mod tests {
         .await;
         match result {
             StartResult::EarlyExit { exit, stderr } => {
-                assert!(matches!(exit, ExitInfo::Failure(Some(3))));
+                assert_matches!(exit, ExitInfo::Failure(Some(3)));
                 assert_eq!(stderr, "oops\n");
             }
             other => panic!("expected EarlyExit, got: {other:?}"),

--- a/src/contexts/evaluation/application/prompt.rs
+++ b/src/contexts/evaluation/application/prompt.rs
@@ -17,6 +17,7 @@ mod tests {
     use crate::contexts::evaluation::domain::prompt::{
         PrId, PullRequest, State, pull_request::state::unblocked::UnblockedState,
     };
+    use std::assert_matches;
 
     #[test]
     fn to_display_items_maps_states() {
@@ -28,6 +29,6 @@ mod tests {
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].0, PrId::new(1));
         assert_eq!(items[0].1.len(), 1);
-        assert!(matches!(items[0].1[0], DisplayItem::MergeReady));
+        assert_matches!(items[0].1[0], DisplayItem::MergeReady);
     }
 }

--- a/src/contexts/evaluation/application/prompt/display_item.rs
+++ b/src/contexts/evaluation/application/prompt/display_item.rs
@@ -4,7 +4,7 @@ use crate::contexts::evaluation::domain::prompt::pull_request::state::blocked::{
 };
 use crate::contexts::evaluation::domain::prompt::pull_request::state::unblocked::UnblockedState;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DisplayItem {
     Conflict,
     UpdateBranch,

--- a/src/contexts/evaluation/domain/prompt/pull_request/state.rs
+++ b/src/contexts/evaluation/domain/prompt/pull_request/state.rs
@@ -49,21 +49,19 @@ pub fn evaluate(
 mod tests {
     use super::*;
     use blocked::{BranchSyncState, CiState, GenericBlockedState, ReviewState};
+    use std::assert_matches;
     use unblocked::UnblockedState;
 
     #[test]
     fn returns_merge_ready_when_no_blockers() {
         let state = evaluate(None, None, None, Some(UnblockedState::MergeReady));
-        assert!(matches!(
-            state,
-            State::Unblocked(UnblockedState::MergeReady)
-        ));
+        assert_matches!(state, State::Unblocked(UnblockedState::MergeReady));
     }
 
     #[test]
     fn returns_draft_when_draft_pr() {
         let state = evaluate(None, None, None, Some(UnblockedState::Draft));
-        assert!(matches!(state, State::Unblocked(UnblockedState::Draft)));
+        assert_matches!(state, State::Unblocked(UnblockedState::Draft));
     }
 
     #[test]
@@ -102,7 +100,7 @@ mod tests {
             None,
             Some(UnblockedState::MergeReady),
         );
-        assert!(matches!(state, State::Blocked(_)));
+        assert_matches!(state, State::Blocked(_));
     }
 
     #[test]

--- a/src/contexts/evaluation/infrastructure/gh/error.rs
+++ b/src/contexts/evaluation/infrastructure/gh/error.rs
@@ -1,5 +1,6 @@
 use crate::contexts::evaluation::domain::error::RepositoryError;
 
+#[derive(Debug)]
 pub(super) enum GhError {
     NotInstalled,
     AuthRequired,
@@ -45,33 +46,34 @@ pub(super) fn classify_gh_error(exit_code: i32, stderr: &str) -> GhError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches;
 
     #[test]
     fn classify_auth_exit_code() {
-        assert!(matches!(classify_gh_error(4, ""), GhError::AuthRequired));
+        assert_matches!(classify_gh_error(4, ""), GhError::AuthRequired);
     }
 
     #[test]
     fn classify_no_pr_message() {
-        assert!(matches!(
+        assert_matches!(
             classify_gh_error(1, "no pull requests found"),
             GhError::NoPr
-        ));
+        );
     }
 
     #[test]
     fn classify_rate_limit_message() {
-        assert!(matches!(
+        assert_matches!(
             classify_gh_error(1, "API rate limit exceeded"),
             GhError::RateLimited
-        ));
+        );
     }
 
     #[test]
     fn classify_non_github_remote_message() {
-        assert!(matches!(
+        assert_matches!(
             classify_gh_error(1, "no git remotes found"),
             GhError::NotGithubRepository
-        ));
+        );
     }
 }

--- a/src/contexts/evaluation/infrastructure/gh/schema.rs
+++ b/src/contexts/evaluation/infrastructure/gh/schema.rs
@@ -138,6 +138,7 @@ pub(super) struct GhCompare {
 }
 
 /// CI チェックの集計用カテゴリ。`aggregate_ci` が消費する。
+#[derive(Debug)]
 pub(super) enum CheckBucket {
     Fail,
     Cancel,
@@ -180,6 +181,7 @@ pub(super) fn context_to_bucket(ctx: &CheckContext) -> CheckBucket {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches;
 
     fn check_run(status: &str, conclusion: Option<&str>) -> CheckContext {
         CheckContext::CheckRun {
@@ -200,97 +202,97 @@ mod tests {
 
     #[test]
     fn check_run_in_progress_is_pending() {
-        assert!(matches!(
+        assert_matches!(
             context_to_bucket(&check_run("IN_PROGRESS", None)),
             CheckBucket::Pending
-        ));
+        );
     }
 
     #[test]
     fn check_run_queued_is_pending() {
-        assert!(matches!(
+        assert_matches!(
             context_to_bucket(&check_run("QUEUED", None)),
             CheckBucket::Pending
-        ));
+        );
     }
 
     #[test]
     fn check_run_success_is_other() {
-        assert!(matches!(
+        assert_matches!(
             context_to_bucket(&check_run("COMPLETED", Some("SUCCESS"))),
             CheckBucket::Other
-        ));
+        );
     }
 
     #[test]
     fn check_run_skipped_is_other() {
-        assert!(matches!(
+        assert_matches!(
             context_to_bucket(&check_run("COMPLETED", Some("SKIPPED"))),
             CheckBucket::Other
-        ));
+        );
     }
 
     #[test]
     fn check_run_failure_is_fail() {
-        assert!(matches!(
+        assert_matches!(
             context_to_bucket(&check_run("COMPLETED", Some("FAILURE"))),
             CheckBucket::Fail
-        ));
+        );
     }
 
     #[test]
     fn check_run_timed_out_is_fail() {
-        assert!(matches!(
+        assert_matches!(
             context_to_bucket(&check_run("COMPLETED", Some("TIMED_OUT"))),
             CheckBucket::Fail
-        ));
+        );
     }
 
     #[test]
     fn check_run_cancelled_is_cancel() {
-        assert!(matches!(
+        assert_matches!(
             context_to_bucket(&check_run("COMPLETED", Some("CANCELLED"))),
             CheckBucket::Cancel
-        ));
+        );
     }
 
     #[test]
     fn check_run_action_required_is_action_required() {
-        assert!(matches!(
+        assert_matches!(
             context_to_bucket(&check_run("COMPLETED", Some("ACTION_REQUIRED"))),
             CheckBucket::ActionRequired
-        ));
+        );
     }
 
     #[test]
     fn status_context_success_is_other() {
-        assert!(matches!(
+        assert_matches!(
             context_to_bucket(&status_context("SUCCESS")),
             CheckBucket::Other
-        ));
+        );
     }
 
     #[test]
     fn status_context_pending_is_pending() {
-        assert!(matches!(
+        assert_matches!(
             context_to_bucket(&status_context("PENDING")),
             CheckBucket::Pending
-        ));
+        );
     }
 
     #[test]
     fn status_context_error_is_fail() {
-        assert!(matches!(
+        assert_matches!(
             context_to_bucket(&status_context("ERROR")),
             CheckBucket::Fail
-        ));
+        );
     }
 
     #[test]
     fn unknown_typename_is_other() {
-        assert!(matches!(
+        assert_matches!(
             context_to_bucket(&CheckContext::Unknown),
             CheckBucket::Other
-        ));
+        );
     }
 }

--- a/src/shared/process_gh.rs
+++ b/src/shared/process_gh.rs
@@ -87,6 +87,7 @@ async fn run_program(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches;
 
     /// `NotFound` 以外の spawn 失敗（ディレクトリを実行 → `PermissionDenied`）は
     /// panic せず `GhProcessError::Io` として返ること（Issue #377）。
@@ -120,6 +121,6 @@ mod tests {
             None,
         )
         .await;
-        assert!(matches!(result, Err(GhProcessError::NotInstalled)));
+        assert_matches!(result, Err(GhProcessError::NotInstalled));
     }
 }


### PR DESCRIPTION
## 概要

Rust 1.96 で安定化した `assert_matches!` を採用する。1.96 の新機能をコードベースと突き合わせた結果、実際に適用できるのは `assert_matches!` のみだった（新 Range 型・`NonZero` の range ループ・`cfg` の `expr` メタ変数等は対象コードなし）。

## 変更内容

- `assert!(matches!(...))` を `assert_matches!(...)` に **32 箇所**置換（8 ファイル）。失敗時に左辺の実値を `Debug` 出力するようになり診断が改善する。
- 各テストモジュールに `use std::assert_matches;` を追加。
  - 1.96 の `assert_matches!` は `std::assert_matches::assert_matches`（モジュール経路）ではなく**クレートルート直下**に再エクスポートされている（`pub use core::{assert_matches, debug_assert_matches}`）。
- `assert_matches!` が要求する `Debug` を `GhError` / `CheckBucket` / `DisplayItem` に derive 追加。
- `Cargo.toml`: `rust-version = "1.95"` → `"1.96"`。README/CONTRIBUTING/CI に他の MSRV 記載はなく更新不要。

## 検証

- `cargo nextest run --workspace` … **410 passed**
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` … No issues
- `cargo fmt --check --all` … OK
- `scripts/check-no-mod-rs.sh` / `check-no-clippy-allow.sh` / `check-layer-deps.sh` … すべて OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)