### PR TITLE
fix(daemon): Unix socket と base_dir の権限を制限する

### DIFF
--- a/src/contexts/daemon/infrastructure/daemon_server.rs
+++ b/src/contexts/daemon/infrastructure/daemon_server.rs
@@ -1,4 +1,5 @@
 use std::future::Future;
+use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -24,6 +25,8 @@ use super::socket_watcher;
 use crate::contexts::daemon::domain::cache::RepoId;
 use crate::contexts::daemon::domain::daemon::DaemonError;
 
+const SOCKET_BASE_DIR_MODE: u32 = 0o700;
+
 /// Imperative Shell から渡される、副作用を含むリフレッシュ実装。
 /// async 関数ポインタとして受け取り、キャプチャを禁じ依存を明示する。
 pub(super) type RefreshFn =
@@ -38,7 +41,7 @@ pub async fn run(on_refresh: RefreshFn, paths: Paths) -> Result<(), DaemonError>
     let config = server_config::DaemonServerConfig::from_env();
     let socket_path = paths.socket_path();
     if let Some(parent) = socket_path.parent() {
-        let _ = std::fs::create_dir_all(parent);
+        ensure_socket_base_dir(parent)?;
     }
 
     let listener = socket_listener::bind(&paths).await?;
@@ -107,6 +110,25 @@ pub async fn run(on_refresh: RefreshFn, paths: Paths) -> Result<(), DaemonError>
         restart::cleanup(&paths);
     }
     Ok(())
+}
+
+fn ensure_socket_base_dir(path: &std::path::Path) -> Result<(), DaemonError> {
+    std::fs::DirBuilder::new()
+        .recursive(true)
+        .mode(SOCKET_BASE_DIR_MODE)
+        .create(path)
+        .map_err(|e| {
+            log::error!("failed to create daemon base directory: {e}");
+            eprintln!("merge-ready daemon: failed to create base directory: {e}");
+            DaemonError::Failure
+        })?;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(SOCKET_BASE_DIR_MODE)).map_err(
+        |e| {
+            log::error!("failed to restrict daemon base directory permissions: {e}");
+            eprintln!("merge-ready daemon: failed to restrict base directory permissions: {e}");
+            DaemonError::Failure
+        },
+    )
 }
 
 /// `accept_loop` の引数をまとめた所有データ。`tokio::spawn` する接続タスクへ

--- a/src/contexts/daemon/infrastructure/socket_listener.rs
+++ b/src/contexts/daemon/infrastructure/socket_listener.rs
@@ -1,3 +1,4 @@
+use std::os::unix::fs::PermissionsExt;
 use std::time::Duration;
 
 use tokio::net::UnixListener;
@@ -7,6 +8,7 @@ use crate::contexts::daemon::domain::daemon::DaemonError;
 
 const BIND_RETRY_INTERVAL_MS: u64 = 100;
 const BIND_RETRY_MAX: usize = 10;
