### PR TITLE
docs: SECURITY.md を追加して脆弱性報告プロセスを定義する

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,54 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are provided for the latest stable release of `merge-ready`.
+Older releases are not supported unless a maintainer explicitly announces
+otherwise for a specific advisory.
+
+| Version | Supported |
+| ------- | --------- |
+| Latest stable release | Yes |
+| Older releases | No |
+
+## Reporting a Vulnerability
+
+Please do not report security vulnerabilities in public GitHub issues.
+
+Use GitHub Private Vulnerability Reporting to submit a report:
+
+<https://github.com/toshiki670/merge-ready/security/advisories/new>
+
+Include as much detail as possible, such as affected versions, reproduction
+steps, impact, and any relevant logs or proof-of-concept material. A maintainer
+will acknowledge the report after review and may follow up privately for more
+information.
+
+## Disclosure Policy
+
+The project follows coordinated vulnerability disclosure.
+
+1. A maintainer reviews the private report and acknowledges it when enough
+   information is available to begin investigation.
+2. The maintainer investigates the impact and works with the reporter on a fix
+   and advisory text when appropriate.
+3. The fix is released before public disclosure whenever possible.
+4. Public disclosure normally happens within 90 days of the initial report, or
+   sooner when a fix is available and the reporter and maintainer agree.
+
+If active exploitation or a high-impact issue requires faster disclosure, the
+timeline may be shortened to protect users.
+
+## Out of Scope
+
+The following reports are generally out of scope unless they demonstrate a
+clear security impact:
+
+- Issues affecting unsupported versions only.
+- Denial-of-service reports that require unrealistic local resource exhaustion.
+- Crashes, panics, or error messages without a security boundary impact.
+- Vulnerabilities caused entirely by a compromised local machine, shell
+  configuration, GitHub token, or `gh` CLI installation.
+- Reports about third-party services or dependencies without a demonstrated
+  impact on `merge-ready`.
+


### PR DESCRIPTION
## 概要

Closes #432

`SECURITY.md` を追加し、脆弱性報告の窓口と開示ポリシーを明文化する。

## 背景

リポジトリに security policy が存在しないと、脆弱性を見つけたユーザーが報告先を判断しづらく、GitHub の Security タブからの報告導線も不明確になる。

Private Vulnerability Reporting は有効化済みのため、`SECURITY.md` から GitHub の private advisory 作成画面へ案内する。

## 修正

- ルートに `SECURITY.md` を追加した。
- サポート対象バージョンを latest stable release として明記した。
- GitHub Private Vulnerability Reporting を報告窓口として記載した。
- 90 日を基準にした coordinated disclosure の流れを定義した。
- セキュリティ影響が明確でない report のスコープ外例を記載した。

## テスト

- `git diff --check`
- `gh api repos/toshiki670/merge-ready/private-vulnerability-reporting`

## 確認

- `SECURITY.md` がリポジトリルートに存在する。
- Private Vulnerability Reporting が `enabled: true` である。
- 報告窓口として private advisory 作成 URL を明記している。

Made with [Cursor](https://cursor.com)