### PR TITLE
fix: 空・相対の XDG_CONFIG_HOME/XDG_CACHE_HOME を無効として扱う

### DIFF
--- a/src/contexts/evaluation/infrastructure.rs
+++ b/src/contexts/evaluation/infrastructure.rs
@@ -2,3 +2,4 @@ pub mod gh;
 pub mod git;
 pub mod logger;
 pub mod toml_loader;
+mod xdg;

--- a/src/contexts/evaluation/infrastructure/logger.rs
+++ b/src/contexts/evaluation/infrastructure/logger.rs
@@ -20,7 +20,7 @@ pub struct LogRecord {
 }
 
 /// デーモン起動時に一度だけ呼ぶ。
-/// `$HOME/.cache/merge-ready/error.log` への追記ロガーを初期化する。
+/// `<cache>/merge-ready/error.log` への追記ロガーを初期化する。
 /// 失敗は静かに無視する（ログが書けなくてもデーモンは止まらない）。
 pub fn init() {
     let Some(path) = log_path() else { return };
@@ -30,9 +30,14 @@ pub fn init() {
     let _ = WriteLogger::init(LevelFilter::Error, Config::default(), file);
 }
 
+// XDG_CACHE_HOME が有効な絶対パスならそちらを優先し、無効（未設定・空・相対パス）なら
+// $HOME/.cache にフォールバックする。設定 (XDG 対応) とログの解決方針を揃える。
 fn log_path() -> Option<PathBuf> {
-    let home = std::env::var_os("HOME")?;
-    let dir = std::path::Path::new(&home).join(".cache/merge-ready");
+    let base = match super::xdg::base_dir("XDG_CACHE_HOME") {
+        Some(dir) => dir,
+        None => PathBuf::from(std::env::var_os("HOME")?).join(".cache"),
+    };
+    let dir = base.join("merge-ready");
     std::fs::create_dir_all(&dir).ok()?;
     Some(dir.join("error.log"))
 }

--- a/src/contexts/evaluation/infrastructure/toml_loader.rs
+++ b/src/contexts/evaluation/infrastructure/toml_loader.rs
@@ -109,14 +109,15 @@ fn merge_error(raw: Option<RawErrorConfig>, default: ErrorConfig) -> ErrorConfig
     }
 }
 
-// XDG_CONFIG_HOME が設定されていればそちらを優先し、なければ $HOME/.config にフォールバックする。
+// XDG_CONFIG_HOME が有効な絶対パスならそちらを優先し、無効（未設定・空・相対パス）なら
+// $HOME/.config にフォールバックする。
 #[must_use]
 pub fn config_path() -> Option<PathBuf> {
-    if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
-        return Some(PathBuf::from(xdg).join("merge-ready.toml"));
-    }
-    let home = std::env::var_os("HOME")?;
-    Some(PathBuf::from(home).join(".config").join("merge-ready.toml"))
+    let base = match super::xdg::base_dir("XDG_CONFIG_HOME") {
+        Some(dir) => dir,
+        None => PathBuf::from(std::env::var_os("HOME")?).join(".config"),
+    };
+    Some(base.join("merge-ready.toml"))
 }
 
 #[derive(Deserialize, Default)]

