### PR TITLE
fix(prompt): daemon 応答読み取り全体に総タイムアウトを設ける

### DIFF
--- a/src_prompt/main.rs
+++ b/src_prompt/main.rs
@@ -1,13 +1,13 @@
 // merge-ready-prompt: 軽量なシェルプロンプト用バイナリ。
 
-use std::io::{Read, Write};
+use std::io::{self, Read, Write};
 use std::os::unix::net::UnixStream;
 use std::process::Stdio;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use merge_ready::{prompt_ipc, prompt_socket_path};
 
-const READ_TIMEOUT_MS: u64 = 500;
+const RESPONSE_TIMEOUT_MS: u64 = 500;
 
 fn main() {
     let output = query_daemon().unwrap_or_else(|| {
@@ -84,16 +84,52 @@ fn query_daemon() -> Option<String> {
         .map(|p| p.to_string_lossy().into_owned())
         .unwrap_or_default();
 
-    let stream = UnixStream::connect(prompt_socket_path()).ok()?;
-    stream
-        .set_read_timeout(Some(Duration::from_millis(READ_TIMEOUT_MS)))
-        .ok()?;
-    let mut stream = stream;
+    let mut stream = UnixStream::connect(prompt_socket_path()).ok()?;
 
     let req = prompt_ipc::Request { cwd };
     stream.write_all(req.encode().as_bytes()).ok()?;
 
-    read_response(&mut stream)
+    let deadline = Instant::now() + Duration::from_millis(RESPONSE_TIMEOUT_MS);
+    let mut reader = DeadlineReader::new(stream, deadline);
+    read_response(&mut reader)
+}
+
+trait ReadTimeout {
+    fn set_read_timeout(&self, timeout: Option<Duration>) -> io::Result<()>;
+}
+
+impl ReadTimeout for UnixStream {
+    fn set_read_timeout(&self, timeout: Option<Duration>) -> io::Result<()> {
+        UnixStream::set_read_timeout(self, timeout)
+    }
+}
+
+struct DeadlineReader<R> {
+    inner: R,
+    deadline: Instant,
+}
+
+impl<R> DeadlineReader<R> {
+    fn new(inner: R, deadline: Instant) -> Self {
+        Self { inner, deadline }
+    }
+}
+
+impl<R: Read + ReadTimeout> Read for DeadlineReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let Some(remaining) = self
+            .deadline
+            .checked_duration_since(Instant::now())
+            .filter(|remaining| !remaining.is_zero())
+        else {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "response deadline exceeded",
+            ));
+        };
+        self.inner.set_read_timeout(Some(remaining))?;
+        self.inner.read(buf)
+    }
 }
 
 /// Maximum number of bytes accepted for a daemon response.
@@ -166,8 +202,10 @@ fn spawn_daemon() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::RefCell;
     use std::collections::VecDeque;
     use std::io;
+    use std::rc::Rc;
 
     /// Test reader that returns at most one queued chunk per `read()` call.
     /// Remaining bytes are pushed back, and an empty queue returns EOF. This
@@ -204,6 +242,41 @@ mod tests {
     impl Read for TimeoutReader {
         fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
             Err(io::Error::new(io::ErrorKind::WouldBlock, "timed out"))
+        }
+    }
+
+    struct RecordingReader {
+        chunks: VecDeque<Vec<u8>>,
+        timeouts: Rc<RefCell<Vec<Option<Duration>>>>,
+    }
+
+    impl RecordingReader {
+        fn new<I: IntoIterator<Item = Vec<u8>>>(
+            chunks: I,
+            timeouts: Rc<RefCell<Vec<Option<Duration>>>>,
+        ) -> Self {
+            Self {
+                chunks: chunks.into_iter().collect(),
+                timeouts,
+            }
+        }
+    }
+
+    impl Read for RecordingReader {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            let Some(chunk) = self.chunks.pop_front() else {
+                return Ok(0);
+            };
+            let n = chunk.len().min(buf.len());
+            buf[..n].copy_from_slice(&chunk[..n]);
+            Ok(n)
+        }
+    }
+
+    impl ReadTimeout for RecordingReader {
+        fn set_read_timeout(&self, timeout: Option<Duration>) -> io::Result<()> {
+            self.timeouts.borrow_mut().push(timeout);
+            Ok(())
         }
     }
 
