### PR TITLE
fix(prompt): daemon 応答を最後まで読み取る

### DIFF
--- a/src_prompt/main.rs
+++ b/src_prompt/main.rs
@@ -93,11 +93,56 @@ fn query_daemon() -> Option<String> {
     let req = prompt_ipc::Request { cwd };
     stream.write_all(req.encode().as_bytes()).ok()?;
 
-    // レスポンスはスタックバッファで受け取る（8KB BufReader ヒープ確保を回避）
-    let mut buf = [0u8; 512];
-    let n = stream.read(&mut buf).ok()?;
+    read_response(&mut stream)
+}
 
-    prompt_ipc::Response::decode(&buf[..n]).map(|r| r.output)
+/// Maximum number of bytes accepted for a daemon response.
+///
+/// The socket is only trusted at the same-user boundary, so keep a defensive
+/// cap to avoid unbounded allocation if another local process owns the socket.
+/// This mirrors the daemon-side request cap and leaves ample room for prompt
+/// status lines.
+const MAX_RESPONSE_BYTES: usize = 1024 * 1024;
+
+/// Reads one newline-terminated response from the daemon.
+///
+/// A Unix socket `read()` is not guaranteed to return a full line in one call,
+/// so long responses or short reads must be reassembled until newline or EOF.
+/// If the configured read timeout fires, the read error becomes `None` and the
+/// caller falls back to starting the daemon.
+///
+/// The common case, where a complete line fits in the first 512-byte read,
+/// still decodes directly from the stack buffer without allocating.
+fn read_response<R: Read>(reader: &mut R) -> Option<String> {
+    let mut chunk = [0u8; 512];
+    let n = reader.read(&mut chunk).ok()?;
+    if n == 0 {
+        return None;
+    }
+    // Hot path: the complete response line arrived in the first read.
+    if chunk[..n].contains(&b'\n') {
+        return prompt_ipc::Response::decode(&chunk[..n]).map(|r| r.output);
+    }
+
+    // Allocate only when the response line spans multiple reads.
+    let mut buf = chunk[..n].to_vec();
+    while buf.len() < MAX_RESPONSE_BYTES {
+        let n = reader.read(&mut chunk).ok()?;
+        if n == 0 {
+            return prompt_ipc::Response::decode(&buf).map(|r| r.output);
+        }
+
+        let remaining = MAX_RESPONSE_BYTES - buf.len();
+        let n = n.min(remaining);
+        let slice = &chunk[..n];
+        let reached_newline = slice.contains(&b'\n');
+        buf.extend_from_slice(slice);
+        if reached_newline {
+            return prompt_ipc::Response::decode(&buf).map(|r| r.output);
+        }
+    }
+
+    None
 }
 
 fn spawn_daemon() {
@@ -121,6 +166,103 @@ fn spawn_daemon() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::VecDeque;
+    use std::io;
+
+    /// Test reader that returns at most one queued chunk per `read()` call.
+    /// Remaining bytes are pushed back, and an empty queue returns EOF. This
+    /// deterministically reproduces short reads from a Unix socket.
+    struct ChunkedReader {
+        chunks: VecDeque<Vec<u8>>,
+    }
+
+    impl ChunkedReader {
+        fn new<I: IntoIterator<Item = Vec<u8>>>(chunks: I) -> Self {
+            Self {
+                chunks: chunks.into_iter().collect(),
+            }
+        }
+    }
+
+    impl Read for ChunkedReader {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            let Some(chunk) = self.chunks.pop_front() else {
+                return Ok(0);
+            };
+            let n = chunk.len().min(buf.len());
+            buf[..n].copy_from_slice(&chunk[..n]);
+            if n < chunk.len() {
+                self.chunks.push_front(chunk[n..].to_vec());
+            }
+            Ok(n)
+        }
+    }
+
+    /// Test reader that simulates a read after `set_read_timeout` expires.
+    struct TimeoutReader;
+
+    impl Read for TimeoutReader {
+        fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
+            Err(io::Error::new(io::ErrorKind::WouldBlock, "timed out"))
+        }
+    }
+
+    fn output_line(output: &str) -> Vec<u8> {
+        let mut line = format!(r#"{{"tag":"output","output":"{output}"}}"#).into_bytes();
+        line.push(b'\n');
+        line
+    }
+
+    #[test]
+    fn read_response_decodes_single_read_complete_line() {
+        let mut reader = ChunkedReader::new([output_line("✓ Ready for merge")]);
+        assert_eq!(
+            read_response(&mut reader).as_deref(),
+            Some("✓ Ready for merge")
+        );
+    }
+
+    #[test]
+    fn read_response_reassembles_line_split_across_reads() {
+        let line = output_line("✓ Ready for merge #200 ✎ Ready for review #201");
+        let mid = line.len() / 2;
+        let mut reader = ChunkedReader::new([line[..mid].to_vec(), line[mid..].to_vec()]);
+        assert_eq!(
+            read_response(&mut reader).as_deref(),
+            Some("✓ Ready for merge #200 ✎ Ready for review #201"),
+        );
+    }
+
+    #[test]
+    fn read_response_reads_response_longer_than_chunk() {
+        let output = "x".repeat(600);
+        let line = output_line(&output);
+        assert!(line.len() > 512, "fixture must exceed the 512B chunk size");
+        let chunks: Vec<Vec<u8>> = line.chunks(512).map(<[u8]>::to_vec).collect();
+        let mut reader = ChunkedReader::new(chunks);
+        assert_eq!(read_response(&mut reader).as_deref(), Some(output.as_str()));
+    }
+
+    #[test]
+    fn read_response_returns_none_for_oversized_input_without_newline() {
+        let oversized = vec![b'a'; MAX_RESPONSE_BYTES + 4096];
+        let mut reader = ChunkedReader::new([oversized]);
+        assert!(read_response(&mut reader).is_none());
+    }
+
+    #[test]
+    fn read_response_rejects_oversized_complete_json_without_newline() {
+        let mut line = format!(r#"{{"tag":"output","output":"{}"}}"#, "x".repeat(64)).into_bytes();
+        line.extend(std::iter::repeat_n(b' ', MAX_RESPONSE_BYTES));
+        let mut reader = ChunkedReader::new([line]);
+        assert!(read_response(&mut reader).is_none());
+    }
+
+    #[test]
+    fn read_response_returns_none_on_read_error() {
+        let mut reader = TimeoutReader;
+        assert!(read_response(&mut reader).is_none());
+    }
 
     #[test]
     fn keeps_plain_text_unchanged() {

--- a/tests/e2e/scenarios/multiple_prs.rs
+++ b/tests/e2e/scenarios/multiple_prs.rs
@@ -113,3 +113,47 @@ fn test_distinct_status_groups_each_aggregated() {
         ))
         .stderr("");
 }
+
+/// Receives and displays daemon responses that exceed the single-read buffer (#406 regression).
+///
+/// The prompt used to perform a single 512-byte `read()`, so responses longer
+/// than that were truncated before JSON decoding and appeared as `? loading`
+/// even while the daemon was healthy.
+#[test]
+fn test_long_response_exceeding_single_read_buffer_is_received_in_full() {
+    // Same-status PRs are aggregated into one token with all PR numbers, making
+    // the response line much larger than the former 512-byte read buffer.
+    let numbers = 1000..1110;
+    let pr_list_json = format!(
+        "[{}]",
+        numbers
+            .clone()
+            .map(|n| format!(
+                r#"{{"number":{n},"state":"OPEN","isDraft":true,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":null,"baseRefName":"","headRefName":""}}"#
+            ))
+            .collect::<Vec<_>>()
+            .join(",")
+    );
+    let expected = numbers.fold(String::from("✎ Ready for review"), |mut s, n| {
+        use std::fmt::Write as _;
+        let _ = write!(s, " #{n}");
+        s
+    });
+    assert!(
+        expected.len() > 512,
+        "fixture must exceed the 512B single-read buffer (was {} bytes)",
+        expected.len()
+    );
+
+    let env = TestEnv::with_pr_list(&pr_list_json, Some(r"[]"));
+
+    let _daemon = DaemonHandle::start(&env);
+    DaemonHandle::wait_for_cache(&env, 5000);
+
+    let mut cmd = Command::cargo_bin(PROMPT_BIN).unwrap();
+    env.apply_with_cache(&mut cmd);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::diff(expected))
+        .stderr("");
+}


