### PR TITLE
fix(daemon): logger のレベルを MERGE_READY_LOG_LEVEL で可変にし既定を warn へ

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,16 @@ CWD              BRANCH          STATUS             CACHED AT
 
 `watch` polls the daemon once per second and redraws the table in place. If the daemon is not running it prints `daemon is not running` and exits immediately.
 
+### Diagnostics
+
+The daemon writes diagnostic logs to `merge-ready/error.log` under `$XDG_CACHE_HOME` (falling back to `~/.cache`).
+
+The log level defaults to `warn`, which records operationally important events such as rate-limit backoff entry, rate-limit fetch failures, and daemon self-termination. Set `MERGE_READY_LOG_LEVEL` to one of `off`, `error`, `warn`, `info`, `debug`, or `trace` (case-insensitive) to change the verbosity. Unknown values fall back to `warn`.
+
+```bash
+MERGE_READY_LOG_LEVEL=info merge-ready daemon start
+```
+
 ## Starship Integration
 
 Add merge status to your [Starship](https://starship.rs/) prompt by using a custom command module in `~/.config/starship.toml`:

--- a/src/contexts/daemon/infrastructure/rate_limit_fetcher.rs
+++ b/src/contexts/daemon/infrastructure/rate_limit_fetcher.rs
@@ -38,7 +38,7 @@ pub(super) async fn run(
                     let effects = state_handle.apply_rate_limit(event).await;
                     for e in effects {
                         if let Effect::EnterBackoff { until } = e {
-                            log::info!("rate_limit backoff until {until:?}");
+                            log::warn!("rate_limit backoff until {until:?}");
                         }
                     }
                 }

--- a/src/contexts/daemon/infrastructure/socket_watcher.rs
+++ b/src/contexts/daemon/infrastructure/socket_watcher.rs
@@ -24,7 +24,7 @@ pub(super) async fn run(paths: Arc<Paths>, interval_secs: u64, cancel: Cancellat
             () = cancel.cancelled() => break,
             _ = ticker.tick() => {
                 if !paths.socket_path().exists() {
-                    log::info!("daemon socket disappeared, self-terminating");
+                    log::warn!("daemon socket disappeared, self-terminating");
                     cancel.cancel();
                     break;
                 }

--- a/src/contexts/evaluation/infrastructure/logger.rs
+++ b/src/contexts/evaluation/infrastructure/logger.rs
@@ -27,7 +27,27 @@ pub fn init() {
     let Ok(file) = OpenOptions::new().create(true).append(true).open(path) else {
         return;
     };
-    let _ = WriteLogger::init(LevelFilter::Error, Config::default(), file);
+    let _ = WriteLogger::init(log_level(), Config::default(), file);
+}
+
+/// `MERGE_READY_LOG_LEVEL` からロガーの記録レベルを決める。
+/// 既定は `warn`（backoff 突入・`rate_limit` 取得失敗・daemon 自己終了といった
+/// 運用上重要なイベントを残すため）。
+fn log_level() -> LevelFilter {
+    parse_log_level(std::env::var("MERGE_READY_LOG_LEVEL").ok().as_deref())
+}
+
+/// `off`/`error`/`warn`/`info`/`debug`/`trace`（大文字小文字無視）を解釈する。
+/// 未設定・空・不明値は `warn`。
+fn parse_log_level(value: Option<&str>) -> LevelFilter {
+    match value.map(|v| v.trim().to_ascii_lowercase()).as_deref() {
+        Some("off") => LevelFilter::Off,
+        Some("error") => LevelFilter::Error,
+        Some("info") => LevelFilter::Info,
+        Some("debug") => LevelFilter::Debug,
+        Some("trace") => LevelFilter::Trace,
+        _ => LevelFilter::Warn,
+    }
 }
 
 // XDG_CACHE_HOME が有効な絶対パスならそちらを優先し、無効（未設定・空・相対パス）なら
@@ -64,5 +84,37 @@ pub fn log_repository_error(e: RepositoryError) {
             category: ErrorCategory::RateLimit,
             detail: None,
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_log_level_unset_defaults_to_warn() {
+        assert_eq!(parse_log_level(None), LevelFilter::Warn);
+    }
+
+    #[test]
+    fn parse_log_level_unknown_defaults_to_warn() {
+        assert_eq!(parse_log_level(Some("verbose")), LevelFilter::Warn);
+        assert_eq!(parse_log_level(Some("")), LevelFilter::Warn);
+    }
+
+    #[test]
+    fn parse_log_level_recognises_each_level() {
+        assert_eq!(parse_log_level(Some("off")), LevelFilter::Off);
+        assert_eq!(parse_log_level(Some("error")), LevelFilter::Error);
+        assert_eq!(parse_log_level(Some("warn")), LevelFilter::Warn);
+        assert_eq!(parse_log_level(Some("info")), LevelFilter::Info);
+        assert_eq!(parse_log_level(Some("debug")), LevelFilter::Debug);
+        assert_eq!(parse_log_level(Some("trace")), LevelFilter::Trace);
+    }
+
+    #[test]
+    fn parse_log_level_is_case_and_whitespace_insensitive() {
+        assert_eq!(parse_log_level(Some("  INFO ")), LevelFilter::Info);
+        assert_eq!(parse_log_level(Some("Debug")), LevelFilter::Debug);
     }
 }

--- a/tests/e2e/scenarios/log_level.rs
+++ b/tests/e2e/scenarios/log_level.rs
@@ -1,0 +1,76 @@
+//! `MERGE_READY_LOG_LEVEL` の E2E（#413）。
+//!
+//! daemon が出す warn/info ログが、設定したレベルに応じて
+//! `$HOME/.cache/merge-ready/error.log` に記録されることを検証する。
+//! 以前は logger が `LevelFilter::Error` 固定で、warn 以下が全て捨てられていた。
+
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use super::super::helpers::DaemonHandle;
+use super::log_level_fixtures;
+
+const POLL_MS: u64 = 5000;
+
+fn error_log_path(home: &Path) -> std::path::PathBuf {
+    home.join(".cache/merge-ready/error.log")
+}
+
+fn read_log(home: &Path) -> String {
+    std::fs::read_to_string(error_log_path(home)).unwrap_or_default()
+}
+
+fn rate_limit_call_count(path: &Path) -> usize {
+    std::fs::read_to_string(path).unwrap_or_default().len()
+}
+
+/// `cond` が真になるまで最大 `max_ms` ミリ秒ポーリングする。
+fn wait_until(max_ms: u64, mut cond: impl FnMut() -> bool) -> bool {
+    let deadline = Instant::now() + Duration::from_millis(max_ms);
+    loop {
+        if cond() {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// デフォルト（warn）では `rate_limit` 取得失敗の warn ログが `error.log` に残る。
+#[test]
+fn warn_log_recorded_at_default_level() {
+    let fx = log_level_fixtures::with_failing_rate_limit();
+    let _daemon = DaemonHandle::start(&fx.env);
+    DaemonHandle::wait_for_cache(&fx.env, 5000);
+
+    let home = fx.env.home().to_path_buf();
+    let found = wait_until(POLL_MS, || {
+        read_log(&home).contains("rate_limit fetch failed")
+    });
+    assert!(
+        found,
+        "default(warn) で rate_limit 失敗の warn が error.log に記録されていない: {:?}",
+        read_log(&home)
+    );
+}
+
+/// `MERGE_READY_LOG_LEVEL=error` では warn ログは捨てられ、`error.log` に残らない。
+#[test]
+fn warn_log_suppressed_at_error_level() {
+    let fx = log_level_fixtures::with_failing_rate_limit();
+    let _daemon = DaemonHandle::start_with_env(&fx.env, &[("MERGE_READY_LOG_LEVEL", "error")]);
+    DaemonHandle::wait_for_cache(&fx.env, 5000);
+
+    // warn を出す経路（rate_limit fetch）を実際に通ったことを保証する。
+    let fired = wait_until(POLL_MS, || rate_limit_call_count(&fx.rate_limit_log) >= 1);
+    assert!(fired, "rate_limit fetch が発火しなかった");
+
+    let home = fx.env.home();
+    assert!(
+        !read_log(home).contains("rate_limit fetch failed"),
+        "error レベルなのに warn が記録された: {:?}",
+        read_log(home)
+    );
+}

--- a/tests/e2e/scenarios/log_level_fixtures.rs
+++ b/tests/e2e/scenarios/log_level_fixtures.rs
@@ -1,0 +1,61 @@
+//! `MERGE_READY_LOG_LEVEL` シナリオ用 `fixture`（#413）。
+//!
+//! fake `gh` は `graphql`（refresh 本体）/ `api compare` を正常応答するが、
+//! `api rate_limit` だけは exit 1 で失敗させる。これにより daemon の
+//! `rate_limit` fetcher が `log::warn!("rate_limit fetch failed: ...")` を出す。
+//! `rate_limit_log` で `api rate_limit` の呼び出し回数を記録し、
+//! 「warn を出す経路を実際に通った」ことをテスト側から確認できるようにする。
+
+use std::path::PathBuf;
+
+use super::super::helpers::{
+    ROLLUP_PASS, TestEnv, graphql_single, setup_git_dirs, write_executable,
+};
+
+pub struct LogLevelFixture {
+    pub env: TestEnv,
+    pub rate_limit_log: PathBuf,
+}
+
+/// `gh api rate_limit` が必ず失敗する fake `gh` を構築する。
+pub fn with_failing_rate_limit() -> LogLevelFixture {
+    let (bin, home_tmp, repo) = setup_git_dirs("feat/my-feature");
+    let rate_limit_log = home_tmp.path().join("rate_limit_calls.log");
+    let rate_limit_log_s = rate_limit_log.display().to_string();
+
+    let graphql_json = graphql_single(
+        r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}"#,
+        Some(ROLLUP_PASS),
+    );
+
+    let script = format!(
+        "#!/bin/sh\n\
+         case \"$*\" in\n\
+           *'api rate_limit'*)\n\
+             printf '1' >> \"{rate_limit_log_s}\"\n\
+             printf 'rate_limit boom' >&2\n\
+             exit 1\n\
+             ;;\n\
+           *graphql*)\n\
+             printf '%s' '{graphql_json}'\n\
+             ;;\n\
+           *'api'*'compare'*)\n\
+             printf '{{\"behind_by\":0}}'\n\
+             ;;\n\
+           *)\n\
+             printf 'unexpected gh call: %s' \"$*\" >&2\n\
+             exit 127\n\
+             ;;\n\
+         esac\n"
+    );
+    write_executable(bin.path().join("gh"), &script);
+
+    LogLevelFixture {
+        env: TestEnv {
+            bin,
+            home_tmp,
+            repo,
+        },
+        rate_limit_log,
+    }
+}

--- a/tests/e2e/scenarios/mod.rs
+++ b/tests/e2e/scenarios/mod.rs
@@ -5,6 +5,8 @@ mod default_branch;
 mod default_branch_fixtures;
 mod entry_expiry;
 mod initial_load;
+mod log_level;
+mod log_level_fixtures;
 mod multi_repo;
 mod multiple_prs;
 mod no_github_remote;


### PR DESCRIPTION
## 背景 / 問題

`logger::init()` が `WriteLogger::init(LevelFilter::Error, ...)` で固定初期化されており、daemon が出す info/warn/debug ログが一切記録されていなかった。その結果、運用診断にもっとも必要な以下のイベントがすべて捨てられていた:

- backoff 突入（`rate_limit_fetcher`、従来 `info`）
- rate_limit 取得失敗（`rate_limit_client`、`warn`）
- daemon の自己終了（`socket_watcher`、従来 `info`）

書く先がないのに毎回フォーマット・呼び出しだけが行われている状態でもあった。#389 と同種の観測性の穴。

## 変更内容

- `MERGE_READY_LOG_LEVEL`（`off`/`error`/`warn`/`info`/`debug`/`trace`、大文字小文字・前後空白を無視）でロガーのレベルを設定可能にした。未設定・空・不明値は既定の `warn`。
- 運用上重要な **backoff 突入**（`rate_limit_fetcher`）と **daemon 自己終了**（`socket_watcher`）を `info` → `warn` へ引き上げ、既定レベル（`warn`）で記録されるようにした。
- README に `Diagnostics` 節を追加し、ログ出力先（`$XDG_CACHE_HOME`／`~/.cache` 配下の `merge-ready/error.log`）と `MERGE_READY_LOG_LEVEL` を記載。

これにより、既定 `warn` で「backoff 突入・rate_limit 取得失敗・daemon 自己終了」が `error.log` に残るようになる。`scheduler` のエントリ失効は routine なため `debug` のまま（`MERGE_READY_LOG_LEVEL=debug` 指定時のみ記録）。

## テスト（TDD: Red → Green）

E2E（`tests/e2e/scenarios/log_level.rs`）— `gh api rate_limit` を失敗させる fixture で daemon の warn ログ経路を駆動:

- `warn_log_recorded_at_default_level`: 既定（warn）で `rate_limit fetch failed` が `error.log` に残る（修正前は空 → Red を確認済み）。
- `warn_log_suppressed_at_error_level`: `MERGE_READY_LOG_LEVEL=error` では warn が捨てられる。

単体（`logger.rs`）— `parse_log_level` の各レベル・既定・大文字小文字／空白の解釈。

ローカル確認: `cargo nextest run --workspace`（426 passed）/ `clippy -D warnings` / `fmt --check` / `deny check` / layer-deps / no-mod-rs / no-clippy-allow すべて green。

Closes #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)