### PR TITLE
chore: ratio_bp / RATIO_SCALE と RefreshFn の重複定義を一本化する

### DIFF
--- a/src/contexts/daemon/domain/cache/transition.rs
+++ b/src/contexts/daemon/domain/cache/transition.rs
@@ -18,8 +18,6 @@ use crate::contexts::daemon::domain::rate_limit_snapshot::RateLimitSnapshot;
 use crate::contexts::daemon::domain::refresh_policy::RefreshPolicy;
 use crate::shared::refresh_mode::RefreshMode;
 
-/// `bottleneck_ratio` の basis points スケール（10000 == 1.0）。
-const RATIO_SCALE_BP: u64 = 10_000;
 /// ボトルネック残量比率がこの値（basis points）以下になったら backoff へ。
 const BACKOFF_THRESHOLD_BP: u64 = 500; // 5%
 
@@ -293,16 +291,7 @@ fn should_enter_backoff(snapshot: &RateLimitSnapshot) -> bool {
     if snapshot.is_exhausted() {
         return true;
     }
-    let core_bp = ratio_bp(snapshot.core_remaining, snapshot.core_limit);
-    let graphql_bp = ratio_bp(snapshot.graphql_remaining, snapshot.graphql_limit);
-    core_bp.min(graphql_bp) <= BACKOFF_THRESHOLD_BP
-}
-
-fn ratio_bp(remaining: u32, limit: u32) -> u64 {
-    if limit == 0 {
-        return RATIO_SCALE_BP;
-    }
-    (u64::from(remaining).saturating_mul(RATIO_SCALE_BP)) / u64::from(limit)
+    snapshot.bottleneck_ratio_bp() <= BACKOFF_THRESHOLD_BP
 }
 
 /// `snapshot.reset_at`（壁時計）を `Instant`（モノトニック）へ変換し、

--- a/src/contexts/daemon/domain/rate_limit_snapshot.rs
+++ b/src/contexts/daemon/domain/rate_limit_snapshot.rs
@@ -1,5 +1,17 @@
 use std::time::{Instant, SystemTime};
 
+/// `bottleneck_ratio` の basis points スケール（10000 == 1.0）。
+pub const RATIO_SCALE_BP: u64 = 10_000;
+
+/// `remaining / limit` を basis points（0..=`RATIO_SCALE_BP`）で返す。
+/// `limit == 0` のリソースは比率不定として `RATIO_SCALE_BP`（=1.0）を採用する。
+fn ratio_bp(remaining: u32, limit: u32) -> u64 {
+    if limit == 0 {
+        return RATIO_SCALE_BP;
+    }
+    (u64::from(remaining).saturating_mul(RATIO_SCALE_BP)) / u64::from(limit)
+}
+
 /// `gh api rate_limit` から得た残量スナップショット。
 ///
 /// `core` と `graphql` の両方を保持し、両者のうち消費比率の高い側を
@@ -26,6 +38,16 @@ impl RateLimitSnapshot {
     #[must_use]
     pub fn is_exhausted(&self) -> bool {
         self.core_remaining == 0 || self.graphql_remaining == 0
+    }
+
+    /// `min(core_ratio, graphql_ratio)` を basis points（0..=`RATIO_SCALE_BP`）で返す。
+    /// 消費比率の高い側（残量比率の小さい側）をボトルネックとみなす。
+    /// `limit == 0` のリソースは比率不定として採用優先順位から外れる。両方 0 なら
+    /// `RATIO_SCALE_BP`。
+    #[must_use]
+    pub fn bottleneck_ratio_bp(&self) -> u64 {
+        ratio_bp(self.core_remaining, self.core_limit)
+            .min(ratio_bp(self.graphql_remaining, self.graphql_limit))
     }
 }
 
@@ -81,5 +103,26 @@ mod tests {
     fn is_exhausted_false_when_both_have_remaining() {
         let s = snapshot(1, 5000, 1, 5000, SystemTime::now());
         assert!(!s.is_exhausted());
+    }
+
+    #[test]
+    fn bottleneck_ratio_bp_picks_smaller_side() {
+        // core 50% (5000 bp) と graphql 10% (1000 bp) → 小さい方 1000 bp。
+        let s = snapshot(5000, 10_000, 1000, 10_000, SystemTime::now());
+        assert_eq!(s.bottleneck_ratio_bp(), 1000);
+    }
+
+    #[test]
+    fn bottleneck_ratio_bp_full_when_remaining_is_full() {
+        let s = snapshot(10_000, 10_000, 10_000, 10_000, SystemTime::now());
+        assert_eq!(s.bottleneck_ratio_bp(), RATIO_SCALE_BP);
+    }
+
+    #[test]
+    fn bottleneck_ratio_bp_treats_zero_limit_as_full() {
+        // limit == 0 は比率不定 → RATIO_SCALE_BP として採用優先順位から外れ、
+        // もう一方（graphql 25% = 2500 bp）が採用される。
+        let s = snapshot(0, 0, 2500, 10_000, SystemTime::now());
+        assert_eq!(s.bottleneck_ratio_bp(), 2500);
     }
 }

