### PR TITLE
perf(daemon): PID 生存確認・SIGTERM 送信を rustix の safe API に置換する

### DIFF
--- a/src/contexts/daemon/infrastructure/daemon_lifecycle.rs
+++ b/src/contexts/daemon/infrastructure/daemon_lifecycle.rs
@@ -38,7 +38,7 @@ impl DaemonLifecyclePort for DaemonLifecycle {
         let pid_path = self.paths.pid_path();
         let client = DaemonClient::new(self.paths.socket_path());
         let running_pid = match pid::read(&pid_path) {
-            Some(p) if pid::is_alive(p).await => Some(p),
+            Some(p) if pid::is_alive(p) => Some(p),
             _ => None,
         };
         if client.stop().await {
@@ -50,7 +50,7 @@ impl DaemonLifecyclePort for DaemonLifecycle {
         let Some(p) = running_pid.or_else(|| pid::read(&pid_path)) else {
             return false;
         };
-        if !pid::is_alive(p).await {
+        if !pid::is_alive(p) {
             pid::remove(&pid_path);
             return false;
         }
@@ -70,7 +70,7 @@ impl DaemonLifecyclePort for DaemonLifecycle {
 
     async fn get_pid(&self) -> Option<u32> {
         match pid::read(&self.paths.pid_path()) {
-            Some(p) if pid::is_alive(p).await => Some(p),
+            Some(p) if pid::is_alive(p) => Some(p),
             _ => None,
         }
     }
@@ -85,12 +85,7 @@ async fn wait_or_terminate(p: u32, pid_path: &Path) -> bool {
 
 async fn terminate_and_wait(p: u32, pid_path: &Path) -> bool {
     // ソケット経由が失敗した、または終了が遅い場合は SIGTERM でフォールバックする。
-    let signalled = tokio::process::Command::new("kill")
-        .args(["-TERM", &p.to_string()])
-        .status()
-        .await
-        .is_ok_and(|s| s.success());
-    signalled && pid::wait_until_gone(p, pid_path, STOP_TIMEOUT).await
+    pid::terminate(p) && pid::wait_until_gone(p, pid_path, STOP_TIMEOUT).await
 }
 
 impl WatchPort for DaemonLifecycle {

--- a/src/contexts/daemon/infrastructure/pid.rs
+++ b/src/contexts/daemon/infrastructure/pid.rs
@@ -2,6 +2,8 @@ use std::fs;
 use std::path::Path;
 use std::time::{Duration, Instant};
 
+use rustix::process::{Pid, Signal, kill_process, test_kill_process};
+
 pub fn write(pid: u32, path: &Path) {
     if let Some(parent) = path.parent() {
         let _ = fs::create_dir_all(parent);
@@ -20,19 +22,40 @@ pub fn remove(path: &Path) {
     let _ = fs::remove_file(path);
 }
 
-pub async fn is_alive(pid: u32) -> bool {
-    tokio::process::Command::new("kill")
-        .args(["-0", &pid.to_string()])
-        .stderr(std::process::Stdio::null())
-        .status()
-        .await
-        .is_ok_and(|s| s.success())
+/// u32 の PID を rustix の `Pid` に変換する。
+///
+/// 0 や `i32` の範囲を超える値は実在しない PID なので `None` を返す。
+fn to_pid(pid: u32) -> Option<Pid> {
+    i32::try_from(pid).ok().and_then(Pid::from_raw)
+}
+
+/// プロセスが生存しているか調べる（`kill(pid, 0)` 相当）。
+///
+/// EPERM（プロセスは存在するが権限が無い）は「生存」とみなす。
+/// ESRCH 等はプロセス不在として `false` を返す。
+#[must_use]
+pub fn is_alive(pid: u32) -> bool {
+    let Some(pid) = to_pid(pid) else {
+        return false;
+    };
+    match test_kill_process(pid) {
+        Ok(()) => true,
+        Err(e) => e == rustix::io::Errno::PERM,
+    }
+}
+
+/// プロセスに SIGTERM を送る。送信できれば `true`。
+pub fn terminate(pid: u32) -> bool {
+    let Some(pid) = to_pid(pid) else {
+        return false;
+    };
+    kill_process(pid, Signal::TERM).is_ok()
 }
 
 pub async fn wait_until_gone(pid: u32, path: &Path, timeout: Duration) -> bool {
     let deadline = Instant::now() + timeout;
     loop {
-        if !is_alive(pid).await {
+        if !is_alive(pid) {
             remove(path);
             return true;
         }
@@ -70,5 +93,44 @@ mod tests {
         let dir = tempdir().unwrap();
         let path = dir.path().join("daemon.pid");
         assert_eq!(super::read(&path), None);
+    }
+
+    #[test]
+    fn is_alive_true_for_current_process() {
+        assert!(super::is_alive(std::process::id()));
+    }
+
+    #[test]
+    fn is_alive_false_for_zero_pid() {
+        assert!(!super::is_alive(0));
+    }
+
+    #[test]
+    fn is_alive_false_after_child_reaped() {
+        let mut child = std::process::Command::new("/bin/sh")
+            .args(["-c", "exit 0"])
+            .spawn()
+            .expect("spawn child");
+        let pid = child.id();
+        child.wait().expect("reap child");
+        assert!(!super::is_alive(pid));
+    }
+
+    #[test]
+    fn terminate_stops_a_running_child() {
+        let mut child = std::process::Command::new("/bin/sh")
+            .args(["-c", "sleep 30"])
+            .spawn()
+            .expect("spawn child");
+        let pid = child.id();
+        assert!(super::is_alive(pid));
+        assert!(super::terminate(pid));
+        child.wait().expect("reap child");
+        assert!(!super::is_alive(pid));
+    }
+
+    #[test]
+    fn terminate_false_for_zero_pid() {
+        assert!(!super::terminate(0));
     }
 }

--- a/src/contexts/daemon/infrastructure/restart.rs
+++ b/src/contexts/daemon/infrastructure/restart.rs
@@ -36,7 +36,7 @@ async fn cleanup_one(old_pid_path: &std::path::Path) {
     let old_sock = old_pid_path.with_file_name(format!("{stem}.sock"));
 
     match pid::read(old_pid_path) {
-        Some(p) if pid::is_alive(p).await => {
+        Some(p) if pid::is_alive(p) => {
             let client = DaemonClient::new(old_sock.clone());
             let _ = client.stop().await;
             // 旧デーモンが Stop を完了するまで待ち、ファイルを掃除する

--- a/src/contexts/daemon/infrastructure/socket_listener.rs
+++ b/src/contexts/daemon/infrastructure/socket_listener.rs
@@ -46,7 +46,7 @@ async fn bind_with(
 
     let pid_path = paths.pid_path();
     match pid::read(&pid_path) {
-        Some(p) if pid::is_alive(p).await => {
+        Some(p) if pid::is_alive(p) => {
             log::error!("daemon is already running (pid {p})");
             eprintln!("merge-ready daemon is already running (pid {p})");
             return Err(DaemonError::AlreadyRunning);


### PR DESCRIPTION
## 概要

Closes #411

PID 操作が外部コマンド `kill` のサブプロセス起動で実装されていたのを、既存依存の `rustix`（`features = ["process"]`、`[target.'cfg(unix)']`）の safe API に置換する。`unsafe_code = "forbid"` と整合する。

## 背景

- `pid::is_alive`: `kill -0 <pid>` を spawn
- `terminate_and_wait`: `kill -TERM <pid>` を spawn
- `wait_until_gone` は 20ms 間隔ポーリングで、タイムアウトまで粘ると**最大 250 回のプロセス起動**になっていた。プロセス起動は 1 回あたり数 ms のオーバーヘッドがあり、fork できない環境要因（EAGAIN 等）で誤判定するリスクもあった。

## 変更点

- 生存確認: `rustix::process::test_kill_process(pid)` に置換。
  - **挙動の差分**: EPERM（プロセスは存在するが権限が無い）を「生存」と解釈する。従来の `kill -0` の終了ステータス判定（EPERM は非成功 → 不在扱い）より正確。merge-ready のデーモンは uid で名前空間分離した temp 配下に自分の PID を書くため、実運用で EPERM が起きる経路はほぼ無いが、より正確な解釈に揃える。
  - ESRCH 等（プロセス不在）は `false`。
- SIGTERM: `rustix::process::kill_process(pid, Signal::TERM)` を `pid::terminate` として切り出し、`terminate_and_wait` から呼ぶ。
- サブプロセス起動が消えたため `is_alive` を**同期関数化**し、`daemon_lifecycle` / `socket_listener` / `restart` の `.await` 連鎖を整理した。
- u32 → `Pid` 変換は `i32::try_from(..).ok().and_then(Pid::from_raw)` で 0 / `i32` 範囲外を `None`（不在）に倒す。

## テスト

`pid.rs` に同期テストを追加（実プロセス注入）:

- `is_alive_true_for_current_process`
- `is_alive_false_for_zero_pid`
- `is_alive_false_after_child_reaped` — 子プロセスを reap した後の不在判定
- `terminate_stops_a_running_child` — SIGTERM 送信 → 終了確認
- `terminate_false_for_zero_pid`

ローカルで通過:

- `cargo nextest run --workspace` (431 passed)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `check-layer-deps.sh` / `check-no-mod-rs.sh` / `check-no-clippy-allow.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)