### PR TITLE
fix(daemon): backoff の reset 時刻をボトルネック側リソース基準にする

### DIFF
--- a/src/contexts/daemon/domain/cache/transition.rs
+++ b/src/contexts/daemon/domain/cache/transition.rs
@@ -294,8 +294,11 @@ fn should_enter_backoff(snapshot: &RateLimitSnapshot) -> bool {
     snapshot.bottleneck_ratio_bp() <= BACKOFF_THRESHOLD_BP
 }
 
-/// `snapshot.reset_at`（壁時計）を `Instant`（モノトニック）へ変換し、
+/// ボトルネック側の reset（壁時計）を `Instant`（モノトニック）へ変換し、
 /// `BACKOFF_SAFETY_MARGIN` を追加した値を返す。
+///
+/// backoff の要因となったリソース（core / graphql のうち消費比率の小さい側）の
+/// reset を使う。core 固定だと graphql 枯渇時に解除時刻がずれる（Issue #407）。
 ///
 /// `gh api rate_limit` が返す `reset` は秒単位の Unix epoch なので、reset の瞬間に
 /// resume すると整数秒の境界に複数の refresh が集中しうる。`SCHEDULER_TICK_SECS` の
@@ -307,7 +310,10 @@ fn reset_instant_from_snapshot(
     now_instant: Instant,
     now_wall: SystemTime,
 ) -> Option<Instant> {
-    let delta = snapshot.reset_at.duration_since(now_wall).ok()?;
+    let delta = snapshot
+        .bottleneck_reset_at()
+        .duration_since(now_wall)
+        .ok()?;
     Some(now_instant + delta + BACKOFF_SAFETY_MARGIN)
 }
 
@@ -853,12 +859,14 @@ mod tests {
     // ── on_rate_limit_observed ───────────────────────────────────
 
     fn make_snapshot(remaining: u32, limit: u32, secs_until_reset: u64) -> RateLimitSnapshot {
+        let reset_at = SystemTime::now() + Duration::from_secs(secs_until_reset);
         RateLimitSnapshot {
             core_remaining: remaining,
             core_limit: limit,
             graphql_remaining: remaining,
             graphql_limit: limit,
-            reset_at: SystemTime::now() + Duration::from_secs(secs_until_reset),
+            core_reset_at: reset_at,
+            graphql_reset_at: reset_at,
             fetched_at: Instant::now(),
         }
     }
@@ -920,5 +928,36 @@ mod tests {
             "EnterBackoff expected when below threshold: {effects:?}"
         );
         assert!(new_store.backoff_until().is_some());
+    }
+
+    #[test]
+    fn on_rate_limit_observed_backoff_uses_graphql_reset_when_graphql_is_bottleneck() {
+        // Issue #407: graphql だけ枯渇し core は健全かつ reset が遠い未来のケース。
+        // backoff の解除時刻は core ではなく graphql の reset を基準にする。
+        let store = CacheStore::new();
+        let now = Instant::now();
+        let now_wall = SystemTime::now();
+        let snapshot = RateLimitSnapshot {
+            core_remaining: 5_000,
+            core_limit: 5_000,
+            graphql_remaining: 0,
+            graphql_limit: 5_000,
+            core_reset_at: now_wall + Duration::from_hours(1),
+            graphql_reset_at: now_wall + Duration::from_mins(1),
+            fetched_at: now,
+        };
+        let event = RateLimitObservedEvent {
+            snapshot,
+            now,
+            now_wall,
+        };
+        let (new_store, _effects) = on_rate_limit_observed(store, &event);
+
+        let until = new_store.backoff_until().expect("backoff set");
+        // graphql reset(60s) + 安全マージン を基準にした Instant になる。
+        let expected = now + Duration::from_mins(1) + BACKOFF_SAFETY_MARGIN;
+        assert_eq!(until, expected);
+        // core reset(3600s) 基準では決してない。
+        assert!(until < now + Duration::from_hours(1));
     }
 }

--- a/src/contexts/daemon/domain/rate_limit_snapshot.rs
+++ b/src/contexts/daemon/domain/rate_limit_snapshot.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::time::{Instant, SystemTime};
 
 /// `bottleneck_ratio` の basis points スケール（10000 == 1.0）。
