### PR TITLE
chore(daemon): rate_limit_client の stale な #[allow(dead_code)] と未配線の force_refresh を整理する

### DIFF
--- a/src/contexts/daemon/infrastructure/rate_limit_client.rs
+++ b/src/contexts/daemon/infrastructure/rate_limit_client.rs
@@ -11,7 +11,6 @@ use serde::Deserialize;
 use crate::contexts::daemon::domain::rate_limit_snapshot::RateLimitSnapshot;
 use crate::shared::process_gh::{GhProcessError, run_gh};
 
-#[allow(dead_code)] // 後続コミットで daemon_server が起動するまでの間
 pub(super) struct RateLimitClient {
     cache: Mutex<Option<RateLimitSnapshot>>,
     ttl: Duration,
@@ -35,7 +34,6 @@ struct ResourceInfo {
     reset: u64,
 }
 
-#[allow(dead_code)]
 impl RateLimitClient {
     pub(super) fn new(ttl: Duration) -> Self {
         Self {
@@ -50,11 +48,6 @@ impl RateLimitClient {
         if let Some(snap) = self.cached_if_fresh() {
             return Some(snap);
         }
-        self.force_refresh().await
-    }
-
-    /// 強制的に再取得する（403 受信時の即時参照用）。
-    pub(super) async fn force_refresh(&self) -> Option<RateLimitSnapshot> {
         let snap = raw_fetch().await?;
         let mut guard = self.cache.lock().unwrap_or_else(PoisonError::into_inner);
         *guard = Some(snap);


### PR DESCRIPTION
## 背景

`src/contexts/daemon/infrastructure/rate_limit_client.rs` に、`daemon_server` 起動までの暫定として付けられた `#[allow(dead_code)]` が残っていた。コメントの「後続コミット」は既に完了しており（`daemon_server.rs` が `RateLimitClient::new` を、`rate_limit_fetcher.rs` が `fetch_or_cached` を使用済み）、この attribute は stale で本来働くべき dead code 検知を隠していた。

その陰で `force_refresh`（doc コメント「403 受信時の即時参照用」）が**どこからも呼ばれていない**未配線状態だった。

## 変更内容（修正案 A）

Issue の修正案 A を採用:

- 構造体・impl の `#[allow(dead_code)]` を 2 箇所とも削除
- 未配線の `force_refresh` を削除し、唯一の呼び出し元だった `fetch_or_cached` に中身をインライン化
- 観測可能な挙動は不変（既存テストはそのまま通過）

403 受信時の即時 backoff（案 B）は、`evaluation`→`daemon` のコンテキストを跨ぐ配線と、キャプチャ禁止な `RefreshFn` 設計の変更を伴う feat 相当の規模になるため見送り。必要になった時点で改めて実装する。

## 検証

- `cargo build` — dead_code 警告なし（検知が復活しても未使用箇所は出ない）
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — クリーン
- `cargo nextest run --workspace` — 410 passed
- `cargo fmt --check --all` — OK

Closes #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)