--- a/src/contexts/evaluation/infrastructure/xdg.rs
+++ b/src/contexts/evaluation/infrastructure/xdg.rs
@@ -1,0 +1,48 @@
+//! XDG Base Directory 仕様に基づくベースディレクトリ解決。
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+/// 環境変数 `var` を XDG ベースディレクトリとして解決する。
+///
+/// XDG Base Directory 仕様では各環境変数は**絶対パス**でなければならず、
+/// 未設定・空文字・相対パスはすべて無効とみなす。無効な場合は `None` を返し、
+/// 呼び出し側でデフォルト（`$HOME/...`）へフォールバックさせる。
+pub(crate) fn base_dir(var: &str) -> Option<PathBuf> {
+    resolve(std::env::var_os(var))
+}
+
+/// 解決ロジック本体。グローバルな環境に触れない純粋関数なので、相対パス・空文字の
+/// 扱いを単体テストで固定できる（E2E では cwd 依存になり安定検証が難しい）。
+fn resolve(value: Option<OsString>) -> Option<PathBuf> {
+    let path = PathBuf::from(value?);
+    path.is_absolute().then_some(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unset_is_none() {
+        assert_eq!(resolve(None), None);
+    }
+
+    #[test]
+    fn empty_is_ignored() {
+        assert_eq!(resolve(Some(OsString::from(""))), None);
+    }
+
+    #[test]
+    fn relative_is_ignored() {
+        assert_eq!(resolve(Some(OsString::from("relative/dir"))), None);
+    }
+
+    #[test]
+    fn absolute_is_used() {
+        assert_eq!(
+            resolve(Some(OsString::from("/abs/dir"))),
+            Some(PathBuf::from("/abs/dir"))
+        );
+    }
+}

--- a/tests/e2e/config/config_path.rs
+++ b/tests/e2e/config/config_path.rs
@@ -1,7 +1,8 @@
-//! `config_path()` の環境変数によるパス解決を検証する E2E テスト（シナリオ #49–50）
+//! `config_path()` の環境変数によるパス解決を検証する E2E テスト（シナリオ #49–51）
 //!
 //! - #49: `XDG_CONFIG_HOME` が設定されている → そちらの設定ファイルを優先する
 //! - #50: `XDG_CONFIG_HOME` と `HOME` 両方ある → `XDG_CONFIG_HOME` が勝つ
+//! - #51: `XDG_CONFIG_HOME` が空文字 → 無効として無視し `$HOME/.config` にフォールバックする
 
 use assert_cmd::Command;
 
@@ -31,6 +32,30 @@ fn test_xdg_config_home_is_used() {
         &env,
         &[("XDG_CONFIG_HOME", xdg_dir.path().to_str().unwrap())],
     );
+
+    DaemonHandle::wait_for_cache(&env, 5000);
+
+    let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
+    env.apply_with_cache(&mut cmd);
+    cmd.assert()
+        .success()
+        .stdout("★ Ready for merge")
+        .stderr("");
+}
+
+/// #51: `XDG_CONFIG_HOME` が空文字 → 無効として無視し `$HOME/.config` を読む。
+///
+/// XDG Base Directory 仕様では空の値は未設定として扱う。空文字を `Some` として
+/// 受け入れると設定パスがカレントディレクトリ相対の `merge-ready.toml` に化けるため、
+/// 確実に `$HOME/.config` 側の設定が読まれることを検証する。
+#[test]
+fn test_empty_xdg_config_home_falls_back_to_home() {
+    let env = TestEnv::new(MERGE_READY_JSON, Some(CHECKS_PASS_JSON));
+    // HOME 側にデフォルト (`✓`) とは異なるシンボルを置く。空の XDG_CONFIG_HOME が
+    // 無視されればこれが読まれ、相対パスへ化けてデフォルトになることはない。
+    env.write_config("[merge_ready]\nsymbol = \"★\"");
+
+    let _daemon = DaemonHandle::start_with_env(&env, &[("XDG_CONFIG_HOME", "")]);
 
     DaemonHandle::wait_for_cache(&env, 5000);
 

--- a/tests/e2e/daemon/logging.rs
+++ b/tests/e2e/daemon/logging.rs
@@ -1,0 +1,53 @@
+//! daemon のログ出力先パス解決を検証する E2E テスト（シナリオ #52–53）
+//!
+//! `logger::init()` は daemon 起動時に `<cache>/merge-ready/error.log` を作成する。
+//! daemon を起動してファイルの生成先を確認することでパス解決を検証できる。
+//!
+//! - #52: `XDG_CACHE_HOME` が有効な絶対パス → そこに `merge-ready/error.log` を作る
+//! - #53: `XDG_CACHE_HOME` が空文字 → 無効として無視し `$HOME/.cache` にフォールバックする
+
+use tempfile::tempdir;
+
+use super::super::helpers::{DaemonHandle, TestEnv};
+
+const MERGE_READY_JSON: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED"}"#;
+const CHECKS_PASS_JSON: &str =
+    r#"[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]"#;
+
+/// #52: `XDG_CACHE_HOME` が有効な絶対パス → そこに `merge-ready/error.log` を作る
+#[test]
+fn test_xdg_cache_home_is_used_for_log() {
+    let env = TestEnv::new(MERGE_READY_JSON, Some(CHECKS_PASS_JSON));
+    let cache_dir = tempdir().expect("tempdir");
+
+    let _daemon = DaemonHandle::start_with_env(
+        &env,
+        &[("XDG_CACHE_HOME", cache_dir.path().to_str().unwrap())],
+    );
+
+    let log = cache_dir.path().join("merge-ready").join("error.log");
+    assert!(
+        log.exists(),
+        "expected log file under XDG_CACHE_HOME at {}",
+        log.display()
+    );
+}
+
+/// #53: `XDG_CACHE_HOME` が空文字 → 無効として無視し `$HOME/.cache` にフォールバックする
+#[test]
+fn test_empty_xdg_cache_home_falls_back_to_home() {
+    let env = TestEnv::new(MERGE_READY_JSON, Some(CHECKS_PASS_JSON));
+
+    let _daemon = DaemonHandle::start_with_env(&env, &[("XDG_CACHE_HOME", "")]);
+
+    let log = env
+        .home()
+        .join(".cache")
+        .join("merge-ready")
+        .join("error.log");
+    assert!(
+        log.exists(),
+        "expected log file under $HOME/.cache at {}",
+        log.display()
+    );
+}

--- a/tests/e2e/daemon/mod.rs
+++ b/tests/e2e/daemon/mod.rs
@@ -1,2 +1,3 @@
 mod lifecycle;
+mod logging;
 mod watch;

--- a/tests/e2e/helpers/daemon_handle.rs
+++ b/tests/e2e/helpers/daemon_handle.rs
@@ -49,6 +49,10 @@ impl DaemonHandle {
             .env("TMPDIR", env.home())
             .env("MERGE_READY_BASE_DIR", base_dir)
             .env("XDG_CONFIG_HOME", env.home().join(".config"))
+            // ログ出力先も隔離 HOME 配下に固定し、実行環境の XDG_CACHE_HOME が
+            // 紛れ込んでテスト用ログが外部へ漏れるのを防ぐ。個別テストは
+            // extra_envs で上書きできる。
+            .env("XDG_CACHE_HOME", env.home().join(".cache"))
             .current_dir(env.repo.path())
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::piped())


### PR DESCRIPTION
## 概要

XDG Base Directory 仕様では各環境変数は**絶対パス**でなければならず、空文字・相対パスは未設定とみなしてデフォルトへフォールバックすべき。従来の実装は 2 点で仕様に反していた。Closes #414

## 問題

- `config_path()`: `XDG_CONFIG_HOME=""`（空文字）でも `Some` 扱いになり、設定パスがカレントディレクトリ相対の `merge-ready.toml` に化けていた。
- `log_path()`: `$HOME/.cache` 固定で `XDG_CACHE_HOME` を参照せず、設定（XDG 対応）とログ（非対応）で解決方針が不一致だった。

## 変更内容

- 共通の解決ロジックを `infrastructure/xdg.rs` の純粋関数 `base_dir` に抽出。未設定・空文字・相対パスをすべて無効（`None`）として扱う。
- `config_path()`: 無効時は `$HOME/.config` にフォールバック。
- `log_path()`: `XDG_CACHE_HOME`（同じく空・相対は無効）→ `$HOME/.cache` の順で解決。
- テストヘルパー（`DaemonHandle`）は `XDG_CACHE_HOME` を隔離 HOME 配下に固定し、実行環境の値が紛れ込んでテスト用ログが外部へ漏れるのを防ぐ。

## テスト（TDD: Red → Green）

純粋関数の単体テスト + E2E で検証（CONTRIBUTING の方針に沿い、cwd 依存になる相対パスのみ単体テスト）。

- 単体（`xdg::tests`）: 未設定 / 空 / 相対 → `None`、絶対 → `Some`
- E2E #51: 空 `XDG_CONFIG_HOME` → `$HOME/.config` を読む
- E2E #52: 有効な `XDG_CACHE_HOME` → そこに `merge-ready/error.log` を作る
- E2E #53: 空 `XDG_CACHE_HOME` → `$HOME/.cache` にフォールバック

## ローカル確認

- `cargo nextest run --workspace`: 420 passed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean
- `cargo fmt --check --all`: clean
- `check-layer-deps.sh` / `check-no-mod-rs.sh` / `check-no-clippy-allow.sh`: OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)