### PR TITLE
fix(daemon): error.log のタイムスタンプを日付込み RFC3339 にする

### DIFF
--- a/src/contexts/evaluation/infrastructure/logger.rs
+++ b/src/contexts/evaluation/infrastructure/logger.rs
@@ -1,7 +1,7 @@
 use std::fs::OpenOptions;
 use std::path::PathBuf;
 
-use simplelog::{Config, LevelFilter, WriteLogger};
+use simplelog::{ConfigBuilder, LevelFilter, WriteLogger};
 
 use crate::contexts::evaluation::domain::error::RepositoryError;
 
@@ -27,7 +27,10 @@ pub fn init() {
     let Ok(file) = OpenOptions::new().create(true).append(true).open(path) else {
         return;
     };
-    let _ = WriteLogger::init(log_level(), Config::default(), file);
+    // simplelog の既定書式は時刻のみ（`HH:MM:SS`）で日付を含まないため、
+    // 障害発生日を特定できるよう日付込みの RFC3339（UTC, 例 `2026-06-14T09:46:44Z`）にする。
+    let config = ConfigBuilder::new().set_time_format_rfc3339().build();
+    let _ = WriteLogger::init(log_level(), config, file);
 }
 
 /// `MERGE_READY_LOG_LEVEL` からロガーの記録レベルを決める。

--- a/tests/e2e/scenarios/log_level.rs
+++ b/tests/e2e/scenarios/log_level.rs
@@ -38,6 +38,19 @@ fn wait_until(max_ms: u64, mut cond: impl FnMut() -> bool) -> bool {
     }
 }
 
+/// 行頭が `YYYY-MM-DDT...` 形式（日付を含む RFC3339）かどうかを判定する。
+/// 旧実装の時刻のみ書式（例: `09:46:44`）は日付が無いため false になる。
+fn starts_with_rfc3339_date(line: &str) -> bool {
+    let b = line.as_bytes();
+    b.len() >= 11
+        && b[0..4].iter().all(u8::is_ascii_digit)
+        && b[4] == b'-'
+        && b[5..7].iter().all(u8::is_ascii_digit)
+        && b[7] == b'-'
+        && b[8..10].iter().all(u8::is_ascii_digit)
+        && b[10] == b'T'
+}
+
 /// デフォルト（warn）では `rate_limit` 取得失敗の warn ログが `error.log` に残る。
 #[test]
 fn warn_log_recorded_at_default_level() {
@@ -72,5 +85,31 @@ fn warn_log_suppressed_at_error_level() {
         !read_log(home).contains("rate_limit fetch failed"),
         "error レベルなのに warn が記録された: {:?}",
         read_log(home)
+    );
+}
+
+/// `error.log` の各行は日付を含む RFC3339 タイムスタンプで始まる（#424）。
+/// 旧実装は時刻のみ（`HH:MM:SS`）で日付が無く、複数日にまたがると
+/// いつ障害が起きたのか特定できなかった。
+#[test]
+fn error_log_line_starts_with_date() {
+    let fx = log_level_fixtures::with_failing_rate_limit();
+    let _daemon = DaemonHandle::start(&fx.env);
+    DaemonHandle::wait_for_cache(&fx.env, 5000);
+
+    let home = fx.env.home().to_path_buf();
+    let found = wait_until(POLL_MS, || {
+        read_log(&home).contains("rate_limit fetch failed")
+    });
+    assert!(found, "warn ログが記録されていない: {:?}", read_log(&home));
+
+    let log = read_log(&home);
+    let line = log
+        .lines()
+        .find(|l| l.contains("rate_limit fetch failed"))
+        .expect("warn 行が見つからない");
+    assert!(
+        starts_with_rfc3339_date(line),
+        "行が日付を含む RFC3339 タイムスタンプで始まっていない: {line:?}"
     );
 }


### PR DESCRIPTION
## 概要

`logger::init()` が出力する `error.log` のタイムスタンプが時刻のみ（`HH:MM:SS`）で日付を含まず、複数日にまたがるログから障害発生日を特定できなかった問題（#424）を修正する。

## 変更内容

- `src/contexts/evaluation/infrastructure/logger.rs`
  - simplelog の `Config::default()`（既定書式は時刻のみ）を `ConfigBuilder::new().set_time_format_rfc3339().build()` に置き換え、日付＋タイムゾーンを含む RFC3339 で出力する。

  ```
  before: 09:46:44 [ERROR] [Auth]
  after:  2026-06-14T09:46:44.123456Z [ERROR] [Auth]
  ```

## 設計判断（UTC を採用）

Issue の「理想は RFC3339＋タイムゾーン」に沿い **UTC の RFC3339** を採用した。

`local-offset` は simplelog 0.12 の default features に含まれるため、`set_time_offset_to_local()` でローカル時刻化も可能。しかし daemon はマルチスレッドであり、time crate の安全策により local offset 取得が失敗 → UTC へフォールバックする公算が大きく挙動が不確実になる。確実に日付とタイムゾーンを残せる UTC を選んだ。

## テスト

CONTRIBUTING の E2E 優先方針に従い、`tests/e2e/scenarios/log_level.rs` に `error.log` の行が日付込み RFC3339 タイムスタンプで始まることを検証するテストを追加（実装前に Red→Green を確認）。

- `cargo nextest run --workspace` … 437 passed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` … clean
- `cargo fmt --check --all` / layer-deps / no-mod-rs / no-clippy-allow … OK

Closes #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)