--- a/src/contexts/daemon/domain/refresh_policy.rs
+++ b/src/contexts/daemon/domain/refresh_policy.rs
@@ -1,11 +1,8 @@
 use std::time::{Instant, SystemTime};
 
 use crate::contexts::daemon::domain::cache::{CacheEntryState, has_recent_query, is_cold};
-use crate::contexts::daemon::domain::rate_limit_snapshot::RateLimitSnapshot;
+use crate::contexts::daemon::domain::rate_limit_snapshot::{RATIO_SCALE_BP, RateLimitSnapshot};
 use crate::shared::refresh_mode::RefreshMode;
-
-/// `bottleneck_ratio` の basis points スケール（10000 == 1.0）。
-const RATIO_SCALE: u64 = 10_000;
 
 /// 安全マージン（残量から 5% を予備として控除）。`budget * SAFETY_NUM / SAFETY_DEN`。
 const SAFETY_NUM: u64 = 95;
@@ -152,7 +149,7 @@ impl RefreshPolicy {
 
         let mode = self.effective_mode(entry, now);
         let params = scaling_params(mode);
-        let ratio_bp = bottleneck_ratio_bp(snapshot);
+        let ratio_bp = snapshot.bottleneck_ratio_bp();
         let secs_until_reset = snapshot
             .secs_until_reset(now_wall)
             .min(RESET_WINDOW_CAP_SECS);
@@ -197,35 +194,17 @@ fn bottleneck_budget(snapshot: &RateLimitSnapshot) -> u32 {
     snapshot.core_remaining.min(snapshot.graphql_remaining)
 }
 
-/// `min(remaining/limit)` を basis points（0..=`RATIO_SCALE`）で返す。
-/// `limit == 0` のリソースは比率不定として `RATIO_SCALE`（=1.0）を採用し、
-/// 採用優先順位から外す。両方 0 なら `RATIO_SCALE`。
-fn bottleneck_ratio_bp(snapshot: &RateLimitSnapshot) -> u64 {
-    let core = ratio_bp(snapshot.core_remaining, snapshot.core_limit);
-    let graphql = ratio_bp(snapshot.graphql_remaining, snapshot.graphql_limit);
-    core.min(graphql)
-}
-
-fn ratio_bp(remaining: u32, limit: u32) -> u64 {
-    if limit == 0 {
-        return RATIO_SCALE;
-    }
-    let lim = u64::from(limit);
-    let rem = u64::from(remaining);
-    (rem.saturating_mul(RATIO_SCALE)) / lim
-}
-
 /// `base * (1 + alpha * (1 - ratio)^2)` を整数演算で計算する。
-/// `alpha_x10` は α を 10 倍したスケール、`ratio_bp` は ratio を `RATIO_SCALE` 倍したスケール。
+/// `alpha_x10` は α を 10 倍したスケール、`ratio_bp` は ratio を `RATIO_SCALE_BP` 倍したスケール。
 fn compute_ratio_term(base: u64, ratio_bp: u64, alpha_x10: u64) -> u64 {
-    let one_minus_r = RATIO_SCALE.saturating_sub(ratio_bp);
+    let one_minus_r = RATIO_SCALE_BP.saturating_sub(ratio_bp);
     // (1 - r)^2 in basis points
-    let one_minus_r_sq_bp = one_minus_r.saturating_mul(one_minus_r) / RATIO_SCALE;
-    // bonus = base * alpha_x10 * one_minus_r_sq_bp / (SCALE_X10 * RATIO_SCALE)
+    let one_minus_r_sq_bp = one_minus_r.saturating_mul(one_minus_r) / RATIO_SCALE_BP;
+    // bonus = base * alpha_x10 * one_minus_r_sq_bp / (SCALE_X10 * RATIO_SCALE_BP)
     let bonus_numer = base
         .saturating_mul(alpha_x10)
         .saturating_mul(one_minus_r_sq_bp);
-    let bonus = bonus_numer / (SCALE_X10.saturating_mul(RATIO_SCALE));
+    let bonus = bonus_numer / (SCALE_X10.saturating_mul(RATIO_SCALE_BP));
     base.saturating_add(bonus)
 }
 
@@ -247,14 +226,16 @@ fn compute_budget_term(
 ) -> u64 {
     let safety = u64::from(budget_remaining).saturating_mul(SAFETY_NUM) / SAFETY_DEN;
     let safety = safety.max(1);
-    let depletion_bp = RATIO_SCALE.saturating_sub(ratio_bp);
+    let depletion_bp = RATIO_SCALE_BP.saturating_sub(ratio_bp);
     // numer = cost * window * weight_x10 * depletion_bp
     let numer = total_cost_per_cycle
         .saturating_mul(secs_until_reset)
         .saturating_mul(weight_x10)
         .saturating_mul(depletion_bp);
-    // denom = safety * SCALE_X10 * RATIO_SCALE
-    let denom = safety.saturating_mul(SCALE_X10).saturating_mul(RATIO_SCALE);
+    // denom = safety * SCALE_X10 * RATIO_SCALE_BP
+    let denom = safety
+        .saturating_mul(SCALE_X10)
+        .saturating_mul(RATIO_SCALE_BP);
     if denom == 0 {
         return u64::MAX;
     }

--- a/src/contexts/daemon/infrastructure/daemon_lifecycle.rs
+++ b/src/contexts/daemon/infrastructure/daemon_lifecycle.rs
@@ -1,18 +1,13 @@
-use std::future::Future;
-use std::path::{Path, PathBuf};
-use std::pin::Pin;
+use std::path::Path;
 use std::time::Duration;
 
 use crate::contexts::daemon::application::port::{EntryView, WatchPort};
-use crate::contexts::daemon::domain::cache::RepoId;
 use crate::contexts::daemon::domain::daemon::{DaemonError, DaemonLifecyclePort, DaemonStatus};
 
+use super::daemon_server::RefreshFn;
 use super::paths::Paths;
 use super::{daemon_client::DaemonClient, daemon_server, pid};
 
-/// Imperative Shell から渡される、副作用を含むリフレッシュ実装。
-/// async 関数ポインタとして受け取ることで、キャプチャを禁じ依存を明示する。
-pub type RefreshFn = fn(RepoId, PathBuf) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
 const STOP_TIMEOUT: Duration = Duration::from_secs(2);
 
 pub struct DaemonLifecycle {
@@ -119,9 +114,14 @@ impl WatchPort for DaemonLifecycle {
 
 #[cfg(test)]
 mod tests {
+    use std::future::Future;
+    use std::path::PathBuf;
+    use std::pin::Pin;
+
     use tempfile::tempdir;
 
     use super::*;
+    use crate::contexts::daemon::domain::cache::RepoId;
 
     fn noop_refresh(
         _repo_id: RepoId,


### PR DESCRIPTION
## 概要

Closes #415

daemon コンテキスト内に同一実装が 2 箇所ずつ定義されていたのを単一情報源化し、片方だけ変更されて判定基準がズレる drift リスクを解消する。**挙動変更なしの純リファクタ。**

## 変更内容

### 1. `ratio_bp` / basis points スケール定数 → `RateLimitSnapshot` へ集約

- `rate_limit_snapshot.rs` に `pub const RATIO_SCALE_BP`・private `ratio_bp`・`pub fn bottleneck_ratio_bp(&self)` を追加
- `transition.rs`（backoff 判定）と `refresh_policy.rs`（スケーリング計算）の重複ローカル定義を削除し、両者とも `snapshot.bottleneck_ratio_bp()` / `RATIO_SCALE_BP` を参照
- `should_enter_backoff` は `snapshot.bottleneck_ratio_bp() <= BACKOFF_THRESHOLD_BP` に簡約

### 2. `RefreshFn` 型エイリアス → `daemon_server` へ一本化

- `daemon_lifecycle.rs` の重複エイリアスを削除し `use super::daemon_server::RefreshFn;` に統一
- `daemon_lifecycle → daemon_server` の既存依存方向に沿うため循環参照は生じない
- test 専用になった import は `mod tests` 側へ移設

## テスト

- `bottleneck_ratio_bp` の characterisation 用 unit test を 3 件追加（通常ケース／残量フル／`limit == 0` の比率不定ケース）
- 既存テスト（`on_rate_limit_observed` 系・`effective_refresh_interval_secs_scaled` 系）が backoff 閾値・スケーリング結果の不変を保証

## 検証

- `cargo build` ✅
- `cargo nextest run --workspace` ✅ 413 passed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✅
- `cargo fmt --check --all` ✅
- `check-layer-deps.sh` / `check-no-clippy-allow.sh` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)