@@ -16,22 +17,45 @@ fn ratio_bp(remaining: u32, limit: u32) -> u64 {
 ///
 /// `core` と `graphql` の両方を保持し、両者のうち消費比率の高い側を
 /// ボトルネックとみなして判定する。`fetched_at` は 60 秒キャッシュの
-/// 鮮度判定に、`reset_at` はリセット時刻までの残時間計算に使う。
+/// 鮮度判定に、`core_reset_at` / `graphql_reset_at` はリセット時刻までの
+/// 残時間計算に使う（reset 時刻は core / graphql で異なりうるため別々に保持し、
+/// ボトルネック側の reset を [`Self::bottleneck_reset_at`] で採用する）。
 #[derive(Debug, Clone, Copy)]
 pub struct RateLimitSnapshot {
     pub core_remaining: u32,
     pub core_limit: u32,
     pub graphql_remaining: u32,
     pub graphql_limit: u32,
-    pub reset_at: SystemTime,
+    pub core_reset_at: SystemTime,
+    pub graphql_reset_at: SystemTime,
     pub fetched_at: Instant,
 }
 
 impl RateLimitSnapshot {
-    /// `now` から `reset_at` までの秒数。既に過ぎていれば 0。
+    /// `now` からボトルネック側の reset までの秒数。既に過ぎていれば 0。
     #[must_use]
     pub fn secs_until_reset(&self, now: SystemTime) -> u64 {
-        self.reset_at.duration_since(now).map_or(0, |d| d.as_secs())
+        self.bottleneck_reset_at()
+            .duration_since(now)
+            .map_or(0, |d| d.as_secs())
+    }
+
+    /// backoff / 予算計算でボトルネックとなった側の reset 時刻を返す。
+    ///
+    /// 残量比率が小さい（=消費が進んだ）側を採用する。これにより graphql が
+    /// 枯渇したのに core の reset まで全リフレッシュを止める / core より先に
+    /// graphql を解除して失敗を繰り返す、という不整合（Issue #407）を防ぐ。
+    /// 比率が同率（両枯渇など）の場合は遅い方の reset を採用し、片側未回復のまま
+    /// resume するのを避ける。
+    #[must_use]
+    pub fn bottleneck_reset_at(&self) -> SystemTime {
+        let core_ratio = ratio_bp(self.core_remaining, self.core_limit);
+        let graphql_ratio = ratio_bp(self.graphql_remaining, self.graphql_limit);
+        match core_ratio.cmp(&graphql_ratio) {
+            Ordering::Less => self.core_reset_at,
+            Ordering::Greater => self.graphql_reset_at,
+            Ordering::Equal => self.core_reset_at.max(self.graphql_reset_at),
+        }
     }
 
     /// `core` または `graphql` の `remaining` が 0 なら枯渇とみなす。
@@ -68,7 +92,28 @@ mod tests {
             core_limit,
             graphql_remaining,
             graphql_limit,
-            reset_at,
+            core_reset_at: reset_at,
+            graphql_reset_at: reset_at,
+            fetched_at: Instant::now(),
+        }
+    }
+
+    /// core / graphql で別々の reset を持つスナップショットを作る。
+    fn snapshot_split_reset(
+        core_remaining: u32,
+        core_limit: u32,
+        graphql_remaining: u32,
+        graphql_limit: u32,
+        core_reset_at: SystemTime,
+        graphql_reset_at: SystemTime,
+    ) -> RateLimitSnapshot {
+        RateLimitSnapshot {
+            core_remaining,
+            core_limit,
+            graphql_remaining,
+            graphql_limit,
+            core_reset_at,
+            graphql_reset_at,
             fetched_at: Instant::now(),
         }
     }
@@ -124,5 +169,45 @@ mod tests {
         // もう一方（graphql 25% = 2500 bp）が採用される。
         let s = snapshot(0, 0, 2500, 10_000, SystemTime::now());
         assert_eq!(s.bottleneck_ratio_bp(), 2500);
+    }
+
+    #[test]
+    fn bottleneck_reset_at_picks_graphql_when_graphql_is_bottleneck() {
+        let now = SystemTime::now();
+        let core_reset = now + Duration::from_hours(1);
+        let graphql_reset = now + Duration::from_mins(1);
+        // graphql が枯渇（比率 0）→ graphql 側の reset を採用。
+        let s = snapshot_split_reset(5000, 5000, 0, 5000, core_reset, graphql_reset);
+        assert_eq!(s.bottleneck_reset_at(), graphql_reset);
+    }
+
+    #[test]
+    fn bottleneck_reset_at_picks_core_when_core_is_bottleneck() {
+        let now = SystemTime::now();
+        let core_reset = now + Duration::from_mins(1);
+        let graphql_reset = now + Duration::from_hours(1);
+        // core が枯渇（比率 0）→ core 側の reset を採用。
+        let s = snapshot_split_reset(0, 5000, 5000, 5000, core_reset, graphql_reset);
+        assert_eq!(s.bottleneck_reset_at(), core_reset);
+    }
+
+    #[test]
+    fn bottleneck_reset_at_picks_later_when_ratios_tie() {
+        let now = SystemTime::now();
+        let core_reset = now + Duration::from_mins(1);
+        let graphql_reset = now + Duration::from_mins(2);
+        // 両方枯渇（比率同率）→ 片側未回復のままの resume を避けるため遅い方を採用。
+        let s = snapshot_split_reset(0, 5000, 0, 5000, core_reset, graphql_reset);
+        assert_eq!(s.bottleneck_reset_at(), graphql_reset);
+    }
+
+    #[test]
+    fn secs_until_reset_uses_bottleneck_side() {
+        let now = SystemTime::now();
+        let core_reset = now + Duration::from_hours(1);
+        let graphql_reset = now + Duration::from_mins(1);
+        // graphql 枯渇 → secs_until_reset は graphql reset（60s）基準になる。
+        let s = snapshot_split_reset(5000, 5000, 0, 5000, core_reset, graphql_reset);
+        assert_eq!(s.secs_until_reset(now), 60);
     }
 }

