### PR TITLE
perf(evaluation): Calculating / CONFLICTING 時に compare API をスキップする

### DIFF
--- a/src/contexts/evaluation/infrastructure/gh.rs
+++ b/src/contexts/evaluation/infrastructure/gh.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 
 use error::{GhError, classify_gh_error};
 use fetch::fetch_behind_by;
-use mapper::{aggregate_ci, translate_review, translate_sync, translate_unblocked};
+use mapper::{aggregate_ci, needs_compare, translate_review, translate_sync, translate_unblocked};
 use schema::{CheckBucket, CheckContext, GhPrNode, GraphQlResponse, Repository, context_to_bucket};
 use tokio::task::JoinSet;
 
@@ -154,13 +154,9 @@ async fn evaluate_single_pr(
     // CI は GraphQL レスポンス（rollup）から同期的に算出する。
     let ci = ci_from_node(&pr_view);
 
-    // branch sync の behind_by だけは GraphQL に対応フィールドが無いため
-    // PR ごとに REST compare を併用する（refresh あたり 1 GraphQL + N compare）。
-    let behind_by =
-        fetch_behind_by(&pr_view.base_ref_name, &pr_view.head_ref_name, Some(&cwd)).await;
-    let branch_sync = translate_sync(&pr_view.mergeable, behind_by);
-
-    // GitHub がまだマージ可能性を計算中（他のシグナルより優先）
+    // GitHub がまだマージ可能性を計算中（他のシグナルより優先）。
+    // behind_by は捨てられるので、無駄な REST compare を避けるため
+    // fetch_behind_by の前に early return する（push 直後の Hot 期で頻発するパス）。
     if matches!(
         pr_view.merge_state_status.as_str(),
         "MERGE_STATE_UNKNOWN" | "UNKNOWN"
@@ -170,6 +166,17 @@ async fn evaluate_single_pr(
             state: State::Calculating,
         });
     }
+
+    // branch sync の behind_by だけは GraphQL に対応フィールドが無いため
+    // PR ごとに REST compare を併用する（refresh あたり 1 GraphQL + N compare）。
+    // ただし CONFLICTING のときは translate_sync が behind_by を見ない（Conflict
+    // 優先）ため compare をスキップする。
+    let behind_by = if needs_compare(&pr_view.mergeable) {
+        fetch_behind_by(&pr_view.base_ref_name, &pr_view.head_ref_name, Some(&cwd)).await
+    } else {
+        None
+    };
+    let branch_sync = translate_sync(&pr_view.mergeable, behind_by);
 
     let review = translate_review(pr_view.review_decision.as_deref());
     let unblocked = translate_unblocked(pr_view.is_draft, &pr_view.merge_state_status);

--- a/src/contexts/evaluation/infrastructure/gh/mapper.rs
+++ b/src/contexts/evaluation/infrastructure/gh/mapper.rs
@@ -13,6 +13,15 @@ pub(super) fn translate_sync(mergeable: &str, behind_by: Option<u64>) -> Option<
     }
 }
 
+/// REST compare（`behind_by`）が `translate_sync` の結果に影響するかを判定する。
+///
+/// `CONFLICTING` のときは `translate_sync` が `behind_by` を見ずに `Conflict` を
+/// 返すため、compare 呼び出しは無駄になる。呼び出し元はこれが `false` のとき
+/// compare をスキップできる（`translate_sync` の優先順位と整合させること）。
+pub(super) fn needs_compare(mergeable: &str) -> bool {
+    mergeable != "CONFLICTING"
+}
+
 pub(super) fn translate_review(decision: Option<&str>) -> Option<ReviewState> {
     match decision {
         Some("CHANGES_REQUESTED") => Some(ReviewState::ChangesRequested),
@@ -93,6 +102,15 @@ mod tests {
             translate_sync("MERGEABLE", None),
             Some(BranchSyncState::SyncUnknown)
         );
+    }
+
+    #[test]
+    fn needs_compare_skips_only_conflicting() {
+        // CONFLICTING は behind_by を使わない（Conflict 優先）ため compare 不要。
+        assert!(!needs_compare("CONFLICTING"));
+        // それ以外は behind_by が結果に影響しうるため compare が必要。
+        assert!(needs_compare("MERGEABLE"));
+        assert!(needs_compare("UNKNOWN"));
     }
 
     #[test]

--- a/tests/e2e/prompt/branch_sync.rs
+++ b/tests/e2e/prompt/branch_sync.rs
@@ -15,6 +15,12 @@ const CONFLICTING_BEHIND: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":
 const CONFLICTING_DIRTY_CHANGES: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"CONFLICTING","mergeStateStatus":"DIRTY","reviewDecision":"CHANGES_REQUESTED"}"#;
 const MERGEABLE_BLOCKED: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"BLOCKED","reviewDecision":null,"baseRefName":"main","headRefName":"feat/test"}"#;
 