### PR DESCRIPTION
## 概要
- daemon からの prompt 応答を、単発 `read()` ではなく改行または EOF まで読み取るようにしました。
- 512B を超える応答や Unix socket の short read でも `? loading` に化けないようにしました。

## 背景
- `merge-ready-prompt` は daemon 応答を 512B 固定バッファへの 1 回の `read()` だけで受信していました。
- 複数 PR の集約表示やスタイル付き出力で応答 JSON が長くなると、途中で切れた JSON を decode して失敗し、daemon が正常でも loading 表示に戻る問題がありました。
- Unix socket の `read()` は 1 行全体を返す保証がないため、512B 未満でも short read で同じ問題が起き得ます。

## 修正
- `src_prompt/main.rs` に `read_response` を追加し、応答をチャンク単位で改行または EOF まで再構成するようにしました。
- 防御的な上限として 1MiB のレスポンスサイズ制限を設け、改行なしで上限に達した入力は拒否します。
- short read、長い応答、タイムアウト、上限超過を unit test で固定しました。
- 512B を超える複数 PR 表示を E2E で追加し、実際の prompt 経路で全量表示されることを確認しました。

## テスト
- `cargo fmt --check --all`
- `cargo test -p merge-ready --bin merge-ready-prompt read_response -- --nocapture`
- `cargo test --test e2e test_long_response_exceeding_single_read_buffer_is_received_in_full -- --nocapture`
- `cargo test --test e2e multiple_prs -- --nocapture`
- `cargo clippy --workspace -- -D warnings`

## 確認
- Issue #406 の長い応答と short read の両方をカバーしています。
- 既存の短い応答は従来どおりスタックバッファから decode する経路を維持しています。
- `fix:` PR として E2E テストを含めています。

Closes #406

Made with [Cursor](https://cursor.com)