--- a/src/contexts/daemon/domain/refresh_policy.rs
+++ b/src/contexts/daemon/domain/refresh_policy.rs
@@ -383,12 +383,14 @@ mod tests {
     fn snapshot_at_bp(remaining_bp: u32, secs_until_reset: u64) -> RateLimitSnapshot {
         let limit: u32 = 10_000;
         let remaining = remaining_bp.min(limit);
+        let reset_at = SystemTime::now() + Duration::from_secs(secs_until_reset);
         RateLimitSnapshot {
             core_remaining: remaining,
             core_limit: limit,
             graphql_remaining: remaining,
             graphql_limit: limit,
-            reset_at: SystemTime::now() + Duration::from_secs(secs_until_reset),
+            core_reset_at: reset_at,
+            graphql_reset_at: reset_at,
             fetched_at: Instant::now(),
         }
     }

--- a/src/contexts/daemon/infrastructure/daemon_state_actor.rs
+++ b/src/contexts/daemon/infrastructure/daemon_state_actor.rs
@@ -214,7 +214,8 @@ mod tests {
             core_limit: 5000,
             graphql_remaining: 5000,
             graphql_limit: 5000,
-            reset_at: now_wall + Duration::from_mins(1),
+            core_reset_at: now_wall + Duration::from_mins(1),
+            graphql_reset_at: now_wall + Duration::from_mins(1),
             fetched_at: Instant::now(),
         };
         let event = RateLimitObservedEvent {
@@ -245,7 +246,8 @@ mod tests {
             core_limit: 5000,
             graphql_remaining: 5000,
             graphql_limit: 5000,
-            reset_at: start_wall + Duration::from_mins(1),
+            core_reset_at: start_wall + Duration::from_mins(1),
+            graphql_reset_at: start_wall + Duration::from_mins(1),
             fetched_at: start,
         };
         let first = handle
@@ -288,7 +290,8 @@ mod tests {
             core_limit: 5000,
             graphql_remaining: 5000,
             graphql_limit: 5000,
-            reset_at: start_wall + Duration::from_mins(1),
+            core_reset_at: start_wall + Duration::from_mins(1),
+            graphql_reset_at: start_wall + Duration::from_mins(1),
             fetched_at: start,
         };
         let first = handle

--- a/src/contexts/daemon/infrastructure/rate_limit_client.rs
+++ b/src/contexts/daemon/infrastructure/rate_limit_client.rs
@@ -100,7 +100,8 @@ fn parse_rate_limit_json(bytes: &[u8], fetched_at: Instant) -> Option<RateLimitS
         core_limit: response.resources.core.limit,
         graphql_remaining: response.resources.graphql.remaining,
         graphql_limit: response.resources.graphql.limit,
-        reset_at: UNIX_EPOCH + Duration::from_secs(response.resources.core.reset),
+        core_reset_at: UNIX_EPOCH + Duration::from_secs(response.resources.core.reset),
+        graphql_reset_at: UNIX_EPOCH + Duration::from_secs(response.resources.graphql.reset),
         fetched_at,
     })
 }