+// #410: compare スキップ検証用。ref を埋めることで「修正前なら compare を呼ぶ」
+// 条件を満たし、修正後に呼ばれないことを観測できる。
+const CONFLICTING_WITH_REFS: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"CONFLICTING","mergeStateStatus":"DIRTY","reviewDecision":null,"baseRefName":"main","headRefName":"feat/test"}"#;
+const MERGE_STATE_UNKNOWN_WITH_REFS: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"UNKNOWN","mergeStateStatus":"MERGE_STATE_UNKNOWN","reviewDecision":null,"baseRefName":"main","headRefName":"feat/test"}"#;
+const UNKNOWN_WITH_REFS: &str = r#"{"state":"OPEN","isDraft":false,"mergeable":"UNKNOWN","mergeStateStatus":"UNKNOWN","reviewDecision":null,"baseRefName":"main","headRefName":"feat/test"}"#;
+
 // `statusCheckRollup.contexts.nodes` 形式
 const PASS_JSON: &str =
     r#"[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]"#;
@@ -76,4 +82,52 @@ fn test_compare_api_error() {
 fn test_compare_invalid_json_shows_check_branch_sync() {
     let env = branch_sync_fixtures::with_invalid_compare_json(MERGEABLE_BLOCKED, PASS_JSON);
     assert_prompt(&env, "? Check branch sync");
+}
+
+// ── #410: compare スキップ（無駄な REST 呼び出しの抑制） ──────────────────────
+
+/// daemon を起動して最初の refresh 完了を待ち、出力を検証したうえで
+/// compare 呼び出しログが生成されていない（= compare ゼロ）ことを確認する。
+fn assert_prompt_without_compare(env: &TestEnv, log_path: &std::path::Path, expected: &str) {
+    let _daemon = DaemonHandle::start(env);
+    DaemonHandle::wait_for_cache(env, 5000);
+
+    let mut cmd = Command::cargo_bin("merge-ready-prompt").unwrap();
+    env.apply_with_cache(&mut cmd);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::diff(expected.to_owned()))
+        .stderr("");
+
+    // refresh が完了してキャッシュが埋まった後に compare ログが無いことは、
+    // evaluate_single_pr が compare を await する前に分岐したことを意味する。
+    assert!(
+        !log_path.exists(),
+        "compare API must not be called (found call log at {})",
+        log_path.display()
+    );
+}
+
+/// #410: `CONFLICTING` は `behind_by` を使わない（Conflict 優先）ため compare をスキップする。
+#[test]
+fn test_conflicting_skips_compare() {
+    let (env, log_path) =
+        branch_sync_fixtures::with_compare_call_log(CONFLICTING_WITH_REFS, Some(PASS_JSON));
+    assert_prompt_without_compare(&env, &log_path, "✗ Resolve conflict");
+}
+
+/// #410: `MERGE_STATE_UNKNOWN`（Calculating）は `behind_by` を捨てるため compare をスキップする。
+#[test]
+fn test_merge_state_unknown_skips_compare() {
+    let (env, log_path) =
+        branch_sync_fixtures::with_compare_call_log(MERGE_STATE_UNKNOWN_WITH_REFS, Some(PASS_JSON));
+    assert_prompt_without_compare(&env, &log_path, "⧖ Wait for status");
+}
+
+/// #410: `UNKNOWN`（Calculating）も同様に compare をスキップする。
+#[test]
+fn test_unknown_status_skips_compare() {
+    let (env, log_path) =
+        branch_sync_fixtures::with_compare_call_log(UNKNOWN_WITH_REFS, Some(PASS_JSON));
+    assert_prompt_without_compare(&env, &log_path, "⧖ Wait for status");
 }

--- a/tests/e2e/prompt/branch_sync_fixtures.rs
+++ b/tests/e2e/prompt/branch_sync_fixtures.rs
@@ -1,4 +1,8 @@
-use super::super::helpers::{TestEnv, graphql_single, setup_git_dirs, write_executable};
+use std::path::PathBuf;
+
+use super::super::helpers::{
+    FAKE_GH_RATE_LIMIT_OK_SNIPPET, TestEnv, graphql_single, setup_git_dirs, write_executable,
+};
 
 /// compare API が `behind_by` を返すシナリオ用の `fake gh` を配置する。
 ///
