### PR TITLE
fix(daemon): 相対 gitdir（submodule 等）を .git 基準で解決し branch を保持する

### DIFF
--- a/src/contexts/daemon/infrastructure/repo_id.rs
+++ b/src/contexts/daemon/infrastructure/repo_id.rs
@@ -23,6 +23,9 @@ pub fn repo_id_from_cwd(cwd: &str) -> Option<String> {
 /// カレントディレクトリから上に向かって `.git` を探す。
 ///
 /// worktree またはサブモジュールの場合 `.git` はファイル（`"gitdir: <path>"` 形式）。
+/// submodule の `gitdir:` は通常 `.git` ファイルからの相対パス（例 `../.git/modules/sub`）
+/// なので、`.git` ファイルを含むディレクトリ基準で絶対パスへ解決する。相対のまま返すと、
+/// 後段の `read_head` が daemon プロセスの cwd 基準で HEAD を探して失敗する。
 fn find_git_dir(start: &Path) -> Option<(PathBuf, PathBuf)> {
     let mut dir = start.to_path_buf();
     loop {
@@ -32,8 +35,13 @@ fn find_git_dir(start: &Path) -> Option<(PathBuf, PathBuf)> {
         }
         if dot_git.is_file() {
             let content = fs::read_to_string(&dot_git).ok()?;
-            let real = content.strip_prefix("gitdir: ")?.trim();
-            return Some((dir, PathBuf::from(real)));
+            let real = Path::new(content.strip_prefix("gitdir: ")?.trim());
+            let git_dir = if real.is_absolute() {
+                real.to_path_buf()
+            } else {
+                dir.join(real)
+            };
+            return Some((dir, git_dir));
         }
         if !dir.pop() {
             return None;

--- a/tests/e2e/daemon/watch.rs
+++ b/tests/e2e/daemon/watch.rs
@@ -1,5 +1,6 @@
 //! `merge-ready watch` コマンドの E2E テスト（シナリオ #W1–#W7）
 
+use std::fs;
 use std::io::{BufRead, BufReader};
 use std::process::Stdio;
 use std::sync::mpsc;
@@ -140,6 +141,43 @@ fn test_watch_leaves_pr_column_empty_without_pr() {
         "unexpected output: {output:?}"
     );
     assert!(!output.contains('#'), "unexpected output: {output:?}");
+}
+
+// ── #408: 相対 gitdir（submodule）の BRANCH 解決 ─────────────────────────────
+
+/// #408: submodule の `.git` ファイルは相対 `gitdir:`（例 `gitdir: ../.git/modules/sub`）
+/// を持つ。daemon プロセスの cwd 基準で誤って解決すると HEAD が読めず branch が空になり、
+/// watch の BRANCH 列が空欄になる。相対 `gitdir` を `.git` を含むディレクトリ基準で解決し、
+/// BRANCH 列にブランチ名が表示されることを検証する。
+#[test]
+fn test_watch_resolves_branch_for_relative_gitdir_submodule() {
+    let env = TestEnv::new(OPEN_PR_VIEW_JSON, Some(CI_PASS_JSON));
+
+    // env.repo を superproject root と見立てて submodule レイアウトを作る:
+    //   <repo>/.git/modules/sub/HEAD  submodule の実 git storage
+    //   <repo>/sub/.git               file: "gitdir: ../.git/modules/sub"
+    // prompt の cwd は <repo>/sub、daemon の cwd は <repo>（= 別ディレクトリ）。この差に
+    // より、相対 gitdir を daemon の cwd 基準で解決するバグが顕在化する。
+    let branch = "feat/in-submodule";
+    let storage = env.repo.path().join(".git/modules/sub");
+    fs::create_dir_all(&storage).expect("create submodule git storage");
+    fs::write(storage.join("HEAD"), format!("ref: refs/heads/{branch}\n")).expect("write HEAD");
+
+    let submodule = env.repo.path().join("sub");
+    fs::create_dir_all(&submodule).expect("create submodule workdir");
+    fs::write(submodule.join(".git"), "gitdir: ../.git/modules/sub\n").expect("write .git file");
+
+    let _daemon = DaemonHandle::start(&env);
+
+    // submodule dir から prompt を発行してキャッシュを温める。
+    DaemonHandle::wait_for_cache_in_dir(&env, &submodule, 5000);
+
+    let output = spawn_watch_and_read(&env, 2, Duration::from_secs(5));
+
+    assert!(
+        output.contains(branch),
+        "BRANCH 列に submodule のブランチが表示されるべき: {output:?}"
+    );
 }
 
 // ── #W7: 複数リポジトリのソート順 ────────────────────────────────────────────

--- a/tests/e2e/helpers/daemon_handle.rs
+++ b/tests/e2e/helpers/daemon_handle.rs
@@ -101,6 +101,15 @@ impl DaemonHandle {
 
     /// キャッシュに有効な値が入るまで最大 `max_ms` ミリ秒ポーリングする。
     pub fn wait_for_cache(env: &TestEnv, max_ms: u64) {
+        Self::wait_for_cache_in_dir(env, env.repo.path(), max_ms);
+    }
+
+    /// `cwd` から `merge-ready-prompt` を実行し、キャッシュに有効な値が入るまで
+    /// 最大 `max_ms` ミリ秒ポーリングする。
+    ///
+    /// daemon の cwd とは別のディレクトリ（submodule など）から prompt を発行して
+    /// キャッシュを温めたいケース用。
+    pub fn wait_for_cache_in_dir(env: &TestEnv, cwd: &Path, max_ms: u64) {
         let bin = assert_cmd::cargo::cargo_bin("merge-ready-prompt");
         let deadline = std::time::Instant::now() + std::time::Duration::from_millis(max_ms);
         loop {
@@ -109,7 +118,7 @@ impl DaemonHandle {
                 .env("HOME", env.home())
                 .env("TMPDIR", env.home())
                 .env("MERGE_READY_BASE_DIR", env.home())
-                .current_dir(env.repo.path());
+                .current_dir(cwd);
             apply_coverage_env(&mut cmd);
             let out = run_prompt_with_timeout(&mut cmd);
             let stdout = String::from_utf8_lossy(&out.stdout);


### PR DESCRIPTION
## 背景 (Closes #408)

`src/contexts/daemon/infrastructure/repo_id.rs` の `find_git_dir` は、`.git` が**ファイル**の場合（submodule / worktree）に `gitdir: <path>` をそのまま `PathBuf::from` で返していた。

submodule の `.git` ファイルは通常**相対パス**（例 `gitdir: ../.git/modules/sub`）を持つ。相対のまま返すと、後段の `read_head` が **daemon プロセスの cwd 基準**で `HEAD` を探して失敗し、`branch` が空文字になる。

結果:

- `repo_id = hash(toplevel + "\0" + "")` となり、submodule 内ではブランチが変わっても**同一 repo_id**（旧ブランチのキャッシュが誤表示される）。
- `watch` の **BRANCH 列が空**になる。

## 修正

相対 `gitdir` を `.git` ファイルを含むディレクトリ基準で絶対パスへ解決する。

```rust
let real = Path::new(content.strip_prefix("gitdir: ")?.trim());
let git_dir = if real.is_absolute() { real.to_path_buf() } else { dir.join(real) };
```

worktree の `.git` ファイルは**絶対** `gitdir` を持つため、従来どおりそのまま使われる（挙動変更なし）。

## テスト (TDD: Red → Green)

`tests/e2e/daemon/watch.rs` に E2E を追加:

- `<repo>/.git/modules/sub/HEAD` と `<repo>/sub/.git`（`gitdir: ../.git/modules/sub`）で submodule レイアウトを構築。
- daemon の cwd（`<repo>`）と prompt の cwd（`<repo>/sub`）を**意図的にずらす**ことで、相対 gitdir を daemon cwd 基準で解決するバグを顕在化させる。
- `watch` の BRANCH 列にブランチ名が表示されることを検証。
- 修正前は BRANCH 列が空欄で **FAIL**、修正後 **PASS** を確認済み。

ヘルパー `DaemonHandle::wait_for_cache_in_dir(env, cwd, max_ms)` を追加（`wait_for_cache` はこれに委譲）。

## 確認したチェック

- `cargo nextest run --workspace` … 432 passed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` … clean
- `cargo fmt --check --all` … clean
- `cargo deny check` … ok（既存の license warning のみ、本変更と無関係）
- `check-layer-deps.sh` / `check-no-mod-rs.sh` / `check-no-clippy-allow.sh` … OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)