@@ -126,9 +127,15 @@ mod tests {
         assert_eq!(snap.core_limit, 5000);
         assert_eq!(snap.graphql_remaining, 4600);
         assert_eq!(snap.graphql_limit, 5000);
-        // reset_at は core.reset の unix epoch
-        let expected = UNIX_EPOCH + Duration::from_secs(1_778_924_570);
-        assert_eq!(snap.reset_at, expected);
+        // core / graphql の reset はそれぞれの resource の値から取る（別時刻）。
+        assert_eq!(
+            snap.core_reset_at,
+            UNIX_EPOCH + Duration::from_secs(1_778_924_570)
+        );
+        assert_eq!(
+            snap.graphql_reset_at,
+            UNIX_EPOCH + Duration::from_secs(1_778_921_661)
+        );
     }
 
     #[test]
@@ -156,7 +163,8 @@ mod tests {
             core_limit: 5000,
             graphql_remaining: 100,
             graphql_limit: 5000,
-            reset_at: SystemTime::now() + Duration::from_hours(1),
+            core_reset_at: SystemTime::now() + Duration::from_hours(1),
+            graphql_reset_at: SystemTime::now() + Duration::from_hours(1),
             fetched_at: Instant::now(),
         };
         *client.cache.lock().unwrap() = Some(snap);
@@ -171,7 +179,8 @@ mod tests {
             core_limit: 5000,
             graphql_remaining: 100,
             graphql_limit: 5000,
-            reset_at: SystemTime::now() + Duration::from_hours(1),
+            core_reset_at: SystemTime::now() + Duration::from_hours(1),
+            graphql_reset_at: SystemTime::now() + Duration::from_hours(1),
             // 2 秒前に取得 → TTL 1 秒では stale
             fetched_at: Instant::now()
                 .checked_sub(Duration::from_secs(2))

--- a/tests/e2e/scenarios/rate_limit_aware.rs
+++ b/tests/e2e/scenarios/rate_limit_aware.rs
@@ -107,3 +107,56 @@ fn test_rate_limit_exhausted_pauses_refresh_until_reset() {
          (during backoff: {pr_calls_during_backoff}, after reset: {pr_calls_after_reset})"
     );
 }
