### PR TITLE
fix(daemon): watch テーブルの列揃えを端末表示幅（Unicode Annex #11）基準にする

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,6 +654,7 @@ dependencies = [
  "tokio-util",
  "toml",
  "twox-hash",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1331,6 +1332,12 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ simplelog = "0.12"
 toml = "1.1"
 crossterm = "0.29"
 bitflags = "2.13"
+# watch テーブルの列揃えを端末上の表示幅（Unicode Annex #11）基準で計算する。
+# CJK・絵文字は 2 桁幅、結合文字は 0 桁幅のため、char 数では正しく揃わない。
+unicode-width = "0.2"
 tokio = { version = "1.52", features = ["full"] }
 tokio-util = { version = "0.7", default-features = false }
 # 設定ファイルの変更検知（非暗号学的な内容ハッシュ）に使う。独自実装を避け xxHash を利用。
@@ -62,6 +65,8 @@ predicates = "3.1"
 rstest = "0.26"
 serde_json = "1.0"
 tempfile = "3.27"
+# watch テーブルの列揃えを E2E で検証する際、端末表示幅を独立して計測するために使う。
+unicode-width = "0.2"
 tokio = { version = "1.52", features = ["test-util"] }
 
 [[bench]]

--- a/src/contexts/daemon/interface/cli/watch.rs
+++ b/src/contexts/daemon/interface/cli/watch.rs
@@ -1,4 +1,3 @@
-use std::fmt::Write as _;
 use std::process::ExitCode;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -7,6 +6,7 @@ use crossterm::{
     terminal::{self, ClearType},
 };
 use tokio::signal::unix::{Signal, SignalKind, signal};
+use unicode_width::UnicodeWidthChar;
 
 use crate::contexts::daemon::application::port::{EntryView, WatchPort};
 
@@ -86,39 +86,54 @@ fn format_table(entries: &[EntryView]) -> String {
     let widths = TableWidths::from_rows(&header, &rows);
 
     let mut out = String::new();
-    let _ = writeln!(
-        out,
-        "{:<cwd_width$}  {:<branch_width$}  {:<pr_width$}  {:<status_width$}  {:>cached_at_width$}",
-        header.cwd,
-        header.branch,
-        header.pr,
-        header.status,
-        header.cached_at,
-        cwd_width = widths.cwd,
-        branch_width = widths.branch,
-        pr_width = widths.pr,
-        status_width = widths.status,
-        cached_at_width = widths.cached_at,
-    );
+    write_row(&mut out, &header, &widths);
     for row in &rows {
-        // Rust の幅指定子は `chars()` 数ベース。ANSI 込みの status を
-        // 見た目幅 `widths.status` で揃えるため、不可視 char 分を足し戻す。
-        let status_pad = widths.status - visible_len(&row.status) + row.status.chars().count();
-        let _ = writeln!(
-            out,
-            "{:<cwd_width$}  {:<branch_width$}  {:<pr_width$}  {:<status_pad$}  {:>cached_at_width$}",
-            row.cwd,
-            row.branch,
-            row.pr,
-            row.status,
-            row.cached_at,
-            cwd_width = widths.cwd,
-            branch_width = widths.branch,
-            pr_width = widths.pr,
-            cached_at_width = widths.cached_at,
-        );
+        write_row(&mut out, row, &widths);
     }
     out
+}
+
+#[derive(Clone, Copy)]
+enum Align {
+    Left,
+    Right,
+}
+
+/// 1 行を `widths` に従って整形して `out` に追記する。列間は空白 2 つで区切る。
+/// Rust の幅指定子 `{:<width$}` は `chars()` 数ベースで端末表示幅を考慮しないため、
+/// パディングは表示幅基準で自前に行う。
+fn write_row(out: &mut String, row: &TableRow, widths: &TableWidths) {
+    push_padded(out, &row.cwd, widths.cwd, Align::Left);
+    out.push_str("  ");
+    push_padded(out, &row.branch, widths.branch, Align::Left);
+    out.push_str("  ");
+    push_padded(out, &row.pr, widths.pr, Align::Left);
+    out.push_str("  ");
+    push_padded(out, &row.status, widths.status, Align::Left);
+    out.push_str("  ");
+    push_padded(out, &row.cached_at, widths.cached_at, Align::Right);
+    out.push('\n');
+}
+
+/// `cell` を表示幅 `width` に合わせてパディングして `out` に追記する。
+fn push_padded(out: &mut String, cell: &str, width: usize, align: Align) {
+    let pad = width.saturating_sub(display_width(cell));
+    match align {
+        Align::Left => {
+            out.push_str(cell);
+            push_spaces(out, pad);
+        }
+        Align::Right => {
+            push_spaces(out, pad);
+            out.push_str(cell);
+        }
+    }
+}
+
+fn push_spaces(out: &mut String, n: usize) {
+    for _ in 0..n {
+        out.push(' ');
+    }
 }
 
 struct TableRow {
@@ -152,16 +167,25 @@ struct TableWidths {
 impl TableWidths {
     fn from_rows(header: &TableRow, rows: &[TableRow]) -> Self {
         Self {
-            cwd: max_width(rows.iter().map(|row| row.cwd.len()), header.cwd.len()),
-            branch: max_width(rows.iter().map(|row| row.branch.len()), header.branch.len()),
-            pr: max_width(rows.iter().map(|row| row.pr.len()), header.pr.len()),
+            cwd: max_width(
+                rows.iter().map(|row| display_width(&row.cwd)),
+                display_width(&header.cwd),
+            ),
+            branch: max_width(
+                rows.iter().map(|row| display_width(&row.branch)),
+                display_width(&header.branch),
+            ),
+            pr: max_width(
+                rows.iter().map(|row| display_width(&row.pr)),
+                display_width(&header.pr),
+            ),
             status: max_width(
-                rows.iter().map(|row| visible_len(&row.status)),
-                header.status.len(),
+                rows.iter().map(|row| display_width(&row.status)),
+                display_width(&header.status),
             ),
             cached_at: max_width(
-                rows.iter().map(|row| row.cached_at.len()),
-                header.cached_at.len(),
+                rows.iter().map(|row| display_width(&row.cached_at)),
+                display_width(&header.cached_at),
             ),
         }
     }
@@ -175,9 +199,10 @@ fn format_pr_id(pr_id: Option<u64>) -> String {
     pr_id.map_or_else(String::new, |id| format!("#{id}"))
 }
 
-fn visible_len(s: &str) -> usize {
-    // ANSI エスケープシーケンス（ESC [ ... m）を除いた表示幅
-    let mut len = 0;
+/// ANSI エスケープシーケンス（ESC [ ... m）を除いた端末上の表示幅。
+/// CJK・絵文字は 2 桁、結合文字は 0 桁として数える（Unicode Annex #11）。
+fn display_width(s: &str) -> usize {
+    let mut width = 0;
     let mut in_escape = false;
     for c in s.chars() {
         if c == '\x1b' {
@@ -187,10 +212,10 @@ fn visible_len(s: &str) -> usize {
                 in_escape = false;
             }
         } else {
-            len += 1;
+            width += UnicodeWidthChar::width(c).unwrap_or(0);
         }
     }
-    len
+    width
 }
 
 fn format_cached_at(cached_at_secs: u64) -> String {
@@ -341,7 +366,7 @@ mod tests {
 
     #[test]
     fn format_table_right_aligns_cached_at_column() {
-        // status は ASCII（visible_len == len）にして他列の幅ぶれを排除し、
+        // status は ASCII（display_width == len）にして他列の幅ぶれを排除し、
         // CACHED AT 列の右揃えのみを検証する。
         let rows = vec![
             make_view("/repo", "main", Some(1), "Ready", 5),
@@ -351,7 +376,7 @@ mod tests {
         let lines: Vec<&str> = table.lines().collect();
         assert_eq!(lines.len(), 3, "header + 2 rows: {table:?}");
 
-        let widths: Vec<usize> = lines.iter().map(|l| visible_len(l)).collect();
+        let widths: Vec<usize> = lines.iter().map(|l| display_width(l)).collect();
         assert!(
             widths.windows(2).all(|w| w[0] == w[1]),
             "全行の表示幅が揃うべき: {widths:?} / {table:?}",
@@ -373,6 +398,39 @@ mod tests {
             lines[2].ends_with("   2h ago"),
             "短い相対時刻は右揃えされるべき: {:?}",
             lines[2],
+        );
+    }
+
+    #[rstest]
+    #[case("a", 1)]
+    #[case("feat/123", 8)]
+    // CJK は 1 文字 2 桁幅。
+    #[case("あ", 2)]
+    #[case("feat/機能追加", 13)]
+    // 結合文字（合成済み「が」= 「か」+ 濁点）は基底 2 桁 + 結合 0 桁。
+    #[case("か\u{3099}", 2)]
+    // ANSI SGR は表示幅 0。
+    #[case("\u{1b}[32m✓ Ready\u{1b}[0m", 7)]
+    fn display_width_counts_terminal_columns(#[case] input: &str, #[case] expected: usize) {
+        assert_eq!(display_width(input), expected);
+    }
+
+    /// 非 ASCII の cwd / branch を含む場合でも、全行が端末表示幅で揃うこと。
+    /// バイト長基準（旧 `len()`）では CJK 行以外が過剰パディングされて崩れる。
+    #[test]
+    fn format_table_aligns_columns_by_display_width_with_cjk() {
+        let rows = vec![
+            make_view("/repo", "feat/機能追加", Some(1), "✓ Ready", 5),
+            make_view("/repo", "main", Some(2), "✓ Ready", 5),
+        ];
+        let table = format_table(&rows);
+        let lines: Vec<&str> = table.lines().collect();
+        assert_eq!(lines.len(), 3, "header + 2 rows: {table:?}");
+
+        let widths: Vec<usize> = lines.iter().map(|l| display_width(l)).collect();
+        assert!(
+            widths.windows(2).all(|w| w[0] == w[1]),
+            "全行の表示幅が揃うべき: {widths:?} / {table:?}",
         );
     }
 }

--- a/tests/e2e/daemon/watch.rs
+++ b/tests/e2e/daemon/watch.rs
@@ -269,6 +269,64 @@ fn test_watch_right_aligns_cached_at_column() {
     );
 }
 
+/// SGR カラーコード（`...m` 終端）を除き、Unicode 表示幅（CJK=2 桁）で可視幅を返す。
+fn display_width(s: &str) -> usize {
+    use unicode_width::UnicodeWidthChar;
+    let mut width = 0;
+    let mut in_esc = false;
+    for c in s.chars() {
+        if c == '\x1b' {
+            in_esc = true;
+        } else if in_esc {
+            if c == 'm' {
+                in_esc = false;
+            }
+        } else {
+            width += UnicodeWidthChar::width(c).unwrap_or(0);
+        }
+    }
+    width
+}
+
+/// #409: BRANCH 列に CJK（マルチバイト・2 桁幅）を含む場合でも、列を端末表示幅で揃える。
+/// バイト長基準（旧実装）だと CJK ブランチ列が過剰に幅計算され、後続の CACHED AT 列の
+/// 右端がヘッダー行とズレる。ヘッダー行とデータ行の表示幅が一致することを検証する。
+#[test]
+fn test_watch_aligns_columns_by_display_width_with_cjk_branch() {
+    let env = TestEnv::new(OPEN_PR_VIEW_JSON, Some(CI_PASS_JSON));
+
+    // BRANCH 列に CJK を含めるため HEAD を上書きする（"機能追加" は各 2 桁幅）。
+    let branch = "feat/機能追加";
+    fs::write(
+        env.repo.path().join(".git/HEAD"),
+        format!("ref: refs/heads/{branch}\n"),
+    )
+    .expect("overwrite HEAD with cjk branch");
+
+    let _daemon = DaemonHandle::start(&env);
+    DaemonHandle::wait_for_cache(&env, 5000);
+
+    let output = spawn_watch_and_read(&env, 2, Duration::from_secs(5));
+    let lines: Vec<&str> = output.lines().collect();
+    assert!(lines.len() >= 2, "header + data 行が読めるべき: {output:?}");
+
+    let header = lines[0].strip_prefix(SCREEN_CLEAR).unwrap_or(lines[0]);
+    let data = lines[1];
+
+    assert!(
+        data.contains(branch),
+        "BRANCH 列に CJK ブランチが表示されるべき: {data:?}"
+    );
+    assert!(header.ends_with("CACHED AT"), "header tail: {header:?}");
+    assert!(data.ends_with("ago"), "data tail: {data:?}");
+
+    assert_eq!(
+        display_width(header),
+        display_width(data),
+        "CJK を含むデータ行とヘッダー行の表示幅が一致すべき (右端揃え): header={header:?}, data={data:?}",
+    );
+}
+
 /// #W7: 複数リポジトリがある場合、watch は CWD 昇順でソートして表示する
 #[test]
 fn test_watch_entries_sorted_by_cwd() {


### PR DESCRIPTION
## 概要

Closes #409

`merge-ready watch` のテーブル列揃えが**バイト長基準**だったため、非 ASCII のパス・ブランチ名で列がズレる問題を修正する。

## 問題

- `TableWidths::from_rows` が列幅を CWD/BRANCH/PR/CACHED AT は `len()`（**バイト長**）、STATUS は `visible_len`（**char 数**）で計算していた。一方パディングは Rust の幅指定子 `{:<width$}`（**char 数**ベース）。
  1. **バイト長 vs char 数の不一致**: `feat/機能追加` のようなマルチバイト文字を含む列では `len()` が char 数の最大 3 倍になり、その行以外が過剰パディングされて列がズレる。
  2. **表示幅の未考慮**: CJK・絵文字は端末上 2 桁幅のため、char 数で揃えても列がズレる。

## 修正

- `unicode-width`（Unicode Annex #11 / East Asian Width）を導入し、**全列の幅計算とパディングを端末表示幅基準に統一**。
- char 数ベースの幅指定子 `{:<width$}` に代えて、表示幅基準の自前パディング（`push_padded` / `Align`）で揃える。
- `visible_len`（ANSI 除去 + char 数）を `display_width`（ANSI 除去 + 表示幅）に置換。

### `unicode-width` 採用根拠（実績）

| 項目 | 内容 |
|------|------|
| 累計DL | 631M+ |
| メンテナ | `unicode-rs` org（Rust 公式 Unicode WG） |
| ライセンス | MIT OR Apache-2.0（`deny.toml` allow に合致） |
| 逆依存 | `clap_builder` / `textwrap` / `console` / `indicatif` / `comfy-table` / `miette` など、整列表示の基盤クレートが広く採用 |

純データのリーフクレートで、追加の推移依存はゼロ。

## テスト

- **E2E** (`tests/e2e/daemon/watch.rs`): CJK ブランチ `feat/機能追加` を含む行でヘッダー行とデータ行の**表示幅が一致**することを検証（`test_watch_aligns_columns_by_display_width_with_cjk_branch`）。
- **Unit** (`watch.rs`): `display_width` の表示幅計算（CJK=2 桁 / 結合文字=0 桁 / ANSI=0 桁）と、CJK を含むテーブルの列揃えを検証。

## チェック

`cargo nextest run --workspace`（447 passed）/ `clippy -D warnings` / `fmt --check` / `cargo deny check` / layer-deps / no-mod-rs / no-clippy-allow いずれもローカルで通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)