### PR TITLE
fix(daemon): 認証失敗ログに gh stderr の原因を残す

### DIFF
--- a/src/contexts/evaluation/infrastructure/gh.rs
+++ b/src/contexts/evaluation/infrastructure/gh.rs
@@ -59,10 +59,11 @@ async fn run_gh(cwd: &Path, args: &[&str]) -> Result<Vec<u8>, GhError> {
 
 fn log_and_convert(e: GhError) -> RepositoryError {
     match &e {
-        GhError::AuthRequired => {
+        GhError::AuthRequired(detail) => {
             log_record(&LogRecord {
                 category: ErrorCategory::Auth,
-                detail: None,
+                // gh stderr（失敗理由）を載せる。空なら従来どおり detail なし。
+                detail: (!detail.is_empty()).then(|| detail.clone()),
             });
         }
         GhError::Timeout => {

--- a/src/contexts/evaluation/infrastructure/gh/error.rs
+++ b/src/contexts/evaluation/infrastructure/gh/error.rs
@@ -3,7 +3,8 @@ use crate::contexts::evaluation::domain::error::RepositoryError;
 #[derive(Debug)]
 pub(super) enum GhError {
     NotInstalled,
-    AuthRequired,
+    /// 認証失敗。原因（gh stderr）を障害解析のため保持する。
+    AuthRequired(String),
     NoPr,
     RateLimited,
     Timeout,
@@ -14,7 +15,7 @@ pub(super) enum GhError {
 impl From<GhError> for RepositoryError {
     fn from(e: GhError) -> Self {
         match e {
-            GhError::NotInstalled | GhError::AuthRequired => RepositoryError::Unauthenticated,
+            GhError::NotInstalled | GhError::AuthRequired(_) => RepositoryError::Unauthenticated,
             GhError::RateLimited => RepositoryError::RateLimited,
             GhError::NoPr
             | GhError::NotGithubRepository
@@ -26,7 +27,7 @@ impl From<GhError> for RepositoryError {
 
 pub(super) fn classify_gh_error(exit_code: i32, stderr: &str) -> GhError {
     if exit_code == 4 || (exit_code == 1 && stderr.contains("HTTP 401")) {
-        GhError::AuthRequired
+        GhError::AuthRequired(stderr.to_owned())
     } else if exit_code == 1 && stderr.contains("no pull requests found") {
         GhError::NoPr
     } else if exit_code == 1 && stderr.contains("rate limit") {
@@ -50,7 +51,16 @@ mod tests {
 
     #[test]
     fn classify_auth_exit_code() {
-        assert_matches!(classify_gh_error(4, ""), GhError::AuthRequired);
+        assert_matches!(classify_gh_error(4, ""), GhError::AuthRequired(_));
+    }
+
+    #[test]
+    fn classify_auth_preserves_stderr() {
+        let GhError::AuthRequired(detail) = classify_gh_error(1, "HTTP 401: Bad credentials")
+        else {
+            panic!("expected AuthRequired");
+        };
+        assert_eq!(detail, "HTTP 401: Bad credentials");
     }
 
     #[test]

--- a/tests/e2e/prompt/errors.rs
+++ b/tests/e2e/prompt/errors.rs
@@ -103,6 +103,35 @@ fn test_error_log_written() {
     assert!(!content.is_empty(), "error.log が空");
 }
 
+/// #425: 認証失敗時、`error.log` の `[Auth]` 行に gh stderr 由来の detail（原因）が
+/// 記録されること。`[Auth]` のみで detail が無いと障害解析ができないため。
+#[test]
+fn test_auth_error_log_includes_stderr_detail() {
+    let stderr = "HTTP 401: Bad credentials (https://api.github.com/graphql)";
+    let env = TestEnv::with_error(stderr, 1);
+    let log_path = env.home().join(".cache/merge-ready/error.log");
+    let _daemon = DaemonHandle::start(&env);
+    DaemonHandle::wait_for_cache(&env, 5000);
+
+    cmd(&env)
+        .assert()
+        .success()
+        .stdout("✗ authentication required");
+
+    // `[Auth]` 行そのものに detail が載っていることを検証する。daemon の
+    // rate_limit fetcher も別行で stderr を warn 出力するため、ファイル全体への
+    // `contains` では誤って通過してしまう（その行は `[Auth]` を含まない）。
+    let content = std::fs::read_to_string(&log_path).unwrap();
+    let auth_line = content
+        .lines()
+        .find(|l| l.contains("[Auth]"))
+        .unwrap_or_else(|| panic!("no [Auth] line in error.log, got: {content}"));
+    assert!(
+        auth_line.contains("HTTP 401: Bad credentials"),
+        "expected gh stderr detail on the [Auth] line, got: {auth_line:?}"
+    );
+}
+
 // ── JSON 解析失敗 ─────────────────────────────────────────────────────────────
 
 /// `gh api graphql` が exit 0 で不正な JSON を返した場合 → `✗ unexpected error`


### PR DESCRIPTION
## 概要

Closes #425

認証失敗時、`error.log` に `[ERROR] [Auth]` の 1 行しか残らず、**どの呼び出しで・gh が何を返したのか**（`HTTP 401: Bad credentials`、トークン期限切れ等）が一切分からず障害解析できなかった。情報が 2 段階で失われていた。

## 原因

- **段階A（分類時）**: `classify_gh_error` が gh stderr を捨てて `GhError::AuthRequired`（ユニットバリアント）に畳んでいた。
- **段階B（ログ時）**: `log_and_convert` の Auth 分岐が `detail: None` を渡していた。

## 変更内容

- `GhError::AuthRequired` を `AuthRequired(String)` に変更し、`classify_gh_error` で gh stderr を保持。
- `log_and_convert` の Auth 分岐で `detail: Some(stderr)` を渡す。stderr が空の場合は従来どおり `[Auth]` のみ（末尾の余分な空白を避ける）。

## テスト

CONTRIBUTING の E2E 優先方針に従い `tests/e2e/prompt/errors.rs` に追加:

- 認証失敗時、`error.log` の `[Auth]` **行そのもの** に gh stderr 由来の detail が載ることを検証。
  - daemon の rate_limit fetcher も別行で stderr を warn 出力するため、ファイル全体への `contains` ではなく `[Auth]` 行を特定して検証している。
- 単体: `classify_gh_error` が認証分類時に stderr を保持することを検証。

```
cargo nextest run --workspace   # 438 passed
cargo clippy --workspace --all-targets --all-features -- -D warnings  # clean
cargo fmt --check --all         # clean
cargo deny check                # ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)