+
+/// Issue #407: graphql のみ枯渇し、core は健全だが reset が遠い未来（now+3600）の
+/// スナップショットを観測したケース。backoff の解除時刻は **ボトルネックである
+/// graphql の reset** を基準にしなければならない。
+///
+/// 旧実装は常に core の reset を採用していたため、graphql 枯渇でも backoff が
+/// core reset（遠い未来）まで続き、graphql 回復後もリフレッシュが再開しなかった。
+/// ボトルネック側の reset を使う修正後は、graphql reset（~2s）経過で再開する。
+#[test]
+fn test_graphql_exhausted_resumes_at_graphql_reset_not_core_reset() {
+    // 1 回目: graphql remaining=0 / reset=now+2s、core remaining=4999 / reset=now+3600s。
+    let fx = rate_limit_aware_fixtures::with_graphql_exhausted_core_late_reset(2);
+    let _daemon = DaemonHandle::start_with_env(
+        &fx.env,
+        &[
+            ("MERGE_READY_HOT_RECENT_QUERY_SECS", "60"),
+            ("MERGE_READY_HOT_WITH_QUERY_SECS", "1"),
+            ("MERGE_READY_WARM_REFRESH_SECS", "1"),
+            ("MERGE_READY_STALE_TTL", "60"),
+            ("MERGE_READY_SCHEDULER_TICK_SECS", "1"),
+            ("MERGE_READY_RATE_LIMIT_FETCH_INTERVAL_SECS", "1"),
+        ],
+    );
+
+    DaemonHandle::wait_for_cache(&fx.env, 15000);
+
+    // backoff 中 (~graphql reset まで) は graphql (pr list) 呼び出しが発生しない。
+    let pr_calls_at_t0 = std::fs::read_to_string(&fx.pr_list_log)
+        .unwrap_or_default()
+        .len();
+    std::thread::sleep(std::time::Duration::from_millis(1500));
+    let pr_calls_during_backoff = std::fs::read_to_string(&fx.pr_list_log)
+        .unwrap_or_default()
+        .len();
+    assert_eq!(
+        pr_calls_at_t0, pr_calls_during_backoff,
+        "during backoff (~1.5s after graphql exhaustion observed), pr list should not be called \
+         (t0: {pr_calls_at_t0}, t0+1.5s: {pr_calls_during_backoff})"
+    );
+
+    // graphql reset(~2s) 経過 + 次の rate_limit fetch + tick で再開する。
+    // core reset(now+3600) を採用していたら、ここでは絶対に再開しない。
+    std::thread::sleep(std::time::Duration::from_secs(4));
+    let pr_calls_after_reset = std::fs::read_to_string(&fx.pr_list_log)
+        .unwrap_or_default()
+        .len();
+    assert!(
+        pr_calls_after_reset > pr_calls_during_backoff,
+        "after graphql reset (~5.5s total), refresh must resume because backoff uses the \
+         bottleneck (graphql) reset, not core's far-future reset \
+         (during backoff: {pr_calls_during_backoff}, after reset: {pr_calls_after_reset})"
+    );
+}

--- a/tests/e2e/scenarios/rate_limit_aware_fixtures.rs
+++ b/tests/e2e/scenarios/rate_limit_aware_fixtures.rs
@@ -75,6 +75,74 @@ pub fn with_rate_limit_response(remaining_bp: u32, reset_offset_secs: u64) -> Ra
     }
 }
 