@@ -61,6 +65,51 @@ pub fn with_compare_error(pr_view_json: &str, pr_checks_json: Option<&str>) -> T
         home_tmp,
         repo,
     }
+}
+
+/// compare API が呼ばれた回数を記録する `fake gh` を配置する（#410）。
+///
+/// graphql は常に成功し、`api ... compare ...` が呼ばれたときだけ
+/// `compare_calls.log` に 1 文字追記する。Calculating / CONFLICTING のように
+/// compare をスキップすべきケースで「ログ未生成（= 呼び出しゼロ）」を
+/// 検証するために使う。`behind_by` は使われないはずだが、念のため `1` を返す。
+pub fn with_compare_call_log(
+    pr_view_json: &str,
+    pr_checks_json: Option<&str>,
+) -> (TestEnv, PathBuf) {
+    let (bin, home_tmp, repo) = setup_git_dirs("feat/my-feature");
+    let log_path = home_tmp.path().join("compare_calls.log");
+    let log = log_path.display().to_string();
+
+    let graphql_json = graphql_single(pr_view_json, pr_checks_json);
+
+    let script = format!(
+        "#!/bin/sh\n\
+         {FAKE_GH_RATE_LIMIT_OK_SNIPPET}\
+         case \"$*\" in\n\
+           *graphql*)\n\
+             printf '%s' '{graphql_json}'\n\
+             ;;\n\
+           *'api'*'compare'*)\n\
+             printf '1' >> \"{log}\"\n\
+             printf '{{\"behind_by\":1}}'\n\
+             ;;\n\
+           *)\n\
+             printf 'unexpected gh call: %s' \"$*\" >&2\n\
+             exit 127\n\
+             ;;\n\
+         esac\n"
+    );
+
+    write_executable(bin.path().join("gh"), &script);
+    (
+        TestEnv {
+            bin,
+            home_tmp,
+            repo,
+        },
+        log_path,
+    )
 }
 
 /// graphql は成功するが compare API が exit 0 で不正な JSON を返すシナリオ


### PR DESCRIPTION
## 背景

`evaluate_single_pr` は PR ごとに REST compare（`behind_by`）を **await した後** に `MERGE_STATE_UNKNOWN` / `UNKNOWN` を `State::Calculating` として early return しており、`behind_by` を捨てるだけの無駄な compare 呼び出しが発生していた。push 直後は render が `StatusCalculating` を返し `RefreshMode::Hot`（既定 2 秒間隔）に入るため、リフレッシュごとに PR 数ぶんの無駄な compare が繰り返される。

さらに `mergeable == "CONFLICTING"` の場合も `translate_sync` は Conflict を優先して `behind_by` を一切使わないため、このケースの compare も無駄だった。

closes #410

## 変更

- `Calculating` の early return を `fetch_behind_by` より **前** へ移動。
- `mergeable == "CONFLICTING"` のときも compare をスキップ。判定は `translate_sync` の優先順位と整合する純粋関数 `needs_compare` として `mapper.rs` に抽出。

レート制限コストモデル（`total_refresh_cost = N+1`）の前提となる実コール数を、もっとも refresh 頻度が高い局面で削減する。観測可能な出力（`⧖ Wait for status` / `✗ Resolve conflict`）は不変。

## テスト

TDD（Red → Green）で実装。compare 呼び出しを記録する fake `gh` fixture（`with_compare_call_log`）を追加し、Calculating（`MERGE_STATE_UNKNOWN` / `UNKNOWN`）と `CONFLICTING` で **compare がまったく呼ばれない** ことを E2E で検証する。修正前は 3 テストとも compare 呼び出しを検知して失敗することを確認済み。

- `tests/e2e/prompt/branch_sync.rs`: `test_conflicting_skips_compare` / `test_merge_state_unknown_skips_compare` / `test_unknown_status_skips_compare`
- `mapper.rs`: `needs_compare_skips_only_conflicting`（単体）

`cargo nextest run --workspace`（430 passed）/ `clippy -D warnings` / `cargo fmt --check` / `cargo deny check` / layer-deps / no-mod-rs / no-clippy-allow いずれもローカルで通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)