@@ -262,6 +335,44 @@ mod tests {
     fn read_response_returns_none_on_read_error() {
         let mut reader = TimeoutReader;
         assert!(read_response(&mut reader).is_none());
+    }
+
+    #[test]
+    fn deadline_reader_refreshes_timeout_before_each_read() {
+        let line = output_line("✓ Ready for merge");
+        let mid = line.len() / 2;
+        let timeouts = Rc::new(RefCell::new(Vec::new()));
+        let inner = RecordingReader::new(
+            [line[..mid].to_vec(), line[mid..].to_vec()],
+            Rc::clone(&timeouts),
+        );
+        let mut reader =
+            DeadlineReader::new(inner, std::time::Instant::now() + Duration::from_secs(10));
+
+        assert_eq!(
+            read_response(&mut reader).as_deref(),
+            Some("✓ Ready for merge")
+        );
+
+        let recorded = timeouts.borrow();
+        assert_eq!(recorded.len(), 2);
+        assert!(recorded.iter().all(Option::is_some));
+    }
+
+    #[test]
+    fn deadline_reader_returns_none_after_total_deadline() {
+        let timeouts = Rc::new(RefCell::new(Vec::new()));
+        let inner = RecordingReader::new([output_line("too late")], Rc::clone(&timeouts));
+        let expired_deadline = std::time::Instant::now()
+            .checked_sub(Duration::from_millis(1))
+            .expect("1ms before now is representable");
+        let mut reader = DeadlineReader::new(inner, expired_deadline);
+
+        assert!(read_response(&mut reader).is_none());
+        assert!(
+            timeouts.borrow().is_empty(),
+            "expired deadline must fail before updating per-read timeout"
+        );
     }
 
     #[test]

--- a/tests/e2e/prompt/mod.rs
+++ b/tests/e2e/prompt/mod.rs
@@ -6,6 +6,7 @@ mod errors;
 mod errors_fixtures;
 mod merge_ready;
 mod pr_state;
+mod response_timeout;
 mod review;
 mod sanitize;
 mod style;

--- a/tests/e2e/prompt/response_timeout.rs
+++ b/tests/e2e/prompt/response_timeout.rs
@@ -1,0 +1,89 @@
+//! `merge-ready-prompt` の daemon 応答読み取り全体のタイムアウトを検証する。
+
+const PROMPT_BIN: &str = "merge-ready-prompt";
+const PROMPT_TIMEOUT_MS: u64 = 1_500;
+
+use std::io::{Read, Write};
+use std::os::unix::net::UnixListener;
+use std::time::{Duration, Instant};
+
+use super::super::helpers::{TestEnv, apply_coverage_env};
+
+fn versioned_socket(base: &std::path::Path) -> std::path::PathBuf {
+    base.join(format!("daemon-{}.sock", env!("CARGO_PKG_VERSION")))
+}
+
+fn run_prompt_with_timeout(env: &TestEnv) -> std::process::Output {
+    let bin = assert_cmd::cargo::cargo_bin(PROMPT_BIN);
+    let mut cmd = std::process::Command::new(bin);
+    cmd.env("PATH", env.path_env())
+        .env("HOME", env.home())
+        .env("TMPDIR", env.home())
+        .env("MERGE_READY_BASE_DIR", env.home())
+        .current_dir(env.repo.path())
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    apply_coverage_env(&mut cmd);
+
+    let mut child = cmd.spawn().expect("spawn merge-ready-prompt");
+    let deadline = Instant::now() + Duration::from_millis(PROMPT_TIMEOUT_MS);
+    loop {
+        if child.try_wait().is_ok_and(|s| s.is_some()) {
+            return child.wait_with_output().expect("collect prompt output");
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("merge-ready-prompt did not finish within {PROMPT_TIMEOUT_MS}ms");
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+#[test]
+fn slow_drip_response_falls_back_to_loading_at_total_deadline() {
+    let env = TestEnv::new(
+        r#"{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED"}"#,
+        Some(r#"[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]"#),
+    );
+    let socket_path = versioned_socket(env.home());
+    let _ = std::fs::remove_file(&socket_path);
+    let listener = UnixListener::bind(&socket_path).expect("bind fake daemon socket");
+
+    let server = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept prompt connection");
+        let mut request = Vec::new();
+        let mut buf = [0_u8; 64];
+        loop {
+            let n = stream.read(&mut buf).expect("read prompt request");
+            if n == 0 {
+                return;
+            }
+            request.extend_from_slice(&buf[..n]);
+            if request.contains(&b'\n') {
+                break;
+            }
+        }
+
+        for byte in br#"{"tag":"output","output":"this response never reaches newline""# {
+            if stream.write_all(&[*byte]).is_err() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(150));
+        }
+    });
+
+    let output = run_prompt_with_timeout(&env);
+    server.join().expect("fake daemon thread");
+
+    assert!(
+        output.status.success(),
+        "prompt failed: status={:?}, stdout={:?}, stderr={:?}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "? loading");
+    assert_eq!(String::from_utf8_lossy(&output.stderr), "");
+}


### PR DESCRIPTION
## 概要

Closes #435

`merge-ready-prompt` が daemon 応答を読み取る際、各 `read()` の timeout だけでなく、応答読み取り全体の wall-clock time にも上限を設ける。

## 背景

Issue #406 / PR #434 で、daemon 応答を 512B の単発 `read()` ではなく、改行または EOF まで読み取るようにした。これにより長い応答や Unix socket の short read は正しく扱えるようになった。

一方で、`read_timeout` は 1 回の `read()` ごとに効くため、壊れた daemon や同一ユーザーのローカルプロセスが timeout 未満の間隔で少量ずつデータを送り続けると、prompt プロセスが長く引き止められる可能性があった。

## 修正

- prompt 応答読み取り用に `DeadlineReader` を追加し、総 deadline を過ぎたら `TimedOut` として `None` に落とすようにした。
- 各 `read()` の直前に deadline までの残り時間を計算し、`UnixStream::set_read_timeout(Some(remaining))` へ反映するようにした。
- 通常の短い応答では、既存の `read_response` hot path を維持する。
- deadline wrapper の unit test と、偽 Unix socket daemon が少量ずつ応答を drip する E2E を追加した。

## テスト

- `cargo test --bin merge-ready-prompt`
- `cargo nextest run --test e2e prompt::response_timeout`
- `cargo fmt --check --all`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`

## 確認

- 通常応答と short read は deadline 内で従来どおり読み切る。
- daemon が少量ずつ送信し続ける場合でも、prompt は総 deadline で `? loading` にフォールバックする。
- `fix:` PR として E2E テストを含めている。

Made with [Cursor](https://cursor.com)