+/// Issue #407: 1 回目の `api rate_limit` で **graphql のみ枯渇**させ、core は健全だが
+/// reset が遠い未来（now + 3600）を返す fake gh を構築する。2 回目以降は両方フル。
+///
+/// `graphql_reset_offset_secs` は 1 回目応答の graphql reset (now + offset)。
+/// backoff の解除に core 固定の reset を使うバグがあると遠い未来まで再開しないが、
+/// ボトルネック（graphql）の reset を使えば短時間で再開する。
+pub fn with_graphql_exhausted_core_late_reset(graphql_reset_offset_secs: u64) -> RateLimitFixture {
+    let (bin, home_tmp, repo) = setup_git_dirs("feat/my-feature");
+    let pr_list_log = home_tmp.path().join("pr_list_calls.log");
+    let rate_limit_log = home_tmp.path().join("rate_limit_calls.log");
+    let pr_list_log_s = pr_list_log.display().to_string();
+    let rate_limit_log_s = rate_limit_log.display().to_string();
+    let rate_limit_counter = home_tmp.path().join("rate_limit_counter");
+    let rate_limit_counter_s = rate_limit_counter.display().to_string();
+
+    let limit: u32 = 5_000;
+    let graphql_json = graphql_single(
+        r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null}"#,
+        Some(ROLLUP_PASS),
+    );
+
+    let script = format!(
+        "#!/bin/sh\n\
+         case \"$*\" in\n\
+           *'api rate_limit'*)\n\
+             printf '1' >> \"{rate_limit_log_s}\"\n\
+             count=$(cat \"{rate_limit_counter_s}\" 2>/dev/null || printf '0')\n\
+             count=$((count + 1))\n\
+             printf '%d' \"$count\" > \"{rate_limit_counter_s}\"\n\
+             now=$(date +%s)\n\
+             core_remaining=4999\n\
+             core_reset=$((now + 3600))\n\
+             if [ \"$count\" -eq 1 ]; then\n\
+               graphql_remaining=0\n\
+               graphql_reset=$((now + {graphql_reset_offset_secs}))\n\
+             else\n\
+               graphql_remaining=4999\n\
+               graphql_reset=$((now + 3600))\n\
+             fi\n\
+             printf '{{\"resources\":{{\"core\":{{\"limit\":{limit},\"remaining\":%d,\"reset\":%d}},\"graphql\":{{\"limit\":{limit},\"remaining\":%d,\"reset\":%d}}}}}}' \"$core_remaining\" \"$core_reset\" \"$graphql_remaining\" \"$graphql_reset\"\n\
+             exit 0\n\
+             ;;\n\
+           *graphql*)\n\
+             printf '1' >> \"{pr_list_log_s}\"\n\
+             printf '%s' '{graphql_json}'\n\
+             ;;\n\
+           *'api'*'compare'*)\n\
+             printf '{{\"behind_by\":0}}'\n\
+             ;;\n\
+           *)\n\
+             printf 'unexpected gh call: %s' \"$*\" >&2\n\
+             exit 127\n\
+             ;;\n\
+         esac\n"
+    );
+    write_executable(bin.path().join("gh"), &script);
+
+    RateLimitFixture {
+        env: TestEnv {
+            bin,
+            home_tmp,
+            repo,
+        },
+        pr_list_log,
+        rate_limit_log,
+    }
+}
+
 /// 1 回目の `api rate_limit` で枯渇、2 回目以降で残量フルを返す fake gh を構築する。
 /// バックオフ → reset 経過後の再開を検証するシナリオで使用する。
 ///


### PR DESCRIPTION
## 背景 / Issue

Closes #407

`RateLimitSnapshot` は core / graphql 両方の残量を持ち、`should_enter_backoff` は両リソースのうちボトルネック側で backoff 突入を判定する。一方 `reset_at` はパース時に**常に `core.reset`** を採用していたため、graphql の枯渇・閾値割れで backoff に入っても解除時刻が core の reset になっていた。

- core の reset が graphql より遅い → graphql 回復済みでも不要に全リフレッシュを停止
- core の reset が先 → graphql 未回復のまま backoff を解除し、失敗するリフレッシュを再開

## 修正

- `RateLimitSnapshot.reset_at` を `core_reset_at` / `graphql_reset_at` に分割して保持
- 消費比率の小さい（=ボトルネック）側の reset を返す `bottleneck_reset_at()` を追加
  - 比率が同率（両枯渇など）の場合は、片側未回復のままの resume を避けるため**遅い方**の reset を採用
- backoff の `reset_instant_from_snapshot`（`transition.rs`）と refresh_policy の予算項が参照する `secs_until_reset` の双方が `bottleneck_reset_at()` を使うことで、ボトルネック判定と reset 時刻の基準を一致させた
- `parse_rate_limit_json` で core / graphql それぞれの `reset` を別々に格納

## テスト

- **E2E**（`tests/e2e/scenarios/rate_limit_aware.rs`）: graphql のみ枯渇 + core が遠い未来（now+3600s）の reset を返すスナップショットを観測したケースで、backoff が **graphql の reset（~2s）** で解除され短時間でリフレッシュが再開することを検証。core 固定の旧挙動ではこのテストは失敗する（手元で revert して red を確認済み）。
- ユニット: `bottleneck_reset_at`（graphql 側 / core 側 / 同率時は遅い方）・`secs_until_reset` がボトルネック側を使うこと・`parse_rate_limit_json` が core/graphql 別々の reset を格納すること。

## 確認

- `cargo nextest run --workspace` … 442 passed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` … clean
- `cargo fmt --check --all` … clean
- `scripts/check-layer-deps.sh` / `check-no-mod-rs.sh` / `check-no-clippy-allow.sh` … OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)