+const SOCKET_FILE_MODE: u32 = 0o600;
 
 pub(super) async fn bind(paths: &Paths) -> Result<UnixListener, DaemonError> {
     bind_with(
@@ -66,6 +68,16 @@ async fn bind_with(
         retry_interval,
     )
     .await?;
+    std::fs::set_permissions(
+        &socket_path,
+        std::fs::Permissions::from_mode(SOCKET_FILE_MODE),
+    )
+    .map_err(|e| {
+        log::error!("failed to restrict daemon socket permissions: {e}");
+        eprintln!("merge-ready daemon: failed to restrict socket permissions: {e}");
+        let _ = std::fs::remove_file(&socket_path);
+        DaemonError::Failure
+    })?;
     pid::write(std::process::id(), &pid_path);
     Ok(listener)
 }

--- a/tests/e2e/daemon/lifecycle.rs
+++ b/tests/e2e/daemon/lifecycle.rs
@@ -4,6 +4,7 @@
 
 use assert_cmd::Command;
 use predicates::prelude::*;
+use std::os::unix::fs::PermissionsExt;
 
 use super::super::helpers::{DaemonHandle, TestEnv, apply_coverage_env};
 
@@ -233,6 +234,20 @@ fn test_daemon_status_includes_version() {
     cmd.assert()
         .success()
         .stdout(predicate::str::contains(env!("CARGO_PKG_VERSION")));
+}
+
+#[test]
+fn test_daemon_socket_permissions_are_owner_only() {
+    let env = TestEnv::new(OPEN_PR_VIEW_JSON, Some(CI_PASS_JSON));
+    let _daemon = DaemonHandle::start(&env);
+
+    let mode = std::fs::metadata(versioned_socket(env.home()))
+        .expect("read daemon socket metadata")
+        .permissions()
+        .mode()
+        & 0o777;
+
+    assert_eq!(mode, 0o600);
 }
 
 // ── #11: daemon stop ─────────────────────────────────────────────────────────

--- a/tests/e2e/daemon/lifecycle.rs
+++ b/tests/e2e/daemon/lifecycle.rs
@@ -237,17 +237,77 @@ fn test_daemon_status_includes_version() {
 }
 
 #[test]
-fn test_daemon_socket_permissions_are_owner_only() {
+fn test_daemon_socket_and_base_dir_permissions_are_restricted_under_loose_umask() {
     let env = TestEnv::new(OPEN_PR_VIEW_JSON, Some(CI_PASS_JSON));
-    let _daemon = DaemonHandle::start(&env);
+    let base = env.home().join("daemon-base");
 
-    let mode = std::fs::metadata(versioned_socket(env.home()))
+    let bin = assert_cmd::cargo::cargo_bin(BIN);
+    let mut cmd = std::process::Command::new("sh");
+    cmd.arg("-c")
+        .arg("umask 000; exec \"$1\" daemon start")
+        .arg("merge-ready-daemon-start")
+        .arg(&bin)
+        .env("PATH", env.path_env())
+        .env("HOME", env.home())
+        .env("TMPDIR", env.home())
+        .env("MERGE_READY_BASE_DIR", &base)
+        .env("XDG_CONFIG_HOME", env.home().join(".config"))
+        .env("XDG_CACHE_HOME", env.home().join(".cache"))
+        .current_dir(env.repo.path())
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    apply_coverage_env(&mut cmd);
+    let mut child = cmd.spawn().expect("spawn daemon start via sh");
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(START_TIMEOUT_MS);
+    let status = loop {
+        if let Ok(Some(s)) = child.try_wait() {
+            break s;
+        }
+        if std::time::Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("daemon did not start within {START_TIMEOUT_MS}ms");
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    };
+    assert!(status.success(), "daemon start should succeed");
+
+    let socket_mode = std::fs::metadata(versioned_socket(&base))
         .expect("read daemon socket metadata")
         .permissions()
         .mode()
         & 0o777;
+    assert_eq!(
+        socket_mode, 0o600,
+        "socket permissions must be 0o600 regardless of umask, got {socket_mode:o}"
+    );
 
-    assert_eq!(mode, 0o600);
+    let dir_mode = std::fs::metadata(&base)
+        .expect("read daemon base dir metadata")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(
+        dir_mode, 0o700,
+        "base dir permissions must be 0o700 regardless of umask, got {dir_mode:o}"
+    );
+
+    if let Ok(pid_str) = std::fs::read_to_string(versioned_pid(&base))
+        && let Ok(pid) = pid_str.trim().parse::<u32>()
+    {
+        let _ = std::process::Command::new("kill")
+            .args(["-TERM", &pid.to_string()])
+            .status();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+        while std::time::Instant::now() < deadline {
+            if !is_pid_alive(pid) {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+    }
 }
 
 // ── #11: daemon stop ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## 概要

Closes #430

daemon が作成する Unix socket とその base_dir の権限がプロセスの umask に依存しており、緩い umask 環境では同一ホスト上の他ユーザから到達可能になり得た問題を修正する。

## 背景

`UnixListener::bind()` が作成する socket ファイルの mode は umask の影響を受ける。さらに socket を置く base_dir も `create_dir_all` 任せだと、umask が `000` の環境では `0777` になり得る。

この状態では socket を `0o600` にしても、ディレクトリ側の保護が意図通りであることを保証できないため、socket と base_dir の両方を明示的に制限する。

## 修正

- daemon の socket base_dir を `0o700` で作成し、既存ディレクトリも `0o700` に明示設定する。
- `UnixListener::bind()` 成功直後に socket ファイルを `0o600` に明示設定する。
- 権限設定に失敗した場合は daemon 起動を失敗扱いにする。
- E2E で `umask 000` の環境でも base_dir が `0o700`、socket が `0o600` になることを検証する。

## テスト

TDD（Red → Green）で実装。`tests/e2e/daemon/lifecycle.rs` に shell 経由で `umask 000` を設定して daemon を起動する E2E を追加した。base_dir 未対応の状態では `0777` となり失敗、修正後に `0o700` / `0o600` で通過することを確認済み。

## 確認

- `cargo test --test e2e test_daemon_socket_and_base_dir_permissions_are_restricted_under_loose_umask`
- `cargo test --test e2e daemon::lifecycle`
- `cargo fmt --check --all`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`

Made with [Cursor](https://cursor.com)